### PR TITLE
Revert "Remove bouncycastle originating from Orbit"

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -51,6 +51,13 @@
       <unit id="javax.inject.source" version="1.0.0.v20220405-0441"/>
       <unit id="javax.xml" version="1.4.1.v20220503-2331"/>
 
+      <!-- PGP - See bug 570907 -->
+      <!-- Currently sticking to Orbit as upstream is jarsigned by a not rooted cert -->
+      <!-- We may remove it and use upstream from Central when we can have PGP signture
+        used for trust despite the jarsignature -->
+      <unit id="org.bouncycastle.bcpg" version="1.71.0.v20220723-1943"/>
+      <unit id="org.bouncycastle.bcprov" version="1.71.0.v20220723-1943"/>
+
       <!-- This is the "normal" Orbit repository. During development on Bug 568936 this repo is the EBR (git)
            sourced bundles of Orbit from 2022-03. This is the sub-p2-repo of the 2022-03 recommended build.
            This is the repo that is expected to be updated on milestones based on Orbit deliveries. -->


### PR DESCRIPTION
This reverts commit 6d78dba714504b6ddb0a917f000a0afa7b6efa48.
BouncyCastle uses jarsigner and certificates that are not rooted in
cacerts, resulting in Trust dialog showing up.
Revert to Orbit variant until p2 can better handle this case.