### PR TITLE
Do not publish apitools.ee.feature

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
@@ -13,7 +13,6 @@
    <feature id="org.eclipse.equinox.executable" version="0.0.0"/>
    <feature id="org.eclipse.sdk" version="0.0.0"/>
    <feature id="org.eclipse.e4.core.tools.feature.source" version="0.0.0"/>
-   <feature id="org.eclipse.pde.api.tools.ee.feature" version="0.0.0"/>
    <feature id="org.eclipse.pde.unittest.junit" version="0.0.0"/>
    <feature id="org.eclipse.pde.unittest.junit.source" version="0.0.0"/>
    <feature id="org.eclipse.tips.feature" version="0.0.0"/>

--- a/oomph/Platform.setup
+++ b/oomph/Platform.setup
@@ -68,8 +68,6 @@
         name="org.eclipse.jdt.feature.group"/>
     <requirement
         name="org.eclipse.pde.feature.group"/>
-    <requirement
-        name="org.eclipse.pde.api.tools.ee.feature.feature.group"/>
   </setupTask>
   <setupTask
       xsi:type="setup:VariableTask"


### PR DESCRIPTION
It contains only cdc/osgiminimum env which are useless nowadays.
Removes the feature from Oomph setup file too.
Part of https://github.com/eclipse-pde/eclipse.pde/issues/102