### PR TITLE
Add two new properties for modules to control pom descriptor

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -134,7 +134,11 @@
     <jgit.dirtyWorkingTree-platformDefault>ignore</jgit.dirtyWorkingTree-platformDefault>
 
     <tycho.buildqualifier.format>'v'yyyyMMdd-HHmm</tycho.buildqualifier.format>
-
+    <!-- allows submodules to enable the inclusion of the pom descriptor in the final artifact -->
+    <tycho.addMavenDescriptor>false</tycho.addMavenDescriptor>
+    <!-- allows submodules to enable the mapping of p2 artifacts to maven artifacts -->
+    <tycho.mapP2Dependencies>false</tycho.mapP2Dependencies>
+    
     <compare-version-with-baselines.skip>true</compare-version-with-baselines.skip>
     <previous-release.baseline>https://download.eclipse.org/eclipse/updates/4.25/R-4.25-202208311800/</previous-release.baseline>
 
@@ -486,8 +490,9 @@
               <generate>true</generate>
             </sourceReferences>
             <archive>
-              <addMavenDescriptor>false</addMavenDescriptor>
+              <addMavenDescriptor>${tycho.addMavenDescriptor}</addMavenDescriptor>
             </archive>
+            <mapP2Dependencies>${tycho.mapP2Dependencies}</mapP2Dependencies>
             <additionalFileSets combine.children="append">
               <fileSet>
                 <directory>${project.build.directory}</directory>


### PR DESCRIPTION
@akurtakov WDYT? I'd like to use that in P2 as an incubator and it seems better to be configured in the parent so it can be enabled by a simple property than to be override the whole execution in the child modules.