### PR TITLE
Add support for Windows on Arm64 (WoA) build

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -270,6 +270,11 @@
             <environment>
               <os>win32</os>
               <ws>win32</ws>
+              <arch>aarch64</arch>
+            </environment>
+            <environment>
+              <os>win32</os>
+              <ws>win32</ws>
               <arch>x86_64</arch>
             </environment>
             <environment>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/testManifest.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/testManifest.xml
@@ -10,6 +10,10 @@
 
     <zipType name="Eclipse SDK">
       <platform
+        id="SWAARCH64"
+        name="Windows (ARM 64 bit version)"
+        fileName="eclipse-SDK-${BUILD_ID}-win32-aarch64.zip"></platform>
+      <platform
         id="SWX8664"
         name="Windows (64 bit version)"
         fileName="eclipse-SDK-${BUILD_ID}-win32-x86_64.zip"></platform>
@@ -59,6 +63,10 @@
 
     <zipType name="Platform Runtime Binary">
       <platform
+        id="PWAARCH64"
+        name="Windows (ARM 64 bit version)"
+        fileName="eclipse-platform-${BUILD_ID}-win32-aarch64.zip"></platform>
+      <platform
         id="PWX8664"
         name="Windows (64 bit version)"
         fileName="eclipse-platform-${BUILD_ID}-win32-x86_64.zip"></platform>
@@ -100,6 +108,10 @@
     </zipType>
 
     <zipType name="SWT">
+      <platform
+        id="SWTWAARCH64"
+        name="Windows (ARM 64 bit version)"
+        fileName="swt-${BUILD_ID}-win32-win32-aarch64.zip"></platform>
       <platform
         id="SWTWX86_64"
         name="Windows (64 bit version)"

--- a/eclipse.platform.releng.tychoeclipsebuilder/equinox/buildConfigs/equinox-launchers/build.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/equinox/buildConfigs/equinox-launchers/build.xml
@@ -13,6 +13,7 @@
 
   <target name="equinoxlaunchers">
     <property name="archiveRoot" value="launchers" />
+    <buildRepos os="win32" ws="win32" arch="aarch64" archiveName="${archiveRoot}-win32.win32.aarch64.${buildId}.zip" />
     <buildRepos os="win32" ws="win32" arch="x86_64" archiveName="${archiveRoot}-win32.win32.x86_64.${buildId}.zip" />
     <buildRepos os="linux" ws="gtk" arch="x86_64" archiveName="${archiveRoot}-linux.gtk.x86_64.${buildId}.tar.gz" />
     <buildRepos os="linux" ws="gtk" arch="ppc64le" archiveName="${archiveRoot}-linux.gtk.ppc64le.${buildId}.tar.gz" />

--- a/eclipse.platform.releng.tychoeclipsebuilder/equinox/publishingFiles/testManifest.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/equinox/publishingFiles/testManifest.xml
@@ -238,6 +238,11 @@
     <zipType name="Launchers">
       <platform
         format="equinox"
+        id="SWAARCH64"
+        name="Windows (AARCH64)"
+        fileName="launchers-win32.win32.aarch64.${BUILD_ID}.zip" />
+      <platform
+        format="equinox"
         id="SW64"
         name="Windows (x86_64)"
         fileName="launchers-win32.win32.x86_64.${BUILD_ID}.zip" />

--- a/eclipse.platform.releng.tychoeclipsebuilder/rcp.config/build.properties
+++ b/eclipse.platform.releng.tychoeclipsebuilder/rcp.config/build.properties
@@ -15,6 +15,9 @@
 #root.permissions.755=eclipse
 root.win32.win32.x86_64=../../rt.equinox.binaries/org.eclipse.equinox.executable/bin/win32/win32/x86_64
 root.win32.win32.x86_64.permissions.755=eclipse.exe
+
+root.win32.win32.aarch64=../../rt.equinox.binaries/org.eclipse.equinox.executable/bin/win32/win32/aarch64
+root.win32.win32.aarch64.permissions.755=eclipse.exe
  
 # Care is need there, for "macosx", as several forms will appear to work, but end up
 # having wrong value in the CFBundleIdentifier field, in the Info.plist, resulting 


### PR DESCRIPTION
The environment triplet for WoA build is: win32/win32/aarch64