### PR TITLE
fix: updating platform name to use gtk3, and update the broken rpm query

### DIFF
--- a/production/testScripts/configuration/sdk.tests/testConfigs/linux/testAll.sh
+++ b/production/testScripts/configuration/sdk.tests/testConfigs/linux/testAll.sh
@@ -44,7 +44,7 @@ export propertyFile=${propertyFile:-platformSpecific.properties}
 
 # in product tests, should be set by runTests2.xml,
 # so we use "vm value",  "x.0" at end, to make obvious if that's not working.
-export testedPlatform=${testedPlatform:-linux.gtk.x86_64_x.0}
+export testedPlatform=${testedPlatform:-linux.gtk3.x86_64_x.0}
 
 echo "=== properties in testAll.sh"
 echo "    DOWNLOAD_HOST: ${DOWNLOAD_HOST}"

--- a/production/testScripts/configuration/sdk.tests/testConfigs/linuxjava11/testAll.sh
+++ b/production/testScripts/configuration/sdk.tests/testConfigs/linuxjava11/testAll.sh
@@ -44,7 +44,7 @@ export propertyFile=${propertyFile:-platformSpecific.properties}
 
 # in product tests, should be set by runTests2.xml,
 # so we use "vm value",  "x.0" at end, to make obvious if that's not working.
-export testedPlatform=${testedPlatform:-linux.gtk.x86_64_x.0}
+export testedPlatform=${testedPlatform:-linux.gtk3.x86_64_x.0}
 
 echo "=== properties in testAll.sh"
 echo "    DOWNLOAD_HOST: ${DOWNLOAD_HOST}"

--- a/production/testScripts/configuration/sdk.tests/testConfigs/linuxjava14/testAll.sh
+++ b/production/testScripts/configuration/sdk.tests/testConfigs/linuxjava14/testAll.sh
@@ -44,7 +44,7 @@ export propertyFile=${propertyFile:-platformSpecific.properties}
 
 # in product tests, should be set by runTests2.xml,
 # so we use "vm value",  "x.0" at end, to make obvious if that's not working.
-export testedPlatform=${testedPlatform:-linux.gtk.x86_64_x.0}
+export testedPlatform=${testedPlatform:-linux.gtk3.x86_64_x.0}
 
 echo "=== properties in testAll.sh"
 echo "    DOWNLOAD_HOST: ${DOWNLOAD_HOST}"

--- a/production/testScripts/configuration/sdk.tests/testScripts/runtests.sh
+++ b/production/testScripts/configuration/sdk.tests/testScripts/runtests.sh
@@ -29,7 +29,7 @@ then
 fi
 #Extract GTK Version and host name
 
-gtkType=$(echo ${testedPlatform}|cut -d- -f4|cut -d_ -f1)
+gtkType=$(echo ${testedPlatform}|cut -d- -f3|cut -d_ -f2|cut -d. -f2)
 gtkVersion=$(rpm -q ${gtkType}|cut -d- -f2)
 
 echo "Jvm        : ${jvm}"


### PR DESCRIPTION
Small edit that should fiz the broken rpm query in the [ep423I-perf-lin64](https://ci.eclipse.org/releng/view/Performance%20Tests/job/ep423I-perf-lin64/68/console) tests. 