### PR TITLE
Eclipse 4.24 M2 Prerequisites: Orbit (fixup jackson)

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -118,9 +118,6 @@
       <unit id="org.bouncycastle.bcprov" version="1.70.0.v20220105-1522"/>
 
       <!-- RedDeer deps-->
-      <unit id="com.fasterxml.jackson.core.jackson-annotations" version="2.12.1.v20210128-1726"/>
-      <unit id="com.fasterxml.jackson.core.jackson-core" version="2.12.1.v20210128-1726"/>
-      <unit id="com.fasterxml.jackson.core.jackson-databind" version="2.12.1.v20210128-1726"/>
       <unit id="org.yaml.snakeyaml" version="1.27.0.v20201111-1638"/>
 
       <!-- This is the "normal" Orbit repository. During development on Bug 568936 this repo is the EBR (git)
@@ -469,6 +466,28 @@
           <groupId>org.osgi</groupId>
           <artifactId>org.osgi.util.xml</artifactId>
           <version>1.0.2</version>
+          <type>jar</type>
+        </dependency>
+      </dependencies>
+    </location>
+    <location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" label="Reddeer Deps" missingManifest="error" type="Maven">
+      <dependencies>
+        <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+          <version>2.13.2</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+          <version>2.13.2</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+          <version>2.13.2.2</version>
           <type>jar</type>
         </dependency>
       </dependencies>


### PR DESCRIPTION
Orbit 2022-06 M2 includes newer version of Jackson. Instead of
pointing at that newer version, consume Jackson directly from
Maven central as it is a proper OSGi bundle.