### PR TITLE
Split CVS vs EBR sourced Orbit bundles #172

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -9,18 +9,9 @@
 
       <unit id="com.jcraft.jsch" version="0.1.55.v20190404-1902"/>
       <unit id="com.jcraft.jsch.source" version="0.1.55.v20190404-1902"/>
-      <unit id="com.sun.el" version="2.2.0.v201303151357"/>
-      <unit id="com.sun.el.source" version="2.2.0.v201303151357"/>
       <unit id="javax.annotation" version="1.3.5.v20200909-1856"/>
       <unit id="javax.annotation.source" version="1.3.5.v20200909-1856"/>
-      <unit id="javax.el" version="2.2.0.v201303151357"/>
-      <unit id="javax.el.source" version="2.2.0.v201303151357"/>
-      <unit id="javax.inject" version="1.0.0.v20091030"/>
-      <unit id="javax.inject.source" version="1.0.0.v20091030"/>
 
-      <unit id="javax.servlet.jsp" version="2.2.0.v201112011158"/>
-      <unit id="javax.servlet.jsp.source" version="2.2.0.v201112011158"/>
-      <unit id="javax.xml" version="1.3.4.v201005080400"/>
       <unit id="org.apache.ant" version="1.10.12.v20211102-1452"/>
       <unit id="org.apache.ant.source" version="1.10.12.v20211102-1452"/>
       <unit id="org.apache.batik.css" version="1.14.0.v20210324-0332"/>
@@ -43,8 +34,6 @@
       <unit id="org.apache.felix.gogo.shell.source" version="1.1.4.v20210111-1007"/>
       <unit id="org.apache.felix.scr" version="2.1.24.v20200924-1939"/>
       <unit id="org.apache.felix.scr.source" version="2.1.24.v20200924-1939"/>
-      <unit id="org.apache.jasper.glassfish" version="2.2.2.v201501141630"/>
-      <unit id="org.apache.jasper.glassfish.source" version="2.2.2.v201501141630"/>
 
       <unit id="org.junit" version="4.13.2.v20211018-1956"/>
       <unit id="org.junit.source" version="4.13.2.v20211018-1956"/>
@@ -58,30 +47,14 @@
       <unit id="org.objectweb.asm.analysis.source" version="9.2.0.v20210813-1119"/>
       <unit id="org.objectweb.asm.commons" version="9.2.0.v20210813-1119"/>
       <unit id="org.objectweb.asm.commons.source" version="9.2.0.v20210813-1119"/>
-      <unit id="org.sat4j.core" version="2.3.5.v201308161310"/>
-      <unit id="org.sat4j.pb" version="2.3.5.v201404071733"/>
       <unit id="org.tukaani.xz" version="1.9.0.v20210624-1259"/>
       <unit id="org.tukaani.xz.source" version="1.9.0.v20210624-1259"/>
-      <unit id="org.w3c.css.sac" version="1.3.1.v200903091627"/>
-      <unit id="org.w3c.css.sac.source" version="1.3.1.v200903091627"/>
-      <unit id="org.w3c.dom.events" version="3.0.0.draft20060413_v201105210656"/>
-      <unit id="org.w3c.dom.events.source" version="3.0.0.draft20060413_v201105210656"/>
-
-      <unit id="org.w3c.dom.smil" version="1.0.1.v200903091627"/>
-      <unit id="org.w3c.dom.smil.source" version="1.0.1.v200903091627"/>
-
-      <unit id="org.w3c.dom.svg" version="1.1.0.v201011041433"/>
-      <unit id="org.w3c.dom.svg.source" version="1.1.0.v201011041433"/>
 
       <!-- specific (additional) to equinox sdk -->
       <unit id="org.apache.sshd.osgi" version="2.8.0.v20211227-1750"/>
       <unit id="org.apache.sshd.osgi.source" version="2.8.0.v20211227-1750"/>
       <unit id="org.slf4j.api" version="1.7.30.v20200204-2150"/>
       <unit id="org.slf4j.api.source" version="1.7.30.v20200204-2150"/>
-
-      <!-- part of e4 ui tools. See bug 422102 -->
-      <unit id="org.apache.commons.jxpath" version="1.3.0.v200911051830"/>
-      <unit id="org.apache.commons.jxpath.source" version="1.3.0.v200911051830"/>
 
       <unit id="org.apache.commons.fileupload" version="1.3.2.v20170320-2229"/>
       <unit id="org.apache.commons.fileupload.source" version="1.3.2.v20170320-2229"/>
@@ -141,7 +114,6 @@
       <unit id="org.hamcrest.core" version="1.3.0.v20180420-1519"/>
       <unit id="org.hamcrest.core.source" version="1.3.0.v20180420-1519"/>
       <unit id="org.hamcrest.library" version="1.3.0.v20180524-2246"/>
