### PR TITLE
Remove global_fp check from index templates.

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/staticDropFiles/testResults.php
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/staticDropFiles/testResults.php
@@ -121,8 +121,8 @@ if (file_exists("buildlogs/reporeports/index.html")) {
 ?>
 <?php
   echo "<li>\n";
-  $generated=file_exists("performance/global_fp.php");
-  if (file_exists("performance/performance.php") && $generated) {
+  //$generated=file_exists("performance/global_fp.php");
+  if (file_exists("performance/performance.php")) {
     echo "View the <a href=\"performance/performance.php\">performance test results</a> for the current build.\n";
   } else {
     echo "Performance tests are pending.\n";

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/templateFiles/index.template_java19.php
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/templateFiles/index.template_java19.php
@@ -219,8 +219,8 @@ else {
   }
 
   /* performance tests line item */
-  $generated=file_exists("performance/global_fp.php");
-  if (file_exists("performance/performance.php") && $generated) {
+  //$generated=file_exists("performance/global_fp.php");
+  if (file_exists("performance/performance.php")) {
     echo "<li>View the <a href=\"performance/performance.php\">performance test results</a> for the current build.</li>\n";
   } else {
     echo "<li>Performance tests are pending.</li>\n";

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/templateFiles/index.template_master.php
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/templateFiles/index.template_master.php
@@ -224,8 +224,8 @@ else {
   }
 
   /* performance tests line item */
-  $generated=file_exists("performance/global_fp.php");
-  if (file_exists("performance/performance.php") && $generated) {
+  //$generated=file_exists("performance/global_fp.php");
+  if (file_exists("performance/performance.php")) {
     echo "<li>View the <a href=\"performance/performance.php\">performance test results</a> for the current build.</li>\n";
   } else {
     echo "<li>Performance tests are pending.</li>\n";


### PR DESCRIPTION
Found another reference to global_fp.php. We aren't currently generating fingerprint files so we should only check for performance.php which actually exists. Hopefully this will make performance tests accessible.