### PR TITLE
Bug 578845 - Deploy ecj compiler from 4.23 M3 and use it in Platform …

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -86,7 +86,7 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cbi-jdt-repo.url>https://repo.eclipse.org/content/repositories/eclipse-staging/</cbi-jdt-repo.url>
-    <cbi-ecj-version>3.29.0.v20220129-2046</cbi-ecj-version>
+    <cbi-ecj-version>3.29.0.v20220214-1307</cbi-ecj-version>
 
     <!--
       Production bundles are produced by ignoring the compiler warnings specified


### PR DESCRIPTION
…build