### PR TITLE
Revert "Switch aggregator I and Y builds to use Java 17"

### DIFF
--- a/JenkinsJobs/Builds/I-build.groovy
+++ b/JenkinsJobs/Builds/I-build.groovy
@@ -187,8 +187,8 @@ spec:
           steps {
               container('jnlp') {
 		      sshagent(['projects-storage.eclipse.org-bot-ssh']) {
-		          withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
-		              withAnt(installation: 'apache-ant-latest', jdk: 'openjdk-jdk17-latest') {
+		          withEnv(["JAVA_HOME=${ tool 'openjdk-jdk11-latest' }"]) {
+		              withAnt(installation: 'apache-ant-latest', jdk: 'openjdk-jdk11-latest') {
 		                sh '''
 		                    cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
 		                    ./mb020_createBaseBuilder.sh $CJE_ROOT/buildproperties.shsource 2>&1 | tee $logDir/mb020_createBaseBuilder.sh.log
@@ -263,7 +263,7 @@ spec:
 	  stage('Create Source Bundles'){
           steps {
               container('jnlp') {
-                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
+                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk11-latest' }"]) {
                     sh '''
                         cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
                         unset JAVA_TOOL_OPTIONS 
@@ -286,7 +286,7 @@ spec:
           }
           steps {
               container('jnlp') {
-                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
+                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk11-latest' }"]) {
                     sh '''
                         cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
                         unset JAVA_TOOL_OPTIONS 
@@ -309,8 +309,8 @@ spec:
           }
           steps {
               container('jnlp') {
-                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
-                      withAnt(installation: 'apache-ant-latest', jdk: 'openjdk-jdk17-latest') {
+                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk11-latest' }"]) {
+                      withAnt(installation: 'apache-ant-latest', jdk: 'openjdk-jdk11-latest') {
                           sh '''
                             cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
                             bash -x ./mb300_gatherEclipseParts.sh $CJE_ROOT/buildproperties.shsource 2>&1 | tee $logDir/mb300_gatherEclipseParts.sh.log
@@ -332,8 +332,8 @@ spec:
           }
           steps {
               container('jnlp') {
-                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
-                      withAnt(installation: 'apache-ant-latest', jdk: 'openjdk-jdk17-latest') {
+                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk11-latest' }"]) {
+                      withAnt(installation: 'apache-ant-latest', jdk: 'openjdk-jdk11-latest') {
                           sh '''
                             cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
                             ./mb310_gatherEquinoxParts.sh $CJE_ROOT/buildproperties.shsource 2>&1 | tee $logDir/mb310_gatherEquinoxParts.sh.log
@@ -351,7 +351,7 @@ spec:
 	  stage('Generate Repo reports'){
           steps {
               container('jnlp') {
-                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
+                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk11-latest' }"]) {
                       sh '''
                         cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
                         unset JAVA_TOOL_OPTIONS 
@@ -370,7 +370,7 @@ spec:
 	  stage('Generate API tools reports'){
           steps {
               container('jnlp') {
-                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
+                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk11-latest' }"]) {
                       sh '''
                         cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
                         unset JAVA_TOOL_OPTIONS 

--- a/JenkinsJobs/Builds/Y-build.groovy
+++ b/JenkinsJobs/Builds/Y-build.groovy
@@ -188,8 +188,8 @@ spec:
           steps {
               container('jnlp') {
 			      sshagent(['projects-storage.eclipse.org-bot-ssh']) {
-			          withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
-			              withAnt(installation: 'apache-ant-latest', jdk: 'openjdk-jdk17-latest') {
+			          withEnv(["JAVA_HOME=${ tool 'openjdk-jdk11-latest' }"]) {
+			              withAnt(installation: 'apache-ant-latest', jdk: 'openjdk-jdk11-latest') {
 			                sh '''
 			                    cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
 			                    ./mb020_createBaseBuilder.sh $CJE_ROOT/buildproperties.shsource 2>&1 | tee $logDir/mb020_createBaseBuilder.sh.log
@@ -278,7 +278,7 @@ spec:
 	  stage('Create Source Bundles'){
           steps {
               container('jnlp') {
-                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
+                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk11-latest' }"]) {
                     sh '''
                         cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
                         unset JAVA_TOOL_OPTIONS 
@@ -300,7 +300,7 @@ spec:
           }
           steps {
               container('jnlp') {
-                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
+                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk11-latest' }"]) {
                     sh '''
                         cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
                         unset JAVA_TOOL_OPTIONS 
@@ -323,8 +323,8 @@ spec:
           }
           steps {
               container('jnlp') {
-                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
-                      withAnt(installation: 'apache-ant-latest', jdk: 'openjdk-jdk17-latest') {
+                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk11-latest' }"]) {
+                      withAnt(installation: 'apache-ant-latest', jdk: 'openjdk-jdk11-latest') {
                           sh '''
                             cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
                             bash -x ./mb300_gatherEclipseParts.sh $CJE_ROOT/buildproperties.shsource 2>&1 | tee $logDir/mb300_gatherEclipseParts.sh.log
@@ -346,8 +346,8 @@ spec:
           }
           steps {
               container('jnlp') {
-                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
-                      withAnt(installation: 'apache-ant-latest', jdk: 'openjdk-jdk17-latest') {
+                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk11-latest' }"]) {
+                      withAnt(installation: 'apache-ant-latest', jdk: 'openjdk-jdk11-latest') {
                           sh '''
                             cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
                             ./mb310_gatherEquinoxParts.sh $CJE_ROOT/buildproperties.shsource 2>&1 | tee $logDir/mb310_gatherEquinoxParts.sh.log
@@ -365,7 +365,7 @@ spec:
 	  stage('Generate Repo reports'){
           steps {
               container('jnlp') {
-                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
+                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk11-latest' }"]) {
                       sh '''
                         cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
                         unset JAVA_TOOL_OPTIONS 
@@ -384,7 +384,7 @@ spec:
 	  stage('Generate API tools reports'){
           steps {
               container('jnlp') {
-                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
+                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk11-latest' }"]) {
                       sh '''
                         cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
                         unset JAVA_TOOL_OPTIONS 


### PR DESCRIPTION
Reverts eclipse-platform/eclipse.platform.releng.aggregator#331

It exposed the following jdt.core bugs:
* https://github.com/eclipse-jdt/eclipse.jdt.core/issues/147
* https://github.com/eclipse-jdt/eclipse.jdt.core/issues/114