### PR TITLE
RPM fix for performance tests

### DIFF
--- a/production/testScripts/configuration/sdk.tests/testScripts/runtests.sh
+++ b/production/testScripts/configuration/sdk.tests/testScripts/runtests.sh
@@ -28,9 +28,7 @@ then
   exit 1
 fi
 #Extract GTK Version and host name
-
-gtkType=$(echo ${testedPlatform}|cut -d- -f4|cut -d_ -f1)
-gtkVersion=$(rpm -q ${gtkType}|cut -d- -f2)
+gtkVersion=$(rpm -q gtk3|cut -d- -f2)
 
 echo "Jvm        : ${jvm}"
 echo "Host       : $(hostname)"


### PR DESCRIPTION
Setting the rpm query to look for gtk3 since it's broken:
[https://ci.eclipse.org/releng/view/Performance%20Tests/job/ep423I-perf-lin64/68/console](https://ci.eclipse.org/releng/view/Performance%20Tests/job/ep423I-perf-lin64/68/console)

