### PR TITLE
Use Tycho-3.0's 'tycho.buildqualifier.format'-property instead of custom property

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -133,7 +133,7 @@
     -->
     <jgit.dirtyWorkingTree-platformDefault>ignore</jgit.dirtyWorkingTree-platformDefault>
 
-    <qualifier.format>'v'yyyyMMdd-HHmm</qualifier.format>
+    <tycho.buildqualifier.format>'v'yyyyMMdd-HHmm</tycho.buildqualifier.format>
 
     <compare-version-with-baselines.skip>true</compare-version-with-baselines.skip>
     <previous-release.baseline>https://download.eclipse.org/eclipse/updates/4.24/R-4.24-202206070700/</previous-release.baseline>
@@ -475,7 +475,6 @@
             </dependency>
           </dependencies>
           <configuration>
-            <format>${qualifier.format}</format>
             <timestampProvider>jgit</timestampProvider>
             <jgit.ignore>
               pom.xml
@@ -576,7 +575,7 @@
    <profile>
       <id>java19patch</id>
       <properties>
-        <qualifier.format>'v'yyyyMMdd-HHmm'_BETA_JAVA19'</qualifier.format>
+        <tycho.buildqualifier.format>'v'yyyyMMdd-HHmm'_BETA_JAVA19'</tycho.buildqualifier.format>
  
         <featureToPatch>org.eclipse.jdt</featureToPatch>
         <featureToPatchPDE>org.eclipse.pde</featureToPatchPDE>


### PR DESCRIPTION
Since Tycho 3.0 the 'tycho-packaging-plugin' provides the property 'tycho.buildqualifier.format' to specify its 'format' config property. 
Instead of configuring a custom property ('qualifier.format') with the same purpose, use Tycho's default property for that. Using more defaults if possible is IMHO a good thing.

When searching my platform-aggregator workspace I found no other references to `qualifier.format` than those adjusted in the platform-parent pom.

@akurtakov any objections?