### PR TITLE
Skip API-analysis automatically on absent api.tools.apiAnalysisNature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ setup.sh
 workspace/
 .metadata/
 RemoteSystemsTempFiles/
+/apiAnalyzer-workspace/

--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -751,15 +751,12 @@
                 <configuration>
                   <exportAntProperties>true</exportAntProperties>
                   <target>
-                    <loadfile srcfile=".project" property="natureIn.project" failonerror="false">
-                      <filterchain>
-                        <linecontains>
-                          <contains value="org.eclipse.pde.api.tools.apiAnalysisNature"/>
-                        </linecontains>
-                      </filterchain>
-                    </loadfile>
                     <condition property="skipAPIDescription" value="false" else="true">
-                        <isset property="natureIn.project" />
+                      <!-- If the property is already set this has no effect because properties are immutable in ANT -->
+                      <and>
+                        <available file="${basedir}/META-INF/MANIFEST.MF"/>
+                        <resourcecontains resource="${basedir}/.project" substring="org.eclipse.pde.api.tools.apiAnalysisNature" />
+                      </and>
                     </condition>
                   </target>
                 </configuration>
@@ -844,10 +841,12 @@
                 <configuration>
                   <exportAntProperties>true</exportAntProperties>
                   <target>
-                    <condition property="skipAPIAnalysis" value="true" else="false">
-                      <not>
+                    <condition property="skipAPIAnalysis" value="false" else="true">
+                      <!-- If the property is already set this has no effect because properties are immutable in ANT -->
+                      <and>
                         <available file="${basedir}/META-INF/MANIFEST.MF"/>
-                      </not>
+                        <resourcecontains resource="${basedir}/.project" substring="org.eclipse.pde.api.tools.apiAnalysisNature" />
+                      </and>
                     </condition>
                     <echo file="${project.build.directory}/${project.artifactId}-apiBaseline.target">
                       <![CDATA[


### PR DESCRIPTION
and also simplify this check for 'api-generation' profile.

For the check ANT's 'resourcecontains'-condition is used:
https://ant.apache.org/manual/Tasks/conditions.html#resourcecontains

This avoids most of the `<skipAPIAnalysis>true<skipAPIAnalysis>` properties in poms, because if an API-analysis is not wanted the API-analysis nature and builder can simply be removed from the .project file.
In most cases where `<skipAPIAnalysis>true<skipAPIAnalysis>` is specified the nature+builder are already absent any ways (e.g. for test-plugins) and that property is only specified to avoid problems during build.
Automatically detecting based on the presence of the nature ensures consistently enabled/disabled API-analysis during build and in the UI.
Even more important allows to remove the `skipAPIAnalysis`-property from most poms, actually all poms since the apiAnalysis-nature can simply be removed if API-analysis is not wanted, which makes many more poms trivial and allows to remove them in favor of Tycho-pomless.

@mickaelistria, @akurtakov what do you think?