### PR TITLE
Update to ecj version 3.30.100.v20220717-1600

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -86,7 +86,7 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cbi-jdt-repo.url>https://repo.eclipse.org/content/repositories/eclipse-staging/</cbi-jdt-repo.url>
-    <cbi-ecj-version>3.30.100.v20220705-0752</cbi-ecj-version>
+    <cbi-ecj-version>3.30.100.v20220717-1600</cbi-ecj-version>
 
     <!--
       Production bundles are produced by ignoring the compiler warnings specified


### PR DESCRIPTION
Tracked in https://github.com/eclipse-jdt/eclipse.jdt.core/issues/241