### PR TITLE
Updating centos 8 dockerfiles to use the latest 8.5 universal base image

### DIFF
--- a/cje-production/dockerfiles/centos-gtk3-metacity/8-gtk3/Dockerfile
+++ b/cje-production/dockerfiles/centos-gtk3-metacity/8-gtk3/Dockerfile
@@ -1,5 +1,5 @@
-ARG FROM_TAG="8"
-FROM centos:${FROM_TAG}
+ARG FROM_TAG="8.5-226"
+FROM registry.access.redhat.com/ubi8/ubi:${FROM_TAG}
 
 ### user name recognition at runtime w/ an arbitrary uid - for OpenShift deployments
 COPY scripts/uid_entrypoint /usr/local/bin/uid_entrypoint

--- a/cje-production/dockerfiles/centos-gtk3-metacity/8-gtk3/Dockerfile
+++ b/cje-production/dockerfiles/centos-gtk3-metacity/8-gtk3/Dockerfile
@@ -1,5 +1,5 @@
-ARG FROM_TAG="8.5-226"
-FROM registry.access.redhat.com/ubi8/ubi:${FROM_TAG}
+ARG FROM_TAG="8"
+FROM quay.io/centos/centos:stream${FROM_TAG}
 
 ### user name recognition at runtime w/ an arbitrary uid - for OpenShift deployments
 COPY scripts/uid_entrypoint /usr/local/bin/uid_entrypoint

--- a/cje-production/dockerfiles/centos-gtk3-metacity/8-swtBuild/Dockerfile
+++ b/cje-production/dockerfiles/centos-gtk3-metacity/8-swtBuild/Dockerfile
@@ -1,5 +1,5 @@
-ARG FROM_TAG="8"
-FROM centos:${FROM_TAG}
+ARG FROM_TAG="8.5-226"
+FROM registry.access.redhat.com/ubi8/ubi:${FROM_TAG}
 
 ### user name recognition at runtime w/ an arbitrary uid - for OpenShift deployments
 COPY scripts/uid_entrypoint /usr/local/bin/uid_entrypoint

--- a/cje-production/dockerfiles/centos-gtk3-metacity/8-swtBuild/Dockerfile
+++ b/cje-production/dockerfiles/centos-gtk3-metacity/8-swtBuild/Dockerfile
@@ -1,5 +1,5 @@
-ARG FROM_TAG="8.5-226"
-FROM registry.access.redhat.com/ubi8/ubi:${FROM_TAG}
+ARG FROM_TAG="8"
+FROM quay.io/centos/centos:stream${FROM_TAG}
 
 ### user name recognition at runtime w/ an arbitrary uid - for OpenShift deployments
 COPY scripts/uid_entrypoint /usr/local/bin/uid_entrypoint


### PR DESCRIPTION
For [issue 29](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/29).