### PR TITLE
Ensure that the .project file created in the

### DIFF
--- a/oomph/Platform.setup
+++ b/oomph/Platform.setup
@@ -700,6 +700,7 @@
     </setupTask>
     <setupTask
         xsi:type="setup:ResourceCreationTask"
+        excludedTriggers="BOOTSTRAP"
         targetURL="${github.clone.platform.releng.aggregator.location|uri}/eclipse.platform.releng.prereqs.sdk/.project"
         encoding="UTF-8">
       <content>


### PR DESCRIPTION
eclipse.platform.releng.prereqs.sdk folder is not done during bootstrap
but rather after the clone task as created the clone.