### PR TITLE
Generate API description for all Plug-in Projects

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -727,39 +727,11 @@
     <profile>
       <id>api-generation</id>
       <activation>
-        <!-- Does it have to be a profile if we can evaluate condition reliably in antrun? -->
+        <!-- Generate API for all Plug-in projects -->
         <file><exists>META-INF/MANIFEST.MF</exists></file>
-        <property>
-          <name>!longnotexistingproperty</name>
-        </property>
       </activation>
       <build>
         <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>check-has-apiTools-nature</id>
-                <phase>validate</phase>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-                <configuration>
-                  <exportAntProperties>true</exportAntProperties>
-                  <target>
-                    <condition property="skipAPIDescription" value="false" else="true">
-                      <!-- If the property is already set this has no effect because properties are immutable in ANT -->
-                      <and>
-                        <available file="${basedir}/META-INF/MANIFEST.MF"/>
-                        <resourcecontains resource="${basedir}/.project" substring="org.eclipse.pde.api.tools.apiAnalysisNature" />
-                      </and>
-                    </condition>
-                  </target>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
           <plugin>
             <groupId>org.eclipse.tycho.extras</groupId>
             <artifactId>tycho-eclipserun-plugin</artifactId>


### PR DESCRIPTION
As suggested in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/352#issuecomment-1159488042, this enables the API-generation for all Eclipse Plug-in projects, regardless of if they have the API-Builder nature.
This also enables API generation for incubating Plug-ins or Plug-ins that are just added and can therefore not have their API checked, but are intended to be checked after the next release.



@mickaelistria if you want this now we can merge this now (given the build succeeds), but I'm on vacation for the next two weeks and can therefore not assist if something has to be fixed. If you want to wait, I'm fine with that either.