### PR TITLE
Add Ubuntu 22.04 test run in smoke tests #160

### DIFF
--- a/cje-production/dockerfiles/ubuntu-gtk3-metacity/22.04-gtk3/Dockerfile
+++ b/cje-production/dockerfiles/ubuntu-gtk3-metacity/22.04-gtk3/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt upgrade -y && apt dist-upgrade -y && apt-get install -
       libgtk-3-0 \
       tigervnc-standalone-server \
       tigervnc-common \
+      tigetvnc-tools \
       metacity \
       x11-xserver-utils \
       libgl1-mesa-dri \


### PR DESCRIPTION
Added tigervnc-tools package to get vncpasswd

fixes #160 