### PR TITLE
[Platform-Setup] temporarily add 'o.e.pde.ds.lib' to Platform-TP

### DIFF
--- a/oomph/Platform.setup
+++ b/oomph/Platform.setup
@@ -138,12 +138,16 @@
           name="org.eclipse.pde.feature.group"/>
       <requirement
           name="org.eclipse.equinox.executable.feature.group"/>
+      <requirement
+          name="org.eclipse.pde.ds.lib"/>
       <repositoryList
           name="CBI+Orbit">
         <repository
             url="https://download.eclipse.org/cbi/updates/license"/>
         <repository
             url="https://download.eclipse.org/tools/orbit/downloads/latest-R"/>
+        <repository
+            url="${eclipse.4.24.release.p2}"/>
       </repositoryList>
     </targlet>
   </setupTask>


### PR DESCRIPTION
Because the 'o.e.pde.ds.lib' bundle has been removed from PDE and to be replaced by the official OSGi `o.o.service.component.annotations` bundles from Maven-Central https://github.com/eclipse-pde/eclipse.pde/pull/276 but the change that PDE-DS understands the new bundle-symbolic names https://github.com/eclipse-pde/eclipse.pde/pull/269/ is only available as I-build, this temporarily adds `o.e.pde.ds.lib` to the Platform-TP in order to keep DS-annotation processing working until https://github.com/eclipse-pde/eclipse.pde/pull/269/ is available in a release.

After the next (milestone?) release this could then be removed.

@laeubi, @merks any objections?