### PR TITLE
Migration of eclipse.jdt.core.binaries.git to github #163

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,7 @@
   url = https://git.eclipse.org/r/jdt/eclipse.jdt.core
 [submodule "eclipse.jdt.core.binaries"]
   path = eclipse.jdt.core.binaries
-  url = https://git.eclipse.org/r/jdt/eclipse.jdt.core.binaries
+  url = https://github.com/eclipse-jdt/eclipse.jdt.core.binaries.git
 [submodule "eclipse.jdt.debug"]
   path = eclipse.jdt.debug
   url = https://git.eclipse.org/r/jdt/eclipse.jdt.debug


### PR DESCRIPTION
Fixes #163