### PR TITLE
Update runTests2.xml so jobs can be run from a folder

### DIFF
--- a/JenkinsJobs/AutomatedTests/ep425Y_unit_cen64_gtk3_java11.groovy
+++ b/JenkinsJobs/AutomatedTests/ep425Y_unit_cen64_gtk3_java11.groovy
@@ -149,7 +149,7 @@ spec:
                   junit keepLongStdio: true, testResults: '**/eclipse-testing/results/xml/*.xml'
               }
               archiveArtifacts '**/eclipse-testing/results/**, **/eclipse-testing/directorLogs/**, *.properties, *.txt'
-              build job: 'ep-collectYbuildResults', parameters: [string(name: 'triggeringJob', value: "${JOB_NAME}"), string(name: 'triggeringBuildNumber', value: "${BUILD_NUMBER}"), string(name: 'buildId', value: "${params.buildId}")], wait: false
+              build job: 'Releng/ep-collectYbuildResults', parameters: [string(name: 'triggeringJob', value: "${JOB_NAME}"), string(name: 'triggeringBuildNumber', value: "${BUILD_NUMBER}"), string(name: 'buildId', value: "${params.buildId}")], wait: false
           }
       }
   }

--- a/JenkinsJobs/AutomatedTests/ep425Y_unit_cen64_gtk3_java17.groovy
+++ b/JenkinsJobs/AutomatedTests/ep425Y_unit_cen64_gtk3_java17.groovy
@@ -148,7 +148,7 @@ spec:
               }
               archiveArtifacts '**/eclipse-testing/results/**, **/eclipse-testing/directorLogs/**, *.properties, *.txt'
               junit keepLongStdio: true, testResults: '**/eclipse-testing/results/xml/*.xml'
-              build job: 'ep-collectYbuildResults', parameters: [string(name: 'triggeringJob', value: "${JOB_NAME}"), string(name: 'triggeringBuildNumber', value: "${BUILD_NUMBER}"), string(name: 'buildId', value: "${params.buildId}")], wait: false
+              build job: 'Releng/ep-collectYbuildResults', parameters: [string(name: 'triggeringJob', value: "${JOB_NAME}"), string(name: 'triggeringBuildNumber', value: "${BUILD_NUMBER}"), string(name: 'buildId', value: "${params.buildId}")], wait: false
           }
       }
   }

--- a/JenkinsJobs/AutomatedTests/ep425Y_unit_cen64_gtk3_java19.groovy
+++ b/JenkinsJobs/AutomatedTests/ep425Y_unit_cen64_gtk3_java19.groovy
@@ -148,7 +148,7 @@ spec:
               }
               archiveArtifacts '**/eclipse-testing/results/**, **/eclipse-testing/directorLogs/**, *.properties, *.txt'
               junit keepLongStdio: true, testResults: '**/eclipse-testing/results/xml/*.xml'
-              build job: 'ep-collectYbuildResults', parameters: [string(name: 'triggeringJob', value: "${JOB_NAME}"), string(name: 'triggeringBuildNumber', value: "${BUILD_NUMBER}"), string(name: 'buildId', value: "${params.buildId}")], wait: false
+              build job: 'Releng/ep-collectYbuildResults', parameters: [string(name: 'triggeringJob', value: "${JOB_NAME}"), string(name: 'triggeringBuildNumber', value: "${BUILD_NUMBER}"), string(name: 'buildId', value: "${params.buildId}")], wait: false
           }
       }
   }

