### PR TITLE
Make $HOME open to the 'root' group

### DIFF
--- a/cje-production/dockerfiles/centos-gtk3-metacity/7-gtk3/Dockerfile
+++ b/cje-production/dockerfiles/centos-gtk3-metacity/7-gtk3/Dockerfile
@@ -43,7 +43,9 @@ RUN mkdir -p ${HOME}/.vnc && chmod -R 775 ${HOME} \
 
 # Create a custom vnc xstartup file
 COPY scripts/xstartup_metacity.sh ${HOME}/.vnc/xstartup.sh
-RUN chmod 755 ${HOME}/.vnc/xstartup.sh
+# Make $HOME open to the 'root' group (so Jenkins/OpenShift user can write there)
+RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME
+
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 ENV LANG=en_US.UTF-8
 

--- a/cje-production/dockerfiles/centos-gtk3-metacity/7-gtk3/Dockerfile
+++ b/cje-production/dockerfiles/centos-gtk3-metacity/7-gtk3/Dockerfile
@@ -44,7 +44,7 @@ RUN mkdir -p ${HOME}/.vnc && chmod -R 775 ${HOME} \
 # Create a custom vnc xstartup file
 COPY scripts/xstartup_metacity.sh ${HOME}/.vnc/xstartup.sh
 # Make $HOME open to the 'root' group (so Jenkins/OpenShift user can write there)
-RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME
+RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME}
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 ENV LANG=en_US.UTF-8

--- a/cje-production/dockerfiles/centos-gtk3-metacity/8-gtk3/Dockerfile
+++ b/cje-production/dockerfiles/centos-gtk3-metacity/8-gtk3/Dockerfile
@@ -48,7 +48,9 @@ RUN mkdir -p var/lib/dbus && dbus-uuidgen > /var/lib/dbus/machine-id \
 
 # Create a custom vnc xstartup file
 COPY scripts/xstartup_metacity.sh ${HOME}/.vnc/xstartup.sh
-RUN chmod 755 ${HOME}/.vnc/xstartup.sh
+# Make $HOME open to the 'root' group (so Jenkins/OpenShift user can write there)
+RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME
+
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 ENV LANG=en_US.UTF-8
 

--- a/cje-production/dockerfiles/centos-gtk3-metacity/8-gtk3/Dockerfile
+++ b/cje-production/dockerfiles/centos-gtk3-metacity/8-gtk3/Dockerfile
@@ -49,7 +49,7 @@ RUN mkdir -p var/lib/dbus && dbus-uuidgen > /var/lib/dbus/machine-id \
 # Create a custom vnc xstartup file
 COPY scripts/xstartup_metacity.sh ${HOME}/.vnc/xstartup.sh
 # Make $HOME open to the 'root' group (so Jenkins/OpenShift user can write there)
-RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME
+RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME}
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 ENV LANG=en_US.UTF-8

--- a/cje-production/dockerfiles/centos-gtk3-metacity/8-swtBuild/Dockerfile
+++ b/cje-production/dockerfiles/centos-gtk3-metacity/8-swtBuild/Dockerfile
@@ -68,6 +68,6 @@ RUN mkdir -p ${HOME}/.vnc && chmod -R 775 ${HOME} \
 # Create a custom vnc xstartup file
 COPY scripts/xstartup_metacity.sh ${HOME}/.vnc/xstartup.sh
 # Make $HOME open to the 'root' group (so Jenkins/OpenShift user can write there)
-RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME
+RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME}
 
 USER 10001

--- a/cje-production/dockerfiles/centos-gtk3-metacity/8-swtBuild/Dockerfile
+++ b/cje-production/dockerfiles/centos-gtk3-metacity/8-swtBuild/Dockerfile
@@ -67,6 +67,7 @@ RUN mkdir -p ${HOME}/.vnc && chmod -R 775 ${HOME} \
 
 # Create a custom vnc xstartup file
 COPY scripts/xstartup_metacity.sh ${HOME}/.vnc/xstartup.sh
-RUN chmod 755 ${HOME}/.vnc/xstartup.sh
+# Make $HOME open to the 'root' group (so Jenkins/OpenShift user can write there)
+RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME
 
 USER 10001

