### PR TITLE
Ignore build.properties and fail on baseline payload differences

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,8 @@ pipeline {
 						.*log,*/target/work/data/.metadata/.*log,\
 						*/tests/target/work/data/.metadata/.*log,\
 						apiAnalyzer-workspace/.metadata/.*log,\
-						eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/target/repository/*'
+						eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/target/repository/*,\
+						**/target/artifactcomparison/*'
 				}
 			}
 		}

--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -482,6 +482,7 @@
             <timestampProvider>jgit</timestampProvider>
             <jgit.ignore>
               pom.xml
+              build.properties
               .polyglot.build.properties
               .gitignore
             </jgit.ignore>
@@ -541,6 +542,7 @@
           <configuration>
             <baselineMode>warn</baselineMode>
             <baselineReplace>all</baselineReplace>
+            <writeComparatorDelta>true</writeComparatorDelta>
             <baselineRepositories>
               <repository>
                 <url>${comparator.repo}</url>
@@ -692,6 +694,7 @@
             </executions>
             <configuration>
               <defaultP2Metadata>false</defaultP2Metadata>
+              <baselineMode>failCommon</baselineMode>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
As suggested in https://github.com/eclipse-equinox/p2/pull/113#issuecomment-1240392193, this ignores build.properties file when computing git-timestamps but in turn fails the build if the baseline and reactor contain artifacts with same qualifier but different content.

One drawback of the initial suggestion is that when building on Windows all text-files are detected as different due to the default line-endings difference between Windows and Linux.
So eventually the `baselineMode = failCommon` should either be wrapped in a profile (activated only on non-windows?) or could be set via the System-property `tycho.baseline`. But the latter would require to adjust many build files, so I think the former is more handy. The profile could be activated when the `CI` property exists, which is created by GH and Jenkins by default to indicate the CI environment.