--- a/JenkinsJobs/AutomatedTests/ep425Y_unit_mac64_java17.groovy
+++ b/JenkinsJobs/AutomatedTests/ep425Y_unit_mac64_java17.groovy
@@ -140,7 +140,7 @@ echo -e "\\n\\tTotal elapsed time: ${TOTAL_TIME} \\n"
       recipientList("sravankumarl@in.ibm.com")
     }
     downstreamParameterized {
-      trigger('ep-collectYbuildResults') {
+      trigger('Releng/ep-collectYbuildResults') {
         condition('UNSTABLE_OR_BETTER')
         parameters {
           predefinedProp('triggeringJob', '$JOB_NAME')

--- a/JenkinsJobs/AutomatedTests/ep425Y_unit_macM1_java17.groovy
+++ b/JenkinsJobs/AutomatedTests/ep425Y_unit_macM1_java17.groovy
@@ -140,7 +140,7 @@ echo -e "\\n\\tTotal elapsed time: ${TOTAL_TIME} \\n"
       recipientList("sravankumarl@in.ibm.com")
     }
     downstreamParameterized {
-      trigger('ep-collectYbuildResults') {
+      trigger('Releng/ep-collectYbuildResults') {
         condition('UNSTABLE_OR_BETTER')
         parameters {
           predefinedProp('triggeringJob', '$JOB_NAME')

--- a/JenkinsJobs/AutomatedTests/ep425Y_unit_win32_java11.groovy
+++ b/JenkinsJobs/AutomatedTests/ep425Y_unit_win32_java11.groovy
@@ -129,7 +129,7 @@ ant -f getEBuilder.xml -Djava.io.tmpdir=%WORKSPACE%\\tmp -Djvm="C:\\\\openjdk\\\
       recipientList("sravankumarl@in.ibm.com")
     }
     downstreamParameterized {
-      trigger('ep-collectYbuildResults') {
+      trigger('Releng/ep-collectYbuildResults') {
         condition('ALWAYS')
         parameters {
           predefinedProp('triggeringJob', '$JOB_NAME')

--- a/JenkinsJobs/AutomatedTests/ep426I_unit_cen64_gtk3_java11.groovy
+++ b/JenkinsJobs/AutomatedTests/ep426I_unit_cen64_gtk3_java11.groovy
@@ -149,7 +149,7 @@ spec:
                   junit keepLongStdio: true, testResults: '**/eclipse-testing/results/xml/*.xml'
               }
               archiveArtifacts '**/eclipse-testing/results/**, **/eclipse-testing/directorLogs/**, *.properties, *.txt'
-              build job: 'ep-collectResults', parameters: [string(name: 'triggeringJob', value: "${JOB_NAME}"), string(name: 'triggeringBuildNumber', value: "${BUILD_NUMBER}"), string(name: 'buildId', value: "${params.buildId}")], wait: false
+              build job: 'Releng/ep-collectResults', parameters: [string(name: 'triggeringJob', value: "${JOB_NAME}"), string(name: 'triggeringBuildNumber', value: "${BUILD_NUMBER}"), string(name: 'buildId', value: "${params.buildId}")], wait: false
           }
       }
   }

--- a/JenkinsJobs/AutomatedTests/ep426I_unit_cen64_gtk3_java17.groovy
+++ b/JenkinsJobs/AutomatedTests/ep426I_unit_cen64_gtk3_java17.groovy
@@ -148,7 +148,7 @@ spec:
               }
               archiveArtifacts '**/eclipse-testing/results/**, **/eclipse-testing/directorLogs/**, *.properties, *.txt'
               junit keepLongStdio: true, testResults: '**/eclipse-testing/results/xml/*.xml'
-              build job: 'ep-collectResults', parameters: [string(name: 'triggeringJob', value: "${JOB_NAME}"), string(name: 'triggeringBuildNumber', value: "${BUILD_NUMBER}"), string(name: 'buildId', value: "${params.buildId}")], wait: false
+              build job: 'Releng/ep-collectResults', parameters: [string(name: 'triggeringJob', value: "${JOB_NAME}"), string(name: 'triggeringBuildNumber', value: "${BUILD_NUMBER}"), string(name: 'buildId', value: "${params.buildId}")], wait: false
           }
       }
   }

--- a/JenkinsJobs/AutomatedTests/ep426I_unit_cen64_gtk3_java19.groovy
+++ b/JenkinsJobs/AutomatedTests/ep426I_unit_cen64_gtk3_java19.groovy
@@ -148,7 +148,7 @@ spec:
               }
               archiveArtifacts '**/eclipse-testing/results/**, **/eclipse-testing/directorLogs/**, *.properties, *.txt'
               junit keepLongStdio: true, testResults: '**/eclipse-testing/results/xml/*.xml'
-              build job: 'ep-collectResults', parameters: [string(name: 'triggeringJob', value: "${JOB_NAME}"), string(name: 'triggeringBuildNumber', value: "${BUILD_NUMBER}"), string(name: 'buildId', value: "${params.buildId}")], wait: false
+              build job: 'Releng/ep-collectResults', parameters: [string(name: 'triggeringJob', value: "${JOB_NAME}"), string(name: 'triggeringBuildNumber', value: "${BUILD_NUMBER}"), string(name: 'buildId', value: "${params.buildId}")], wait: false
           }
       }
   }

