### PR TITLE
Update to Jetty 10.0.11

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -243,43 +243,43 @@
         <dependency>
           <groupId>org.eclipse.jetty</groupId>
 	      <artifactId>jetty-http</artifactId>
-	      <version>10.0.9</version>
+	      <version>10.0.11</version>
           <type>jar</type>
         </dependency>
         <dependency>
           <groupId>org.eclipse.jetty</groupId>
 	      <artifactId>jetty-io</artifactId>
-	      <version>10.0.9</version>
+	      <version>10.0.11</version>
           <type>jar</type>
         </dependency>
         <dependency>
           <groupId>org.eclipse.jetty</groupId>
 	      <artifactId>jetty-security</artifactId>
-	      <version>10.0.9</version>
+	      <version>10.0.11</version>
           <type>jar</type>
         </dependency>
         <dependency>
           <groupId>org.eclipse.jetty</groupId>
 	      <artifactId>jetty-server</artifactId>
-	      <version>10.0.9</version>
+	      <version>10.0.11</version>
           <type>jar</type>
         </dependency>
         <dependency>
           <groupId>org.eclipse.jetty</groupId>
 	      <artifactId>jetty-servlet</artifactId>
-	      <version>10.0.9</version>
+	      <version>10.0.11</version>
           <type>jar</type>
         </dependency>
         <dependency>
           <groupId>org.eclipse.jetty</groupId>
 	      <artifactId>jetty-util</artifactId>
-	      <version>10.0.9</version>
+	      <version>10.0.11</version>
           <type>jar</type>
         </dependency>
         <dependency>
           <groupId>org.eclipse.jetty</groupId>
 	      <artifactId>jetty-util-ajax</artifactId>
-	      <version>10.0.9</version>
+	      <version>10.0.11</version>
           <type>jar</type>
         </dependency>
         <dependency>


### PR DESCRIPTION
Update target platform to contain Jetty 10.0.11.
Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/363