### PR TITLE
Migrate Equinox to GitHub

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,13 +58,13 @@
   url = https://git.eclipse.org/r/platform/eclipse.platform.ui
 [submodule "rt.equinox.binaries"]
   path = rt.equinox.binaries
-  url = https://git.eclipse.org/r/equinox/rt.equinox.binaries.git
+  url = https://github.com/eclipse-equinox/equinox.binaries.git
 [submodule "rt.equinox.bundles"]
   path = rt.equinox.bundles
-  url = https://git.eclipse.org/r/equinox/rt.equinox.bundles
+  url = https://github.com/eclipse-equinox/equinox.bundles.git
 [submodule "rt.equinox.framework"]
   path = rt.equinox.framework
-  url = https://git.eclipse.org/r/equinox/rt.equinox.framework
+  url = https://github.com/eclipse-equinox/equinox.framework.git
 [submodule "rt.equinox.p2"]
   path = rt.equinox.p2
   url = https://git.eclipse.org/r/equinox/rt.equinox.p2


### PR DESCRIPTION
Removed the "rt" prefix from repos as these are no longer under RT TLP
for very long time.
Not adding "eclipse" as it's just redundant making paths longer.

Fixes #103