### PR TITLE
Change aggregator build to use merged equinox repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -53,12 +53,9 @@
 [submodule "rt.equinox.binaries"]
   path = rt.equinox.binaries
   url = https://github.com/eclipse-equinox/equinox.binaries.git
-[submodule "rt.equinox.bundles"]
-  path = rt.equinox.bundles
-  url = https://github.com/eclipse-equinox/equinox.bundles.git
-[submodule "rt.equinox.framework"]
-  path = rt.equinox.framework
-  url = https://github.com/eclipse-equinox/equinox.framework.git
+[submodule "equinox"]
+  path = equinox
+  url = https://github.com/eclipse-equinox/equinox.git
 [submodule "rt.equinox.p2"]
   path = rt.equinox.p2
   url = https://github.com/eclipse-equinox/p2.git

--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,7 @@
     <module>eclipse.platform.ua</module>
     <module>eclipse.platform.ui.tools</module>
 
-    <module>rt.equinox.bundles</module>
-    <module>rt.equinox.framework</module>
+    <module>equinox</module>
     <module>rt.equinox.p2</module>
 
     <module>eclipse.platform.releng</module>


### PR DESCRIPTION
Switches aggregator build to use the new merged equinox repository
instead of the old split ones.
See https://github.com/eclipse-equinox/equinox.bundles/issues/18