### PR TITLE
Enable dependabot for eclipse-platform-parent

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: eclipse-platform-parent
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    labels:
+      - dependencies


### PR DESCRIPTION
As dependabot tries to figure submodules and failes if run on /