-      <unit id="org.hamcrest.integration" version="1.3.0.v201305210900"/>
 
       <!-- Tip of the Day - See bug 531786 -->
       <unit id="com.google.gson" version="2.8.9.v20220111-1409"/>
@@ -157,14 +129,59 @@
       <unit id="org.bouncycastle.bcprov" version="1.70.0.v20220105-1522"/>
 
       <!-- RedDeer deps-->
-      <unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
       <unit id="com.fasterxml.jackson.core.jackson-annotations" version="2.12.1.v20210128-1726"/>
       <unit id="com.fasterxml.jackson.core.jackson-core" version="2.12.1.v20210128-1726"/>
       <unit id="com.fasterxml.jackson.core.jackson-databind" version="2.12.1.v20210128-1726"/>
-      <unit id="org.json" version="1.0.0.v201011060100"/>
       <unit id="org.yaml.snakeyaml" version="1.27.0.v20201111-1638"/>
 
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220302172233/repository/"/>
+      <!-- This is the "normal" Orbit repository. During development on Bug 568936 this repo is the EBR (git)
+           sourced bundles of Orbit from 2022-03. This is the sub-p2-repo of the 2022-03 recommended build.
+           This is the repo that is expected to be updated on milestones based on Orbit deliveries. -->
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops2/R20220302172233/repository/"/>
+    </location>
+    <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
+
+      <unit id="com.sun.el" version="2.2.0.v201303151357"/>
+      <unit id="com.sun.el.source" version="2.2.0.v201303151357"/>
+      <unit id="javax.el" version="2.2.0.v201303151357"/>
+      <unit id="javax.el.source" version="2.2.0.v201303151357"/>
+      <unit id="javax.inject" version="1.0.0.v20091030"/>
+      <unit id="javax.inject.source" version="1.0.0.v20091030"/>
+
+      <unit id="javax.servlet.jsp" version="2.2.0.v201112011158"/>
+      <unit id="javax.servlet.jsp.source" version="2.2.0.v201112011158"/>
+      <unit id="javax.xml" version="1.3.4.v201005080400"/>
+      <unit id="org.apache.jasper.glassfish" version="2.2.2.v201501141630"/>
+      <unit id="org.apache.jasper.glassfish.source" version="2.2.2.v201501141630"/>
+
+      <unit id="org.sat4j.core" version="2.3.5.v201308161310"/>
+      <unit id="org.sat4j.pb" version="2.3.5.v201404071733"/>
+      <unit id="org.w3c.css.sac" version="1.3.1.v200903091627"/>
+      <unit id="org.w3c.css.sac.source" version="1.3.1.v200903091627"/>
+      <unit id="org.w3c.dom.events" version="3.0.0.draft20060413_v201105210656"/>
+      <unit id="org.w3c.dom.events.source" version="3.0.0.draft20060413_v201105210656"/>
+
+      <unit id="org.w3c.dom.smil" version="1.0.1.v200903091627"/>
+      <unit id="org.w3c.dom.smil.source" version="1.0.1.v200903091627"/>
+
+      <unit id="org.w3c.dom.svg" version="1.1.0.v201011041433"/>
+      <unit id="org.w3c.dom.svg.source" version="1.1.0.v201011041433"/>
+
+      <unit id="org.hamcrest.integration" version="1.3.0.v201305210900"/>
+
+      <!-- part of e4 ui tools. See bug 422102 -->
+      <unit id="org.apache.commons.jxpath" version="1.3.0.v200911051830"/>
+      <unit id="org.apache.commons.jxpath.source" version="1.3.0.v200911051830"/>
+
+      <!-- RedDeer deps-->
+      <unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
+      <unit id="org.json" version="1.0.0.v201011060100"/>
+
+      <!-- This is the last build of the CVS sourced Orbit repository - this was a subrepo of the recommended Orbit
+           for 2022-03. Due to Bug 568936 this is not included in 2022-06 recommended Orbit repos and beyond.
+           The intention is to migrate the above (where possible) to newer sources, such as pulling from
+           maven central. -->
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20201118194144/repository/"/>
     </location>
 
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">


### PR DESCRIPTION
With Bug 568936 Orbit is dropping the old CVS sourced
bundles. This change splits out these two locations so
that while needed the older bundles can be collected
from the last place that CVS bundles were published.

@SDawley this is part one of the update. You can take this one, or wait until I complete the 2022-06 M1 build of Orbit to get the final URL for 2022-06 M1.

As of now the 2022-06 M1 for Orbit has the same contents (except for dropped CVS sourced bundles) as 2022-03 R.