### PR TITLE
Add felix.scr and felix.gogo.command/runtime/shell from Maven-Central

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -28,12 +28,8 @@
       <unit id="org.apache.commons.logging.source" version="1.2.0.v20180409-1502"/>
       <unit id="org.apache.felix.gogo.command" version="1.1.2.v20210111-1007"/>
       <unit id="org.apache.felix.gogo.command.source" version="1.1.2.v20210111-1007"/>
-      <unit id="org.apache.felix.gogo.runtime" version="1.1.4.v20210111-1007"/>
-      <unit id="org.apache.felix.gogo.runtime.source" version="1.1.4.v20210111-1007"/>
       <unit id="org.apache.felix.gogo.shell" version="1.1.4.v20210111-1007"/>
       <unit id="org.apache.felix.gogo.shell.source" version="1.1.4.v20210111-1007"/>
-      <unit id="org.apache.felix.scr" version="2.1.24.v20200924-1939"/>
-      <unit id="org.apache.felix.scr.source" version="2.1.24.v20200924-1939"/>
 
       <unit id="org.junit" version="4.13.2.v20211018-1956"/>
       <unit id="org.junit.source" version="4.13.2.v20211018-1956"/>
@@ -501,6 +497,22 @@
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
           <version>2.13.2.2</version>
+          <type>jar</type>
+        </dependency>
+      </dependencies>
+    </location>
+	  <location includeDependencyDepth="none" includeSource="true" label="Apache Felix" missingManifest="error" type="Maven">
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>org.apache.felix.gogo.runtime</artifactId>
+          <version>1.1.6</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>org.apache.felix.scr</artifactId>
+          <version>2.2.2</version>
           <type>jar</type>
         </dependency>
       </dependencies>


### PR DESCRIPTION
Use the latest Jars from Maven-Central for the following Apache Felix bundles:
- org.apache.felix.scr
- org.apache.felix.gogo.runtime
- org.apache.felix.gogo.command
- org.apache.felix.gogo.shell

This updates the version of the first two. For completeness I also added the latter two, but I'm a bit concerned if that can cause problems due to different build qualifiers respectively I expect that the previous variants will not be updated if available (but that should actually not be a problem then).

This is not intended to be merged after the master for the next Eclipse release cycle has opened and not before the upcoming Apache-Felix release. 
Although the versions are not yet final, we can discuss the change itself already.