### PR TITLE
Revert "Revert "Update ICU4J to version 71.1""

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -166,7 +166,7 @@
 			  <dependency>
 				  <groupId>com.ibm.icu</groupId>
 				  <artifactId>icu4j</artifactId>
-				  <version>67.1</version>
+				  <version>71.1</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>


### PR DESCRIPTION
Reverts eclipse-platform/eclipse.platform.releng.aggregator#477 as it was reverted so it can land early in 4.26 stream.