### PR TITLE
Use more recent BND annotations and include versioning annotations

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -343,10 +343,15 @@
 	  </location>
 	  <location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" label="OSGi" missingManifest="error" type="Maven">
 		  <dependencies>
-			  <dependency>
+  			  <dependency>
 				  <groupId>biz.aQute.bnd</groupId>
-				  <artifactId>annotation</artifactId>
-				  <version>2.4.0</version>
+				  <artifactId>biz.aQute.bnd.annotation</artifactId>
+				  <version>6.3.1</version>
+  			  </dependency>
+  			  <dependency>
+				  <groupId>org.osgi</groupId>
+				  <artifactId>org.osgi.annotation.versioning</artifactId>
+				  <version>1.1.2</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>


### PR DESCRIPTION
There was on old version of BND annotations included and the version annotations are missing.