### PR TITLE
Updated 4.25 release name to 2022-09

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -49,7 +49,7 @@
       such as Version: Mars (4.5), for main features.
       See bug 328139.
     -->
-    <releaseName>2022-06</releaseName>
+    <releaseName>2022-09</releaseName>
     <!--
       The releaseNumbers below, for SDK and Platform, might be
       thought of as the "marketing number" or "branding number",


### PR DESCRIPTION
That was missed during 4.25 version changes.

See comments on
https://github.com/eclipse-platform/eclipse.platform/issues/59