### PR TITLE
Revert "Moving to daily ecj snapshot"

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -85,8 +85,8 @@
     <tycho-snapshot-repo.url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</tycho-snapshot-repo.url>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cbi-jdt-repo.url>https://repo.eclipse.org/content/repositories/eclipse-snapshots/</cbi-jdt-repo.url>
-    <cbi-ecj-version>3.31.0-SNAPSHOT</cbi-ecj-version>
+    <cbi-jdt-repo.url>https://repo.eclipse.org/content/repositories/eclipse-staging/</cbi-jdt-repo.url>
+    <cbi-ecj-version>3.31.0.v20220831-1439</cbi-ecj-version>
 
     <!--
       Production bundles are produced by ignoring the compiler warnings specified


### PR DESCRIPTION
Reverts eclipse-platform/eclipse.platform.releng.aggregator#581

Reverting this one as this is causing PR validation to fail