### PR TITLE
Update ICU4J to version 71.1

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -157,7 +157,7 @@
 			  <dependency>
 				  <groupId>com.ibm.icu</groupId>
 				  <artifactId>icu4j</artifactId>
-				  <version>67.1</version>
+				  <version>71.1</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>


### PR DESCRIPTION
This version updates CLDR to 41 and adds Unicode 14 support.