### PR TITLE
Switch some Orbit deps to latest I-build

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -101,6 +101,9 @@
 
       <unit id="org.hamcrest.core" version="1.3.0.v20180420-1519"/>
       <unit id="org.hamcrest.core.source" version="1.3.0.v20180420-1519"/>
+      <unit id="javax.inject" version="1.0.0.v20220405-0441"/>
+      <unit id="javax.inject.source" version="1.0.0.v20220405-0441"/>
+      <unit id="javax.xml" version="1.4.1.v20220503-2331"/>
 
       <!-- Tip of the Day - See bug 531786 -->
       <unit id="com.google.gson" version="2.8.9.v20220111-1409"/>
@@ -117,11 +120,12 @@
 
       <!-- RedDeer deps-->
       <unit id="org.yaml.snakeyaml" version="1.27.0.v20201111-1638"/>
+      <unit id="org.apache.commons.lang" version="2.6.0.v20220406-2305"/>
 
       <!-- This is the "normal" Orbit repository. During development on Bug 568936 this repo is the EBR (git)
            sourced bundles of Orbit from 2022-03. This is the sub-p2-repo of the 2022-03 recommended build.
            This is the repo that is expected to be updated on milestones based on Orbit deliveries. -->
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/S20220426182153/repository/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/I20220504015222/repository/"/>
     </location>
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
 
@@ -129,12 +133,9 @@
       <unit id="com.sun.el.source" version="2.2.0.v201303151357"/>
       <unit id="javax.el" version="2.2.0.v201303151357"/>
       <unit id="javax.el.source" version="2.2.0.v201303151357"/>
-      <unit id="javax.inject" version="1.0.0.v20091030"/>
-      <unit id="javax.inject.source" version="1.0.0.v20091030"/>
 
       <unit id="javax.servlet.jsp" version="2.2.0.v201112011158"/>
       <unit id="javax.servlet.jsp.source" version="2.2.0.v201112011158"/>
-      <unit id="javax.xml" version="1.3.4.v201005080400"/>
       <unit id="org.apache.jasper.glassfish" version="2.2.2.v201501141630"/>
       <unit id="org.apache.jasper.glassfish.source" version="2.2.2.v201501141630"/>
 
@@ -154,7 +155,6 @@
       <unit id="org.apache.commons.jxpath.source" version="1.3.0.v200911051830"/>
 
       <!-- RedDeer deps-->
-      <unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
       <unit id="org.json" version="1.0.0.v201011060100"/>
 
       <!-- This is the last build of the CVS sourced Orbit repository - this was a subrepo of the recommended Orbit


### PR DESCRIPTION
They were locked at the old CVS repo as they were not available in the
new recipes way until very recently.