### PR TITLE
Update jna version to 5.12.1

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -178,13 +178,13 @@
 			  <dependency>
 				  <groupId>net.java.dev.jna</groupId>
 				  <artifactId>jna-platform</artifactId>
-				  <version>5.8.0</version>
+				  <version>5.12.1</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
 				  <groupId>net.java.dev.jna</groupId>
 				  <artifactId>jna</artifactId>
-				  <version>5.8.0</version>
+				  <version>5.12.1</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>


### PR DESCRIPTION
- Finalizers are removed from java 18 and this latest version adapts this change