--- a/cje-production/dockerfiles/centos-gtk4-mutter/9-gtk4/Dockerfile
+++ b/cje-production/dockerfiles/centos-gtk4-mutter/9-gtk4/Dockerfile
@@ -48,7 +48,7 @@ RUN mkdir -p var/lib/dbus && dbus-uuidgen > /var/lib/dbus/machine-id \
 # Create a custom vnc xstartup file
 COPY scripts/xstartup_metacity.sh ${HOME}/.vnc/xstartup.sh
 # Make $HOME open to the 'root' group (so Jenkins/OpenShift user can write there)
-RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME
+RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME}
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 ENV LANG=en_US.UTF-8

--- a/cje-production/dockerfiles/centos-gtk4-mutter/9-gtk4/Dockerfile
+++ b/cje-production/dockerfiles/centos-gtk4-mutter/9-gtk4/Dockerfile
@@ -47,7 +47,9 @@ RUN mkdir -p var/lib/dbus && dbus-uuidgen > /var/lib/dbus/machine-id \
 
 # Create a custom vnc xstartup file
 COPY scripts/xstartup_metacity.sh ${HOME}/.vnc/xstartup.sh
-RUN chmod 755 ${HOME}/.vnc/xstartup.sh
+# Make $HOME open to the 'root' group (so Jenkins/OpenShift user can write there)
+RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME
+
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 ENV LANG=en_US.UTF-8
 

--- a/cje-production/dockerfiles/centos-gtk4-mutter/9-swtBuild/Dockerfile
+++ b/cje-production/dockerfiles/centos-gtk4-mutter/9-swtBuild/Dockerfile
@@ -64,6 +64,7 @@ RUN mkdir -p ${HOME}/.vnc && chmod -R 775 ${HOME} \
 
 # Create a custom vnc xstartup file
 COPY scripts/xstartup_metacity.sh ${HOME}/.vnc/xstartup.sh
-RUN chmod 755 ${HOME}/.vnc/xstartup.sh
+# Make $HOME open to the 'root' group (so Jenkins/OpenShift user can write there)
+RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME
 
 USER 10001

--- a/cje-production/dockerfiles/centos-gtk4-mutter/9-swtBuild/Dockerfile
+++ b/cje-production/dockerfiles/centos-gtk4-mutter/9-swtBuild/Dockerfile
@@ -65,6 +65,6 @@ RUN mkdir -p ${HOME}/.vnc && chmod -R 775 ${HOME} \
 # Create a custom vnc xstartup file
 COPY scripts/xstartup_metacity.sh ${HOME}/.vnc/xstartup.sh
 # Make $HOME open to the 'root' group (so Jenkins/OpenShift user can write there)
-RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME
+RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME}
 
 USER 10001

--- a/cje-production/dockerfiles/opensuse-gtk3-metacity/15-gtk3/Dockerfile
+++ b/cje-production/dockerfiles/opensuse-gtk3-metacity/15-gtk3/Dockerfile
@@ -35,6 +35,6 @@ RUN mkdir -p ${HOME}/.vnc && chmod -R 775 ${HOME} \
 # Create a custom vnc xstartup file
 COPY scripts/xstartup_metacity.sh ${HOME}/.vnc/xstartup.sh
 # Make $HOME open to the 'root' group (so Jenkins/OpenShift user can write there)
-RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME
+RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME}
 
 USER 10001

--- a/cje-production/dockerfiles/opensuse-gtk3-metacity/15-gtk3/Dockerfile
+++ b/cje-production/dockerfiles/opensuse-gtk3-metacity/15-gtk3/Dockerfile
@@ -34,6 +34,7 @@ RUN mkdir -p ${HOME}/.vnc && chmod -R 775 ${HOME} \
 
 # Create a custom vnc xstartup file
 COPY scripts/xstartup_metacity.sh ${HOME}/.vnc/xstartup.sh
-RUN chmod 755 ${HOME}/.vnc/xstartup.sh
+# Make $HOME open to the 'root' group (so Jenkins/OpenShift user can write there)
+RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME
 
 USER 10001

