### PR TITLE
Update Google GSON to 2.9.1

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -151,7 +151,7 @@
 			  <dependency>
 				  <groupId>com.google.code.gson</groupId>
 				  <artifactId>gson</artifactId>
-				  <version>2.8.9</version>
+				  <version>2.9.1</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>


### PR DESCRIPTION
Version shipped was 2.8.9. Changelog available at
https://github.com/google/gson/blob/master/CHANGELOG.md