### PR TITLE
Do not add transitive Maven deps to .target

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -155,7 +155,7 @@
     -->
 
     <!-- Maven versions of asm; Orbit versions of asm are specified above. -->
-	  <location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" missingManifest="error" type="Maven">
+	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="error" type="Maven">
 		  <dependencies>
 			  <dependency>
 				  <groupId>com.google.code.gson</groupId>
@@ -206,6 +206,12 @@
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
+				  <groupId>org.ow2.sat4j</groupId>
+				  <artifactId>org.ow2.sat4j.core</artifactId>
+				  <version>2.3.6</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
 				  <groupId>org.tukaani</groupId>
 				  <artifactId>xz</artifactId>
 				  <version>1.9</version>
@@ -239,7 +245,7 @@
 				</dependency>
 		  </dependencies>
 	  </location>
-	  <location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" label="Jetty and servlet API" missingManifest="error" type="Maven">
+	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="Jetty and servlet API" missingManifest="error" type="Maven">
 		  <dependencies>
 			  <dependency>
 				  <groupId>jakarta.servlet</groupId>
@@ -296,7 +302,7 @@
 			  </dependency>
 		  </dependencies>
 	  </location>
-	  <location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" label="Test dependencies" missingManifest="error" type="Maven">
+	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="Test dependencies" missingManifest="error" type="Maven">
 		  <dependencies>
 			  <dependency>
 				  <groupId>net.bytebuddy</groupId>
@@ -330,7 +336,7 @@
 			  </dependency>
 		  </dependencies>
 	  </location>
-	  <location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" label="ASM" missingManifest="error" type="Maven">
+	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="ASM" missingManifest="error" type="Maven">
 		  <dependencies>
 			  <dependency>
 				  <groupId>org.ow2.asm</groupId>
@@ -344,9 +350,21 @@
 				  <version>9.3</version>
 				  <type>jar</type>
 			  </dependency>
+			  <dependency>
+				  <groupId>org.ow2.asm</groupId>
+				  <artifactId>asm</artifactId>
+				  <version>9.3</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>org.ow2.asm</groupId>
+				  <artifactId>asm-tree</artifactId>
+				  <version>9.3</version>
+				  <type>jar</type>
+			  </dependency>
 		  </dependencies>
 	  </location>
-	  <location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" label="OSGi" missingManifest="error" type="Maven">
+	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="OSGi" missingManifest="error" type="Maven">
 		  <dependencies>
   			  <dependency>
 				  <groupId>biz.aQute.bnd</groupId>
@@ -493,7 +511,7 @@
 			  </dependency>
 		  </dependencies>
 	  </location>
-	  <location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" label="Reddeer Deps" missingManifest="error" type="Maven">
+	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="Reddeer Deps" missingManifest="error" type="Maven">
 		  <dependencies>
 			  <dependency>
 				  <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
This allows a finer control of the dependencies, and also avoid
duplicated artifacts in different versions.
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/489