### PR TITLE
Remove bouncycastle originating from Orbit

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -92,12 +92,6 @@
       <unit id="javax.inject.source" version="1.0.0.v20220405-0441"/>
       <unit id="javax.xml" version="1.4.1.v20220503-2331"/>
 
-      <!-- PGP - See bug 570907 -->
-      <!-- Upstream Maven artifact uses just bcpg and bcprov as Bundle-SymbolicName. Need to update
-        customers -->
-      <unit id="org.bouncycastle.bcpg" version="1.70.0.v20220507-1208"/>
-      <unit id="org.bouncycastle.bcprov" version="1.70.0.v20220507-1208"/>
-
       <!-- This is the "normal" Orbit repository. During development on Bug 568936 this repo is the EBR (git)
            sourced bundles of Orbit from 2022-03. This is the sub-p2-repo of the 2022-03 recommended build.
            This is the repo that is expected to be updated on milestones based on Orbit deliveries. -->


### PR DESCRIPTION
Stick only to Maven Central originating bundles