### PR TITLE
Always check for API analysis when profile is on #174

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -842,10 +842,9 @@
                   <goal>run</goal>
                 </goals>
                 <configuration>
-                  <skip>${skipAPIAnalysis}</skip>
                   <exportAntProperties>true</exportAntProperties>
                   <target>
-                    <condition property="skipAPIAnalysis" value="true">
+                    <condition property="skipAPIAnalysis" value="true" else="false">
                       <not>
                         <available file="${basedir}/META-INF/MANIFEST.MF"/>
                       </not>


### PR DESCRIPTION
In some cases, the skipAPIAnalysis=true property can be exported from
Ant into the Maven session or some parent (instead of current project
properties). This might be related to pom-less generating a static value
for this property.
The `skipAPIAnalysis` is useless here anyway because people who want a
flag to skip API Analysis can explicitly exclude the profile already.