### PR TITLE
Add the bundle and bnd annotations to the target platform

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -354,7 +354,19 @@
     -->
 
     <location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" label="OSGi" missingManifest="error" type="Maven">
-      <dependencies>
+        <dependencies>
+		  <dependency>
+		  <groupId>biz.aQute.bnd</groupId>
+		  <artifactId>annotation</artifactId>
+		  <version>2.4.0</version>
+		  <type>jar</type>
+        </dependency>
+        <dependency>
+		  <groupId>org.osgi</groupId>
+		  <artifactId>org.osgi.annotation.bundle</artifactId>
+		  <version>2.0.0</version>
+		  <type>jar</type>
+        </dependency>
         <dependency>
           <groupId>org.osgi</groupId>
           <artifactId>org.osgi.service.cm</artifactId>


### PR DESCRIPTION
Recently there [was a demand to use the bnd annotations](https://github.com/eclipse-equinox/equinox/issues/27) and there is a [open PDE issue to support the bundle annotations](https://github.com/eclipse-pde/eclipse.pde/issues/69), for both use cases we would need the bnd/osgi annotation available at the targetplatform.