### PR TITLE
Add org.osgi.util-bundles from Maven-Central

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -224,7 +224,7 @@
     <location path="${eclipse_home}" type="Profile"/>
     -->
     
-    <location includeDependencyScope="compile" includeSource="true" missingManifest="error" type="Maven">
+    <location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" missingManifest="error" type="Maven">
       <dependencies>
         <dependency>
           <groupId>org.ow2.sat4j</groupId>
@@ -236,7 +236,7 @@
     </location>
     
     
-    <location includeDependencyScope="compile" includeSource="true" label="Jetty and servlet API" missingManifest="error" type="Maven">
+    <location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" label="Jetty and servlet API" missingManifest="error" type="Maven">
       <dependencies>
         <dependency>
           <groupId>org.eclipse.jetty</groupId>
@@ -289,7 +289,7 @@
       </dependencies>
     </location>
     
-    <location includeDependencyScope="compile" includeSource="true" label="Test dependencies" missingManifest="error" type="Maven">
+    <location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" label="Test dependencies" missingManifest="error" type="Maven">
       <dependencies>
         <!-- TODO consider removing those deps to bytebuddy and let transitive
         dep be picked. However this specific version is required in org.eclipse.test feature at the moment.
@@ -327,7 +327,7 @@
       </dependencies>
     </location>
   
-    <location includeDependencyScope="compile" includeSource="true" label="ASM" missingManifest="error" type="Maven">
+    <location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" label="ASM" missingManifest="error" type="Maven">
       <dependencies>
         <dependency>
           <groupId>org.ow2.asm</groupId>
@@ -339,6 +339,40 @@
           <groupId>org.ow2.asm</groupId>
           <artifactId>asm-commons</artifactId>
           <version>9.3</version>
+          <type>jar</type>
+        </dependency>
+      </dependencies>
+    </location>
+    <location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" label="OSGi-util" missingManifest="error" type="Maven">
+      <dependencies>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.util.function</artifactId>
+          <version>1.2.0</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.util.promise</artifactId>
+          <version>1.2.0</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.util.measurement</artifactId>
+          <version>1.0.2</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.util.position</artifactId>
+          <version>1.0.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.util.xml</artifactId>
+          <version>1.0.2</version>
           <type>jar</type>
         </dependency>
       </dependencies>


### PR DESCRIPTION
Add the org.osgi.util-bundles to the Eclipse-SDK prerequisite target, which is required for [#eclipse-equinox/equinox.framework/41](https://github.com/eclipse-equinox/equinox.framework/pull/41).

@tjwatson are you fine with the versions?