### PR TITLE
Update to commons-fileupload 1.4

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -46,8 +46,6 @@
       <unit id="org.slf4j.api" version="1.7.30.v20200204-2150"/>
       <unit id="org.slf4j.api.source" version="1.7.30.v20200204-2150"/>
 
-      <unit id="org.apache.commons.fileupload" version="1.3.2.v20170320-2229"/>
-      <unit id="org.apache.commons.fileupload.source" version="1.3.2.v20170320-2229"/>
       <unit id="org.apache.commons.io" version="2.8.0.v20210415-0900"/>
       <unit id="org.apache.commons.io.source" version="2.8.0.v20210415-0900"/>
 
@@ -227,6 +225,12 @@
           <groupId>org.ow2.sat4j</groupId>
           <artifactId>org.ow2.sat4j.pb</artifactId>
           <version>2.3.6</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>commons-fileupload</groupId>
+          <artifactId>commons-fileupload</artifactId>
+          <version>1.4</version>
           <type>jar</type>
         </dependency>
       </dependencies>


### PR DESCRIPTION
Currently shipped version 1.3.2 has a CVE
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1000031 .
Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/250