### PR TITLE
Fix broken link in Performance Table

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/buildScripts/publish.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/buildScripts/publish.xml
@@ -106,7 +106,7 @@
     <!-- xml results directory -->
     <condition
       property="xmlDirectoryName"
-      value="${buildDirectory}/performance/xml">
+      value="${buildDirectory}/xml">
       <contains
         string="${job}"
         substring="-perf-" />


### PR DESCRIPTION
xml links in https://download.eclipse.org/eclipse/downloads/drops4/I20220802-1800/performance/performance.php are broken. 
The php file includes an html file that's one directory up from it. The html is written to work from that location and it used to work when pulled into the php file but for some reason now the paths need to work from the php files directory. This should fix it.