### PR TITLE
Y-build move to java 11 based container

### DIFF
--- a/JenkinsJobs/Builds/Y-build.groovy
+++ b/JenkinsJobs/Builds/Y-build.groovy
@@ -14,7 +14,7 @@ kind: Pod
 spec:
   containers:
   - name: "jnlp"
-    image: "eclipsecbi/jiro-agent-centos-8:latest"
+    image: "eclipsecbi/jiro-agent-centos-8-jdk11:latest"
     imagePullPolicy: "Always"
     resources:
       limits:


### PR DESCRIPTION
tracked in https://github.com/eclipse-jdt/eclipse.jdt/issues/30