### PR TITLE
[License-Check] use built in cache of setup-java action

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -25,13 +25,7 @@ jobs:
       with:
         java-version: '11'
         distribution: 'adopt'
-    - name: Cache local Maven repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
+        cache: 'maven' # cache local Maven repository
     - name: License check
       run: | 
         mvn -U -V -e -B -ntp org.eclipse.dash:license-tool-plugin:license-check --file pom.xml -Ddash.fail=true


### PR DESCRIPTION
The `setup-java` action provides a [cache for Maven dependencies](https://github.com/actions/setup-java/#caching-packages-dependencies). Under the hood it uses [actions/cache](https://github.com/actions/cache) but it makes the configuration simpler.