### PR TITLE
Add sat4j 2.3.6 to target

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -153,8 +153,6 @@
       <unit id="org.apache.jasper.glassfish" version="2.2.2.v201501141630"/>
       <unit id="org.apache.jasper.glassfish.source" version="2.2.2.v201501141630"/>
 
-      <unit id="org.sat4j.core" version="2.3.5.v201308161310"/>
-      <unit id="org.sat4j.pb" version="2.3.5.v201404071733"/>
       <unit id="org.w3c.css.sac" version="1.3.1.v200903091627"/>
       <unit id="org.w3c.css.sac.source" version="1.3.1.v200903091627"/>
       <unit id="org.w3c.dom.events" version="3.0.0.draft20060413_v201105210656"/>
@@ -236,7 +234,19 @@
     <location path="${eclipse_home}" type="Profile"/>
     -->
     
-      <location includeDependencyScope="compile" includeSource="true" label="Jetty and servlet API" missingManifest="error" type="Maven">
+    <location includeDependencyScope="compile" includeSource="true" missingManifest="error" type="Maven">
+      <dependencies>
+        <dependency>
+          <groupId>org.ow2.sat4j</groupId>
+          <artifactId>org.ow2.sat4j.pb</artifactId>
+          <version>2.3.6</version>
+          <type>jar</type>
+        </dependency>
+      </dependencies>
+    </location>
+    
+    
+    <location includeDependencyScope="compile" includeSource="true" label="Jetty and servlet API" missingManifest="error" type="Maven">
       <dependencies>
         <dependency>
           <groupId>org.eclipse.jetty</groupId>
@@ -289,7 +299,7 @@
       </dependencies>
     </location>
     
-    <location includeDependencyScope="compile" includeSource="true" missingManifest="error" type="Maven">
+    <location includeDependencyScope="compile" includeSource="true" label="Test dependencies" missingManifest="error" type="Maven">
       <dependencies>
         <!-- TODO consider removing those deps to bytebuddy and let transitive
         dep be picked. However this specific version is required in org.eclipse.test feature at the moment.


### PR DESCRIPTION
Older sat4j will be removed later when dependent features and bundles
have migrated to use 2.3.6.

eclipse-equinox/p2#28