--- a/JenkinsJobs/AutomatedTests/ep426I_unit_mac64_java17.groovy
+++ b/JenkinsJobs/AutomatedTests/ep426I_unit_mac64_java17.groovy
@@ -140,7 +140,7 @@ echo -e "\\n\\tTotal elapsed time: ${TOTAL_TIME} \\n"
       recipientList("sravankumarl@in.ibm.com")
     }
     downstreamParameterized {
-      trigger('ep-collectResults') {
+      trigger('Releng/ep-collectResults') {
         condition('UNSTABLE_OR_BETTER')
         parameters {
           predefinedProp('triggeringJob', '$JOB_NAME')

--- a/JenkinsJobs/AutomatedTests/ep426I_unit_macM1_java17.groovy
+++ b/JenkinsJobs/AutomatedTests/ep426I_unit_macM1_java17.groovy
@@ -140,7 +140,7 @@ echo -e "\\n\\tTotal elapsed time: ${TOTAL_TIME} \\n"
       recipientList("sravankumarl@in.ibm.com")
     }
     downstreamParameterized {
-      trigger('ep-collectResults') {
+      trigger('Releng/ep-collectResults') {
         condition('UNSTABLE_OR_BETTER')
         parameters {
           predefinedProp('triggeringJob', '$JOB_NAME')

--- a/JenkinsJobs/AutomatedTests/ep426I_unit_win32_java11.groovy
+++ b/JenkinsJobs/AutomatedTests/ep426I_unit_win32_java11.groovy
@@ -129,7 +129,7 @@ ant -f getEBuilder.xml -Djava.io.tmpdir=%WORKSPACE%\\tmp -Djvm="C:\\\\openjdk\\\
       recipientList("sravankumarl@in.ibm.com")
     }
     downstreamParameterized {
-      trigger('ep-collectResults') {
+      trigger('Releng/ep-collectResults') {
         condition('ALWAYS')
         parameters {
           predefinedProp('triggeringJob', '$JOB_NAME')

--- a/production/testScripts/runTests2.xml
+++ b/production/testScripts/runTests2.xml
@@ -846,7 +846,7 @@
     
     <property
       name="testedPlatform"
-      value="${env.JOB_NAME}_${osgi.os}.${osgi.ws}.${osgi.arch}_${javaMajorVersion}" />
+      value="${env.JOB_BASE_NAME}_${osgi.os}.${osgi.ws}.${osgi.arch}_${javaMajorVersion}" />
 
     <!-- The directory that will contain all files containing information on
       the tests that ran. -->
@@ -1042,7 +1042,7 @@
       value="env.HOSTNAME" />
     <printPHPProperty
       phpvar="HUDSON_JOB_NAME"
-      value="env.JOB_NAME" />
+      value="env.JOB_BASE_NAME" />
     <printPHPProperty
       phpvar="HUDSON_BUILD_NUMBER"
       value="env.BUILD_NUMBER" />


### PR DESCRIPTION
Changing runtests2.xml to use JOB_BASE_NAME instead of JOB_NAME since the latter includes the jenkins folder while JOB_BASE_NAME is just the job name, and should work for both the new and old locations.

Also updated unit test groovy files since I moved collectResults to a central location. 