### PR TITLE
Don't use old Orbit bundles that Jetty published to Maven 

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -60,10 +60,19 @@
       <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/S20220726152247/repository/"/>
     </location>
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
+
+      <unit id="com.sun.el" version="2.2.0.v201303151357"/>
+      <unit id="com.sun.el.source" version="2.2.0.v201303151357"/>
+
       <!-- Upstream artifact from Maven Central misses OSGi info, stick to Orbit variant -->
       <unit id="javax.el" version="2.2.0.v201303151357"/>
       <unit id="javax.el.source" version="2.2.0.v201303151357"/>
-    
+
+      <unit id="javax.servlet.jsp" version="2.2.0.v201112011158"/>
+      <unit id="javax.servlet.jsp.source" version="2.2.0.v201112011158"/>
+      <unit id="org.apache.jasper.glassfish" version="2.2.2.v201501141630"/>
+      <unit id="org.apache.jasper.glassfish.source" version="2.2.2.v201501141630"/>
+
       <unit id="org.w3c.css.sac" version="1.3.1.v200903091627"/>
       <unit id="org.w3c.css.sac.source" version="1.3.1.v200903091627"/>
       <unit id="org.w3c.dom.events" version="3.0.0.draft20060413_v201105210656"/>
@@ -243,18 +252,6 @@
 				<artifactId>javax.servlet.jsp-api</artifactId>
 				<version>2.3.3</version>
 			</dependency>
-			  <dependency>
-				  <groupId>org.eclipse.jetty.orbit</groupId>
-				  <artifactId>com.sun.el</artifactId>
-				  <version>2.2.0.v201303151357</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>org.eclipse.jetty.orbit</groupId>
-				  <artifactId>org.apache.jasper.glassfish</artifactId>
-				  <version>2.2.2.v201112011158</version>
-				  <type>jar</type>
-			  </dependency>
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>
 				  <artifactId>jetty-http</artifactId>


### PR DESCRIPTION
These are published under groupdId org.eclipse.jetty.orbit and have jar signatures that use very old certificates that are no longer rooted in a modern Java's cacerts while Orbit provides versions with newer signatures. This applies specifically for com.sun.el and
org.apache.jasper.glassfish.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/438