### PR TITLE
Add a profile to generate and attach javadoc artifacts

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -1151,6 +1151,50 @@
         <surefire.moduleProperties>--add-modules=ALL-SYSTEM</surefire.moduleProperties>
       </properties>
     </profile>
+	<profile>
+		<id>javadoc</id>
+		<build>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<!-- Must use older version see https://issues.apache.org/jira/projects/MJAVADOC/issues/MJAVADOC-707 -->
+					<artifactId>maven-javadoc-plugin</artifactId>
+					<version>3.0.1</version>
+					<executions>
+						<execution>
+							<id>attach-javadocs</id>
+							<phase>package</phase>
+							<goals>
+								<goal>jar</goal>
+							</goals>
+						</execution>
+					</executions>
+					<configuration>
+						<source>${java.version}</source>
+						<failOnError>false</failOnError>
+						<!-- These are provided by PDE/Tycho by default but javadoc do not know that ... -->
+						<additionalDependencies>
+							<additionalDependency>
+								<groupId>org.osgi</groupId>
+								<artifactId>org.osgi.annotation.bundle</artifactId>
+								<version>2.0.0</version>
+							</additionalDependency>
+							<additionalDependency>
+								<groupId>org.osgi</groupId>
+								<artifactId>org.osgi.annotation.versioning</artifactId>
+								<version>1.1.2</version>
+							</additionalDependency>
+							<additionalDependency>
+								<groupId>org.osgi</groupId>
+								<artifactId>org.osgi.service.component.annotations</artifactId>
+								<version>1.5.0</version>
+							</additionalDependency>
+						</additionalDependencies>
+					</configuration>
+				</plugin>
+			</plugins>
+		</build>
+	</profile>
   </profiles>
   <scm>
     <connection>scm:git:https://github.com/eclipse-platform/eclipse.platform.releng.aggregator.git</connection>


### PR DESCRIPTION
When deploying artifacts to maven it is common to provide also javadoc artifacts. This adds a profile that could be used in sub-projects to accomplish this.

I was able to use this for equinox to generate javadoc artifacts, but though it might be more appropriate to have this in the master so other projects might easily reuse that as well. This also will allow us to catch javadoc errors earlier than with the current "doc-build".