### PR TITLE
Update aggregator with move of PDE build modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,9 +14,6 @@
 [submodule "eclipse.jdt.ui"]
   path = eclipse.jdt.ui
   url = https://github.com/eclipse-jdt/eclipse.jdt.ui.git
-[submodule "eclipse.pde.build"]
-  path = eclipse.pde.build
-  url = https://github.com/eclipse-pde/eclipse.pde.build.git
 [submodule "eclipse.pde"]
 	path = eclipse.pde
 	url = https://github.com/eclipse-pde/eclipse.pde.git

--- a/cje-production/streams/repositories_java18.txt
+++ b/cje-production/streams/repositories_java18.txt
@@ -7,7 +7,6 @@ eclipse.jdt.core.binaries: master
 eclipse.jdt.core: BETA_JAVA18
 eclipse.jdt.debug: BETA_JAVA18
 eclipse.jdt.ui: BETA_JAVA18
-eclipse.pde.build: BETA_JAVA18
 eclipse.pde: BETA_JAVA18
 eclipse.platform.debug: master
 eclipse.platform.resources: master

--- a/cje-production/streams/repositories_java18patch.txt
+++ b/cje-production/streams/repositories_java18patch.txt
@@ -2,4 +2,3 @@ eclipse.jdt.core: BETA_JAVA18
 eclipse.pde: BETA_JAVA18
 eclipse.jdt.ui: BETA_JAVA18
 eclipse.jdt.debug: BETA_JAVA18
-eclipse.pde.build: BETA_JAVA18

--- a/cje-production/streams/repositories_master.txt
+++ b/cje-production/streams/repositories_master.txt
@@ -7,7 +7,6 @@ eclipse.jdt.core: master
 eclipse.jdt.debug: master
 eclipse.jdt: master
 eclipse.jdt.ui: master
-eclipse.pde.build: master
 eclipse.pde: master
 eclipse.platform.debug: master
 eclipse.platform.resources: master

--- a/eclipse.platform.releng.tychoeclipsebuilder/java18patch/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/java18patch/pom.xml
@@ -43,7 +43,7 @@
     <module>../../eclipse.jdt.core/org.eclipse.jdt.compiler.tool</module>
     <module>../../eclipse.jdt.ui/org.eclipse.jdt.core.manipulation</module>
     <module>../../eclipse.jdt.ui/org.eclipse.jdt.ui</module>
-    <module>../../eclipse.pde.build/org.eclipse.pde.build</module>
+    <module>../../eclipse.pde/build/org.eclipse.pde.build</module>
     <module>../../eclipse.pde/apitools/org.eclipse.pde.api.tools</module>
      <module>../../eclipse.jdt.debug/org.eclipse.jdt.launching</module>
     <module>org.eclipse.jdt.java18patch</module>


### PR DESCRIPTION
https://github.com/eclipse-pde/eclipse.pde/pull/39 merged PDE build
into the PDE repo so we need to update the aggregator.