### PR TITLE
Releng JIPP fails builds due to using Java 8

### DIFF
--- a/JenkinsJobs/Builds/I-build.groovy
+++ b/JenkinsJobs/Builds/I-build.groovy
@@ -14,7 +14,7 @@ kind: Pod
 spec:
   containers:
   - name: "jnlp"
-    image: "eclipsecbi/jiro-agent-centos-8:latest"
+    image: "eclipsecbi/jiro-agent-centos-8-jdk11:latest"
     imagePullPolicy: "Always"
     resources:
       limits:


### PR DESCRIPTION
https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/1618

Use CentOS 8 docker image with JDK11