### PR TITLE
Disable concurrent verification builds.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@ pipeline {
 	options {
 		timeout(time: 240, unit: 'MINUTES')
 		buildDiscarder(logRotator(numToKeepStr:'5'))
+		disableConcurrentBuilds(abortPrevious: true)
 	}
 	agent {
 		label "centos-7-6gb"


### PR DESCRIPTION
This option leads to only single build happening per branch/PR and
canceling existing one if new one is scheduled.