### PR TITLE
Revert "Remove bcprov from Maven Central from target platform"

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -48,8 +48,9 @@
       <unit id="javax.xml" version="1.4.1.v20220503-2331"/>
 
       <!-- PGP - See bug 570907 -->
-      <!-- Currently sticking to Orbit as we cannot consume bcprov direct from Maven because of IP
-           issues, see https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/3008#note_1020135 -->
+      <!-- Currently sticking to Orbit as upstream is jarsigned by a not rooted cert -->
+      <!-- We may remove it and use upstream from Central when we can have PGP signture
+        used for trust despite the jarsignature -->
       <unit id="org.bouncycastle.bcpg" version="1.71.0.v20220723-1943"/>
       <unit id="org.bouncycastle.bcprov" version="1.71.0.v20220723-1943"/>
 
@@ -226,6 +227,16 @@
 					<groupId>commons-lang</groupId>
 					<artifactId>commons-lang</artifactId>
 					<version>2.6</version>
+				</dependency>
+				<dependency>
+					<groupId>org.bouncycastle</groupId>
+					<artifactId>bcpg-jdk18on</artifactId>
+					<version>1.71</version>
+				</dependency>
+				<dependency>
+					<groupId>org.bouncycastle</groupId>
+					<artifactId>bcprov-jdk18on</artifactId>
+					<version>1.71</version>
 				</dependency>
 				<dependency>
 					<groupId>commons-io</groupId>


### PR DESCRIPTION
bcprov is now IP-cleared from MAven Central!
This reverts commit f503ae14579b9d418829b93abf5752453c380ab3.