### PR TITLE
Ensure that a project containing the eclipse-sdk-prereqs.target is available in the workspace.

### DIFF
--- a/oomph/Platform.setup
+++ b/oomph/Platform.setup
@@ -706,6 +706,8 @@
             name="org.eclipse.platform.releng.tychoeclipsebuilder.plain.project"/>
         <requirement
             name="org.eclipse.platform.setup.plain.project"/>
+        <requirement
+            name="org.eclipse.platform.releng.prereqs.sdk.plain.project"/>
         <sourceLocator
             rootFolder="${github.clone.platform.releng.aggregator.location}"
             locateNestedProjects="true"/>
@@ -722,6 +724,25 @@
               project="org.eclipse.platform.releng.tychoeclipsebuilder"/>
         </predicate>
       </workingSet>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:ResourceCreationTask"
+        targetURL="${github.clone.platform.releng.aggregator.location|uri}/eclipse.platform.releng.prereqs.sdk/.project"
+        encoding="UTF-8">
+      <content>
+        &lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?>
+        &lt;projectDescription>
+        	&lt;name>org.eclipse.platform.releng.prereqs.sdk&lt;/name>
+        	&lt;comment>&lt;/comment>
+        	&lt;projects>
+        	&lt;/projects>
+        	&lt;buildSpec>
+        	&lt;/buildSpec>
+        	&lt;natures>
+        	&lt;/natures>
+        &lt;/projectDescription>
+
+      </content>
     </setupTask>
     <stream
         name="master"
@@ -793,13 +814,13 @@
         label="Master"/>
     <description>The Platform Releng Build Tools</description>
   </project>
-  <project href="../../../eclipse.platform.resources/master/bundles/org.eclipse.core.resources.releng/platformResources.setup#/"/>
-  <project href="../../../eclipse.platform.runtime/master/bundles/org.eclipse.core.runtime.releng/platformRuntime.setup#/"/>
-  <project href="../../../eclipse.platform.swt/master/bundles/org.eclipse.swt.tools/Oomph/platformSwt.setup#/"/>
-  <project href="../../../eclipse.platform.team/master/bundles/org.eclipse.team.releng/platformTeam.setup#/"/>
-  <project href="../../../eclipse.platform.text/master/org.eclipse.text.releng/platformText.setup#/"/>
-  <project href="../../../eclipse.platform.ua/master/org.eclipse.ua.releng/platformUa.setup#/"/>
-  <project href="../../../eclipse.platform.ui/master/releng/org.eclipse.ui.releng/platformUi.setup#/"/>
+  <project href="https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.resources/master/bundles/org.eclipse.core.resources.releng/platformResources.setup#/"/>
+  <project href="https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.runtime/master/bundles/org.eclipse.core.runtime.releng/platformRuntime.setup#/"/>
+  <project href="https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.swt/master/bundles/org.eclipse.swt.tools/Oomph/platformSwt.setup#/"/>
+  <project href="https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.team/master/bundles/org.eclipse.team.releng/platformTeam.setup#/"/>
+  <project href="https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.text/master/org.eclipse.text.releng/platformText.setup#/"/>
+  <project href="https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ua/master/org.eclipse.ua.releng/platformUa.setup#/"/>
+  <project href="https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/releng/org.eclipse.ui.releng/platformUi.setup#/"/>
   <project name="ui.tools"
       label="UI Tools">
     <setupTask


### PR DESCRIPTION
The eclipse.platform.releng.prereqs.sdk folder contains a .gitignore
that ignored the .project file so we can create a .project file
automatically without dirtying the repository.

Also use absolute URIs to reference the child projects now that the
setup itself can be opened via a workspace project.