### PR TITLE
EMF Update for 4.24 M3

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -179,11 +179,11 @@
        <!-- Check version in "<EMF>/features" directory -->
       <unit id="org.eclipse.emf.edit.feature.group" version="2.18.0.v20220201-1551"/>
       <unit id="org.eclipse.emf.edit.source.feature.group" version="2.18.0.v20220201-1551"/>
-      <unit id="org.eclipse.emf.databinding.feature.group" version="1.8.0.v20210924-1718"/>
-      <unit id="org.eclipse.emf.databinding.source.feature.group" version="1.8.0.v20210924-1718"/>
+      <unit id="org.eclipse.emf.databinding.feature.group" version="1.9.0.v20220516-1117"/>
+      <unit id="org.eclipse.emf.databinding.source.feature.group" version="1.9.0.v20220516-1117"/>
       <unit id="org.eclipse.emf.databinding.edit.feature.group" version="1.9.0.v20210924-1718"/>
       <unit id="org.eclipse.emf.databinding.edit.source.feature.group" version="1.9.0.v20210924-1718"/>
-      <repository location="https://download.eclipse.org/modeling/emf/emf/builds/milestone/S202204260307"/>
+      <repository location="https://download.eclipse.org/modeling/emf/emf/builds/milestone/S202205161126"/>
     </location>
 
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">


### PR DESCRIPTION
Updates #171 

I noticed org.eclipse.emf.databinding.feature.group and org.eclipse.emf.databinding.feature.group were still set to 1.8 so I've updated them to 1.9.0.v20220516-1117 but asking for review from @merks to make sure they weren't left at 1.8 for a reason.