### PR TITLE
Revert relativation of project references

### DIFF
--- a/oomph/Platform.setup
+++ b/oomph/Platform.setup
@@ -906,10 +906,10 @@
         label="Master"/>
     <description>The Platform Releng Build Tools</description>
   </project>
-  <project href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='platform']/@projects[name='swt']"/>
-  <project href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='platform']/@projects[name='text']"/>
-  <project href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='platform']/@projects[name='ua']"/>
-  <project href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='platform']/@projects[name='ui']"/>
+  <project href="https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.swt/master/bundles/org.eclipse.swt.tools/Oomph/platformSwt.setup#/"/>
+  <project href="https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.text/master/org.eclipse.text.releng/platformText.setup#/"/>
+  <project href="https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ua/master/org.eclipse.ua.releng/platformUa.setup#/"/>
+  <project href="https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/releng/org.eclipse.ui.releng/platformUi.setup#/"/>
   <project name="ui.tools"
       label="UI Tools">
     <setupTask


### PR DESCRIPTION
This partially reverts the project reference relativization of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/474, which caused a `StackOverflowError`, as written in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/474#issuecomment-1214138487.

@merks I'm going to merge this right now. Maybe you want to have a look at this and debug it. Since the message was that there was an error while displaying an error, I suspect that this change was not correct.