### PR TITLE
Ignore .gitignore for jgit-timestamp computation

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -480,6 +480,7 @@
             <jgit.ignore>
               pom.xml
               .polyglot.build.properties
+              .gitignore
             </jgit.ignore>
             <jgit.dirtyWorkingTree>${jgit.dirtyWorkingTree-platformDefault}</jgit.dirtyWorkingTree>
             <sourceReferences>


### PR DESCRIPTION
Changes/removal/additions in the .gitignore file should not lead to a change of the artifact. Therefore the build-timestamp should not be influenced by a change of that file.