### PR TITLE
Revert "Re-add commons-io to target"

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -258,11 +258,6 @@
 					<artifactId>commons-lang</artifactId>
 					<version>2.6</version>
 				</dependency>
-				<dependency>
-					<groupId>commons-io</groupId>
-					<artifactId>commons-io</artifactId>
-					<version>2.11.0</version>
-				</dependency>
 		  </dependencies>
 	  </location>
 	  <location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" label="Jetty and servlet API" missingManifest="error" type="Maven">


### PR DESCRIPTION
Reverts eclipse-platform/eclipse.platform.releng.aggregator#392 as it causes an issue trying to use older apiguardian