### PR TITLE
Remove exclusions of now fixed projects from Platform-Oomph-setup

### DIFF
--- a/oomph/Platform.setup
+++ b/oomph/Platform.setup
@@ -181,53 +181,7 @@
         <requirement
             name="*"/>
         <sourceLocator
-            rootFolder="${github.clone.platform.location}">
-          <predicate
-              xsi:type="predicates:AndPredicate">
-            <operand
-                xsi:type="predicates:NotPredicate">
-              <operand
-                  xsi:type="predicates:NamePredicate"
-                  pattern="org\.eclipse\.core\.tools-.*">
-                <annotation
-                    source="http://www.eclipse.org/oomph/base/Warning">
-                  <detail
-                      key="diagnostic">
-                    <value>This bundle appears to be very old and no longer supported.</value>
-                  </detail>
-                </annotation>
-              </operand>
-            </operand>
-            <operand
-                xsi:type="predicates:NotPredicate">
-              <operand
-                  xsi:type="predicates:NamePredicate"
-                  pattern="org\.eclipse\.core\.tools\.resources">
-                <annotation
-                    source="http://www.eclipse.org/oomph/base/Warning">
-                  <detail
-                      key="diagnostic">
-                    <value>This bundle appears to be very old and no longer supported.</value>
-                  </detail>
-                </annotation>
-              </operand>
-            </operand>
-            <operand
-                xsi:type="predicates:NotPredicate">
-              <operand
-                  xsi:type="predicates:NamePredicate"
-                  pattern="examples">
-                <annotation
-                    source="http://www.eclipse.org/oomph/base/Warning">
-                  <detail
-                      key="diagnostic">
-                    <value>This project is just a pom container and has errors because of the m2e nature</value>
-                  </detail>
-                </annotation>
-              </operand>
-            </operand>
-          </predicate>
-        </sourceLocator>
+            rootFolder="${github.clone.platform.location}"/>
       </targlet>
     </setupTask>
     <setupTask
@@ -952,10 +906,10 @@
         label="Master"/>
     <description>The Platform Releng Build Tools</description>
   </project>
-  <project href="https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.swt/master/bundles/org.eclipse.swt.tools/Oomph/platformSwt.setup#/"/>
-  <project href="https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.text/master/org.eclipse.text.releng/platformText.setup#/"/>
-  <project href="https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ua/master/org.eclipse.ua.releng/platformUa.setup#/"/>
-  <project href="https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/releng/org.eclipse.ui.releng/platformUi.setup#/"/>
+  <project href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='platform']/@projects[name='swt']"/>
+  <project href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='platform']/@projects[name='text']"/>
+  <project href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='platform']/@projects[name='ua']"/>
+  <project href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='platform']/@projects[name='ui']"/>
   <project name="ui.tools"
       label="UI Tools">
     <setupTask


### PR DESCRIPTION
With the following two PRs the exclusions in the targlat of the Platform-Oomph-setup can now be removed.
- https://github.com/eclipse-platform/eclipse.platform/pull/78
- https://github.com/eclipse-platform/eclipse.platform/pull/110