### PR TITLE
Add osgi-services, -app, -coordinator, -log bundles from Maven-Central

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -343,17 +343,101 @@
         </dependency>
       </dependencies>
     </location>
-    <location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" label="OSGi-util" missingManifest="error" type="Maven">
+    <location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" label="OSGi" missingManifest="error" type="Maven">
       <dependencies>
         <dependency>
           <groupId>org.osgi</groupId>
-          <artifactId>org.osgi.util.function</artifactId>
+          <artifactId>org.osgi.service.application</artifactId>
+          <version>1.1.0</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.service.cm</artifactId>
+          <version>1.6.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.service.component.annotations</artifactId>
+          <version>1.5.0</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.service.component</artifactId>
+          <version>1.5.0</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.service.coordinator</artifactId>
+          <version>1.0.2</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.service.device</artifactId>
+          <version>1.1.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.service.event</artifactId>
+          <version>1.4.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.service.http.whiteboard</artifactId>
+          <version>1.1.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.service.http</artifactId>
+          <version>1.2.2</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.service.log.stream</artifactId>
+          <version>1.0.0</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.service.metatype</artifactId>
+          <version>1.4.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.service.provisioning</artifactId>
           <version>1.2.0</version>
           <type>jar</type>
         </dependency>
         <dependency>
           <groupId>org.osgi</groupId>
-          <artifactId>org.osgi.util.promise</artifactId>
+          <artifactId>org.osgi.service.upnp</artifactId>
+          <version>1.2.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.service.useradmin</artifactId>
+          <version>1.1.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.service.wireadmin</artifactId>
+          <version>1.0.2</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.util.function</artifactId>
           <version>1.2.0</version>
           <type>jar</type>
         </dependency>
@@ -367,6 +451,18 @@
           <groupId>org.osgi</groupId>
           <artifactId>org.osgi.util.position</artifactId>
           <version>1.0.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.util.promise</artifactId>
+          <version>1.2.0</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.util.pushstream</artifactId>
+          <version>1.0.2</version>
           <type>jar</type>
         </dependency>
         <dependency>


### PR DESCRIPTION
Add more osgi bundles to the Eclipse-SDK prerequisite target, which are required for:
- https://github.com/eclipse-equinox/equinox.framework/pull/44
- https://github.com/eclipse-equinox/equinox.bundles/pull/26

@tjwatson are you again fine with the versions? I selected the latest ones again.