### PR TITLE
Bug 579215 - IES423: The hebrew translation will not be available in

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.product
@@ -9,7 +9,7 @@
    <launcherArgs>
       <programArgs>--launcher.defaultAction openFile --launcher.appendVmargs
       </programArgs>
-      <vmArgs>-Dosgi.requiredJavaVersion=11 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true -Xms40m -Xmx512m --add-modules=ALL-SYSTEM
+      <vmArgs>-Dosgi.requiredJavaVersion=11 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true -Djava.locale.useOldISOCodes=true -Xms40m -Xmx512m --add-modules=ALL-SYSTEM
       </vmArgs>
       <vmArgsMac>-Xdock:icon=../Resources/Eclipse.icns -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
@@ -66,7 +66,7 @@ downloadable archives (&quot;Downloads&quot;).
     include plug-ins (&quot;Plug-ins&quot;), plug-in fragments (&quot;Fragments&quot;), and
     features (&quot;Features&quot;).
 -   Each Plug-in or Fragment may be packaged as a sub-directory or JAR
-    (Java&#8482; ARchive) in a directory named &quot;plugins&quot;.
+    (Java™ ARchive) in a directory named &quot;plugins&quot;.
 -   A Feature is a bundle of one or more Plug-ins and/or Fragments and
     associated material. Each Feature may be packaged as a sub-directory in a
     directory named &quot;features&quot;. Within a Feature, files named &quot;feature.xml&quot; may
@@ -189,9 +189,9 @@ United States, other countries, or both.
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
-      <property name="org.eclipse.update.reconcile" value="false" />
-      <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />
+      <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
+      <property name="org.eclipse.update.reconcile" value="false" />
    </configurations>
 
 </product>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.sdk.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.sdk.product
@@ -9,7 +9,7 @@
    <launcherArgs>
       <programArgs>--launcher.defaultAction openFile --launcher.appendVmargs
       </programArgs>
-      <vmArgs>-Dosgi.requiredJavaVersion=11 -Xms40m -Xmx384m --add-modules=ALL-SYSTEM
+      <vmArgs>-Dosgi.requiredJavaVersion=11 -Djava.locale.useOldISOCodes=true -Xms40m -Xmx384m --add-modules=ALL-SYSTEM
       </vmArgs>
       <vmArgsMac>-Xdock:icon=../Resources/Eclipse.icns -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
@@ -66,7 +66,7 @@ downloadable archives (&quot;Downloads&quot;).
     include plug-ins (&quot;Plug-ins&quot;), plug-in fragments (&quot;Fragments&quot;), and
     features (&quot;Features&quot;).
 -   Each Plug-in or Fragment may be packaged as a sub-directory or JAR
-    (Java&#8482; ARchive) in a directory named &quot;plugins&quot;.
+    (Java™ ARchive) in a directory named &quot;plugins&quot;.
 -   A Feature is a bundle of one or more Plug-ins and/or Fragments and
     associated material. Each Feature may be packaged as a sub-directory in a
     directory named &quot;features&quot;. Within a Feature, files named &quot;feature.xml&quot; may

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/rcp.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/rcp.product
@@ -9,7 +9,7 @@
    <launcherArgs>
       <programArgs>--launcher.appendVmargs
       </programArgs>
-      <vmArgs>-Xms40m -Xmx384m
+      <vmArgs>-Djava.locale.useOldISOCodes=true -Xms40m -Xmx384m
       </vmArgs>
       <vmArgsMac>-Xdock:icon=../Resources/Eclipse.icns -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
@@ -64,7 +64,7 @@ downloadable archives (&quot;Downloads&quot;).
     include plug-ins (&quot;Plug-ins&quot;), plug-in fragments (&quot;Fragments&quot;), and
     features (&quot;Features&quot;).
 -   Each Plug-in or Fragment may be packaged as a sub-directory or JAR
-    (Java&#8482; ARchive) in a directory named &quot;plugins&quot;.
+    (Java™ ARchive) in a directory named &quot;plugins&quot;.
 -   A Feature is a bundle of one or more Plug-ins and/or Fragments and
     associated material. Each Feature may be packaged as a sub-directory in a
     directory named &quot;features&quot;. Within a Feature, files named &quot;feature.xml&quot; may

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/rcp.sdk.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/rcp.sdk.product
@@ -9,7 +9,7 @@
    <launcherArgs>
       <programArgs>--launcher.appendVmargs
       </programArgs>
-      <vmArgs>-Xms40m -Xmx384m
+      <vmArgs>-Djava.locale.useOldISOCodes=true -Xms40m -Xmx384m
       </vmArgs>
       <vmArgsMac>-Xdock:icon=../Resources/Eclipse.icns -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
@@ -66,7 +66,7 @@ downloadable archives (&quot;Downloads&quot;).
     include plug-ins (&quot;Plug-ins&quot;), plug-in fragments (&quot;Fragments&quot;), and
     features (&quot;Features&quot;).
 -   Each Plug-in or Fragment may be packaged as a sub-directory or JAR
-    (Java&#8482; ARchive) in a directory named &quot;plugins&quot;.
+    (Java™ ARchive) in a directory named &quot;plugins&quot;.
 -   A Feature is a bundle of one or more Plug-ins and/or Fragments and
     associated material. Each Feature may be packaged as a sub-directory in a
     directory named &quot;features&quot;. Within a Feature, files named &quot;feature.xml&quot; may

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.product
@@ -9,7 +9,7 @@
    <launcherArgs>
       <programArgs>--launcher.defaultAction openFile  --launcher.appendVmargs
       </programArgs>
-      <vmArgs>-Dosgi.requiredJavaVersion=11 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true -Xms256m -Xmx2048m --add-modules=ALL-SYSTEM
+      <vmArgs>-Dosgi.requiredJavaVersion=11 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true -Djava.locale.useOldISOCodes=true -Xms256m -Xmx2048m --add-modules=ALL-SYSTEM
       </vmArgs>
       <vmArgsMac>-Xdock:icon=../Resources/Eclipse.icns -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
@@ -66,7 +66,7 @@ downloadable archives (&quot;Downloads&quot;).
     include plug-ins (&quot;Plug-ins&quot;), plug-in fragments (&quot;Fragments&quot;), and
     features (&quot;Features&quot;).
 -   Each Plug-in or Fragment may be packaged as a sub-directory or JAR
-    (Java&#8482; ARchive) in a directory named &quot;plugins&quot;.
+    (Java™ ARchive) in a directory named &quot;plugins&quot;.
 -   A Feature is a bundle of one or more Plug-ins and/or Fragments and
     associated material. Each Feature may be packaged as a sub-directory in a
     directory named &quot;features&quot;. Within a Feature, files named &quot;feature.xml&quot; may
@@ -194,9 +194,9 @@ United States, other countries, or both.
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
-      <property name="osgi.bundles.defaultStartLevel" value="4" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="org.eclipse.update.reconcile" value="false" />
+      <property name="osgi.bundles.defaultStartLevel" value="4" />
    </configurations>
 
 </product>

--- a/eclipse.platform.releng.tychoeclipsebuilder/equinox.starterkit.product/EclipseRTOSGiStarterKit.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/equinox.starterkit.product/EclipseRTOSGiStarterKit.product
@@ -9,7 +9,7 @@
    <launcherArgs>
       <programArgs>-console -nosplash -consolelog -noexit
       </programArgs>
-      <vmArgs>-Declipse.ignoreApp=true
+      <vmArgs>-Declipse.ignoreApp=true -Djava.locale.useOldISOCodes=true
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
@@ -67,7 +67,7 @@ downloadable archives (&quot;Downloads&quot;).
     include plug-ins (&quot;Plug-ins&quot;), plug-in fragments (&quot;Fragments&quot;), and
     features (&quot;Features&quot;).
 -   Each Plug-in or Fragment may be packaged as a sub-directory or JAR
-    (Java&#8482; ARchive) in a directory named &quot;plugins&quot;.
+    (Java™ ARchive) in a directory named &quot;plugins&quot;.
 -   A Feature is a bundle of one or more Plug-ins and/or Fragments and
     associated material. Each Feature may be packaged as a sub-directory in a
     directory named &quot;features&quot;. Within a Feature, files named &quot;feature.xml&quot; may
@@ -188,8 +188,8 @@ United States, other countries, or both.
       <plugin id="org.eclipse.equinox.frameworkadmin.equinox" autoStart="true" startLevel="3" />
       <plugin id="org.eclipse.equinox.p2.console" autoStart="true" startLevel="3" />
       <plugin id="org.eclipse.equinox.simpleconfigurator.manipulator" autoStart="true" startLevel="3" />
-      <property name="eclipse.ignoreApp" value="true" />
       <property name="osgi.noShutdown" value="true" />
+      <property name="eclipse.ignoreApp" value="true" />
    </configurations>
 
 </product>


### PR DESCRIPTION
JDK17

Adding the vm argument -Djava.locale.useOldISOCodes=true to ini files.

Signed-off-by: Kalyan Prasad Tatavarthi <kalyan_prasad@in.ibm.com>