--- a/cje-production/dockerfiles/ubuntu-gtk3-metacity/18.04-gtk3/Dockerfile
+++ b/cje-production/dockerfiles/ubuntu-gtk3-metacity/18.04-gtk3/Dockerfile
@@ -41,6 +41,6 @@ RUN mkdir -p ${HOME}/.vnc && chmod -R 775 ${HOME} \
 # Create a custom vnc xstartup file
 COPY scripts/xstartup_metacity.sh ${HOME}/.vnc/xstartup.sh
 # Make $HOME open to the 'root' group (so Jenkins/OpenShift user can write there)
-RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME
+RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME}
 
 USER 10001

--- a/cje-production/dockerfiles/ubuntu-gtk3-metacity/18.04-gtk3/Dockerfile
+++ b/cje-production/dockerfiles/ubuntu-gtk3-metacity/18.04-gtk3/Dockerfile
@@ -40,6 +40,7 @@ RUN mkdir -p ${HOME}/.vnc && chmod -R 775 ${HOME} \
 
 # Create a custom vnc xstartup file
 COPY scripts/xstartup_metacity.sh ${HOME}/.vnc/xstartup.sh
-RUN chmod 755 ${HOME}/.vnc/xstartup.sh
+# Make $HOME open to the 'root' group (so Jenkins/OpenShift user can write there)
+RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME
 
 USER 10001

--- a/cje-production/dockerfiles/ubuntu-gtk3-metacity/20.04-gtk3/Dockerfile
+++ b/cje-production/dockerfiles/ubuntu-gtk3-metacity/20.04-gtk3/Dockerfile
@@ -41,5 +41,7 @@ RUN mkdir -p ${HOME}/.vnc && chmod -R 775 ${HOME} \
 # Create a custom vnc xstartup file
 COPY scripts/xstartup_metacity.sh ${HOME}/.vnc/xstartup.sh
 RUN chmod 755 ${HOME}/.vnc/xstartup.sh
+# Make $HOME open to the 'root' group (so Jenkins/OpenShift user can write there)
+RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME
 
 USER 10001

--- a/cje-production/dockerfiles/ubuntu-gtk3-metacity/20.04-gtk3/Dockerfile
+++ b/cje-production/dockerfiles/ubuntu-gtk3-metacity/20.04-gtk3/Dockerfile
@@ -42,6 +42,6 @@ RUN mkdir -p ${HOME}/.vnc && chmod -R 775 ${HOME} \
 COPY scripts/xstartup_metacity.sh ${HOME}/.vnc/xstartup.sh
 RUN chmod 755 ${HOME}/.vnc/xstartup.sh
 # Make $HOME open to the 'root' group (so Jenkins/OpenShift user can write there)
-RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME
+RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME}
 
 USER 10001

--- a/cje-production/dockerfiles/ubuntu-gtk3-metacity/22.04-gtk3/Dockerfile
+++ b/cje-production/dockerfiles/ubuntu-gtk3-metacity/22.04-gtk3/Dockerfile
@@ -43,6 +43,6 @@ RUN mkdir -p ${HOME}/.vnc && chmod -R 775 ${HOME} \
 # Create a custom vnc xstartup file
 COPY scripts/xstartup_metacity.sh ${HOME}/.vnc/xstartup.sh
 # Make $HOME open to the 'root' group (so Jenkins/OpenShift user can write there)
-RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME
+RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME}
 
 USER 10001

--- a/cje-production/dockerfiles/ubuntu-gtk3-metacity/22.04-gtk3/Dockerfile
+++ b/cje-production/dockerfiles/ubuntu-gtk3-metacity/22.04-gtk3/Dockerfile
@@ -42,6 +42,7 @@ RUN mkdir -p ${HOME}/.vnc && chmod -R 775 ${HOME} \
 
 # Create a custom vnc xstartup file
 COPY scripts/xstartup_metacity.sh ${HOME}/.vnc/xstartup.sh
-RUN chmod 755 ${HOME}/.vnc/xstartup.sh
+# Make $HOME open to the 'root' group (so Jenkins/OpenShift user can write there)
+RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME
 
 USER 10001


### PR DESCRIPTION
So Jenkins/OpenShift user can write there, see
 https://docs.openshift.com/container-platform/3.9/creating_images/guidelines.html#use-uid

Should fix
https://github.com/eclipse-platform/eclipse.platform.swt/issues/108 as
 newer WebKitGTK transitively needs to write in HOME folder.