### PR TITLE
Improve verifyFreezePeriod workflow

### DIFF
--- a/.github/workflows/verifyFreezePeriod.yml
+++ b/.github/workflows/verifyFreezePeriod.yml
@@ -9,12 +9,13 @@ jobs:
   verify-freeze-period:
     runs-on: ubuntu-latest
     steps:
-      - name: Checking whether Eclipse project is currently in stabilitzation/code-freeze period ...
+      - name: Checking whether Eclipse project is currently in stabilization/code-freeze period ...
         run: |
           today=$(TZ=UTC date "+%Y%m%d")
           tomorrow=$(TZ=UTC date -d "+1 days" "+%Y%m%d")
-          calID="cHJmazI2ZmRtcHJ1MW1wdGxiMDZwMGpoNHNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ"
-          curl "https://calendar.google.com/calendar/u/0/htmlembed?src=${calID}&mode=AGENDA&ctz=UTC&dates=${today}/${tomorrow}" | grep -i -q -e "stabilization"
+          calURL="https://calendar.google.com/calendar/u/0/htmlembed?src=cHJmazI2ZmRtcHJ1MW1wdGxiMDZwMGpoNHNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ"
+          echo "Querying calendar ${calURL}"
+          curl "${calURL}&mode=AGENDA&ctz=UTC&dates=${today}/${tomorrow}" | grep -i -q -e "stabilization"
           if [[ $? == 0 ]]; then
             echo "::error::Today is a freeze day"
             exit 1 #Exiting with non-0 makes this workflow fail


### PR DESCRIPTION
As requested in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/206#issuecomment-1129257714 this PR implements a first minor improvement of the freezePeriod check workflow, by printing the queried calendar on the console.
So in case of a freeze period one can check manually when it has started and when it ends.

Additionally the script could be enhanced to print the end of the freeze period. This could be determined by querying the calendar in a loop until the first day is encountered that has no "stabilization" entry. Technically this would be feasible but I'm not sure if this is wanted. Usually the re-opening of the master is announced via the mailing-list, so I'm not sure what's the source of truth here. On the other hand, if this check is triggered on the first day after a freeze-period it succeeds anyway. 

Besides that we should consider to have dedicated "freeze-period" dates into the calendar. At the moment any date that contains the string `stabilization` is interpreted as freeze period but this check seems not be reliable anymore since there is no such date for the current days although the master branch is only open for PMC/Project lead approved changes (so it is not fully frozen).
More aliases for `stabilization` like "endgame", "signoff" or "promotion" could be added, but IHMO having dedicated freeze-periode dates would make it more clear.

This already caused confusion in https://github.com/eclipse-equinox/p2/pull/64 and https://github.com/eclipse-pde/eclipse.pde/pull/122