### PR TITLE
Remove pde.build module from aggregator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,6 @@
     <module>eclipse.jdt.debug</module>
     <module>eclipse.jdt.ui</module>
 
-    <module>eclipse.pde.build</module>
     <module>eclipse.pde</module>
 
     <module>eclipse.platform</module>


### PR DESCRIPTION
It's merged into pde. See
https://github.com/eclipse-pde/eclipse.pde/pull/39