### PR TITLE
Add upstream ASM 9.3 to target-platform

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -37,6 +37,7 @@
 
       <unit id="org.junit" version="4.13.2.v20211018-1956"/>
       <unit id="org.junit.source" version="4.13.2.v20211018-1956"/>
+      <!-- Those asm units will be removed in favor of Maven artifacts -->
       <unit id="org.objectweb.asm" version="9.2.0.v20210813-1119"/>
       <unit id="org.objectweb.asm.source" version="9.2.0.v20210813-1119"/>
       <unit id="org.objectweb.asm.tree" version="9.2.0.v20210813-1119"/>
@@ -332,6 +333,23 @@
           <groupId>org.mockito</groupId>
           <artifactId>mockito-core</artifactId>
           <version>4.3.1</version>
+          <type>jar</type>
+        </dependency>
+      </dependencies>
+    </location>
+  
+    <location includeDependencyScope="compile" includeSource="true" label="ASM" missingManifest="error" type="Maven">
+      <dependencies>
+        <dependency>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm-util</artifactId>
+          <version>9.3</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm-commons</artifactId>
+          <version>9.3</version>
           <type>jar</type>
         </dependency>
       </dependencies>


### PR DESCRIPTION
So bundles can start using it. Older references will be removed later
once all consumers have updated the necessary Required-Bundles or
feature.xml content.

See also eclipse-pde/eclipse.pde.ui#11