### PR TITLE
Revert "Updating comparator repo and eclipse run repo to 4.26-I-builds.  "

### DIFF
--- a/cje-production/Y-build/buildproperties.txt
+++ b/cje-production/Y-build/buildproperties.txt
@@ -57,7 +57,7 @@ PREVIOUS_RELEASE_ID="S-4.25RC2-202208311800"
 BUILDTOOLS_REPO="https://download.eclipse.org/eclipse/updates/buildtools/"
 WEBTOOLS_REPO="https://download.eclipse.org/webtools/downloads/drops/R3.22.0/R-3.22.0-20210612170523/repositoryunittests/"
 BASEBUILDER_DIR="tmp/org.eclipse.releng.basebuilder"
-ECLIPSE_RUN_REPO="https://download.eclipse.org/eclipse/updates/4.26-I-builds/"
+ECLIPSE_RUN_REPO="https://download.eclipse.org/eclipse/updates/4.25-I-builds/"
 
 #Maven parameters
 MAVEN_OPTS="-Xmx6G"

--- a/cje-production/buildproperties.txt
+++ b/cje-production/buildproperties.txt
@@ -57,7 +57,7 @@ PREVIOUS_RELEASE_ID="S-4.25RC2-202208311800"
 BUILDTOOLS_REPO="https://download.eclipse.org/eclipse/updates/buildtools/"
 WEBTOOLS_REPO="https://download.eclipse.org/webtools/downloads/drops/R3.22.0/R-3.22.0-20210612170523/repositoryunittests/"
 BASEBUILDER_DIR="tmp/org.eclipse.releng.basebuilder"
-ECLIPSE_RUN_REPO="https://download.eclipse.org/eclipse/updates/4.26-I-builds/"
+ECLIPSE_RUN_REPO="https://download.eclipse.org/eclipse/updates/4.25-I-builds/"
 
 #Maven parameters
 MAVEN_OPTS="-Xmx6G"

--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -77,9 +77,9 @@
       'eclipiserun-repo' repository, such as for computing .api-descriptions and
       generating API Tools reports.
     -->
-    <eclipserun-repo>https://download.eclipse.org/eclipse/updates/4.26-I-builds/</eclipserun-repo>
+    <eclipserun-repo>https://download.eclipse.org/eclipse/updates/4.25-I-builds/</eclipserun-repo>
     
-    <comparator.repo>https://download.eclipse.org/eclipse/updates/4.26-I-builds</comparator.repo>
+    <comparator.repo>https://download.eclipse.org/eclipse/updates/4.25-I-builds</comparator.repo>
 
     <!-- only used when Tycho snapshot repo is enabled in <pluginRepositories> further down -->
     <tycho-snapshot-repo.url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</tycho-snapshot-repo.url>
@@ -622,7 +622,7 @@
           For maintenance streams should always be "M-builds".
           Ideally, this value would be provided by the environment, see bug 489789.
         -->
-        <eclipse-p2-repo.url>https://download.eclipse.org/eclipse/updates/4.26-I-builds</eclipse-p2-repo.url>
+        <eclipse-p2-repo.url>https://download.eclipse.org/eclipse/updates/4.25-I-builds</eclipse-p2-repo.url>
       </properties>
       <repositories>
         <repository>


### PR DESCRIPTION
Reverts eclipse-platform/eclipse.platform.releng.aggregator#534 as there is nothing in the repo published until we get good build.