### PR TITLE
Stop using deprecated appArgLine in tycho-eclipserun-plugin config

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -779,12 +779,18 @@
                 <configuration>
                   <skip>${skipAPIDescription}</skip>
                   <work>${project.build.directory}/apigeneration-workspace</work>
-                  <appArgLine>-application org.eclipse.pde.api.tools.apiGeneration
-                  -projectName ${project.artifactId}_${qualifiedVersion}
-                  -project ${project.basedir}
-                  -binary ${tychoProject.build.outputDirectories}
-                  -target ${project.build.directory}
-                  </appArgLine>
+                  <applicationsArgs>
+	                  <args>-application</args>
+	                  <args>org.eclipse.pde.api.tools.apiGeneration</args>
+	                  <args>-projectName</args>
+	                  <args>${project.artifactId}_${qualifiedVersion}</args>
+	                  <args>-project</args>
+	                  <args>${project.basedir}</args>
+	                  <args>-binary</args>
+	                  <args>${tychoProject.build.outputDirectories}</args>
+	                  <args>-target</args>
+	                  <args>${project.build.directory}</args>
+                  </applicationsArgs>
                   <dependencies>
                     <!-- list of bundles that we need -->
                     <dependency>


### PR DESCRIPTION
It's gone in 3.0.0-SNAPSHOT now.