### PR TITLE
Remove org.osgi:org.osgi.service.application

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -344,12 +344,6 @@
       <dependencies>
         <dependency>
           <groupId>org.osgi</groupId>
-          <artifactId>org.osgi.service.application</artifactId>
-          <version>1.1.0</version>
-          <type>jar</type>
-        </dependency>
-        <dependency>
-          <groupId>org.osgi</groupId>
           <artifactId>org.osgi.service.cm</artifactId>
           <version>1.6.1</version>
           <type>jar</type>


### PR DESCRIPTION
After some considerations we decided to not use the `org.osgi:org.osgi.service.application` dependency, so it is not used and can be removed again:
https://github.com/eclipse-equinox/equinox.bundles/pull/26#issuecomment-1112647217

