### PR TITLE
Accommodate the merge of resources into platform

### DIFF
--- a/oomph/PlatformSDKConfiguration.setup
+++ b/oomph/PlatformSDKConfiguration.setup
@@ -212,8 +212,6 @@
     <stream
         href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='platform']/@projects[name='news']/@streams[name='master']"/>
     <stream
-        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='platform']/@projects[name='resources']/@streams[name='master']"/>
-    <stream
         href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='platform']/@projects[name='swt']/@streams[name='master']"/>
     <stream
         href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='platform']/@projects[name='swt']/@projects[name='website']/@streams[name='master']"/>


### PR DESCRIPTION
The Platform-Resources repository was merged into Eclipse-Platform via:
https://github.com/eclipse-platform/eclipse.platform/pull/76

