### PR TITLE
Update Jetty version in R4_23_maintenance branch to 10.0.11

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/pom.xml
@@ -42,6 +42,13 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-p2-repository-plugin</artifactId>
+        <configuration>
+        	<includeAllDependencies>true</includeAllDependencies>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>
           <execution>
@@ -382,6 +389,7 @@
               </rootFolders>
             </product>
           </products>
+          <source>repository</source> <!-- To leverage PGP signatures added to repo -->
           <profileProperties>
             <pgp.trustedPublicKeys><![CDATA[----BEGIN PGP PUBLIC KEY BLOCK-----
 
@@ -497,14 +505,9 @@ UNmHBQdtflW5G1L5fQggWG7V
           <plugin>
             <groupId>org.eclipse.tycho</groupId>
             <artifactId>tycho-gpg-plugin</artifactId>
-            <version>${tycho.version}</version>
             <executions>
               <execution>
                 <goals><goal>sign-p2-artifacts</goal></goals>
-                <configuration>
-                  <keyname>b6d3ab9bcc641282</keyname>
-                  <skipIfJarsigned>true</skipIfJarsigned>
-                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
Updating repository pom.xml to use jetty from maven central
Tracked in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/396