### PR TITLE
Update target platform to bouncycastle 1.72

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -232,12 +232,12 @@
 				<dependency>
 					<groupId>org.bouncycastle</groupId>
 					<artifactId>bcpg-jdk18on</artifactId>
-					<version>1.71.1</version>
+					<version>1.72</version>
 				</dependency>
 				<dependency>
 					<groupId>org.bouncycastle</groupId>
 					<artifactId>bcprov-jdk18on</artifactId>
-					<version>1.71.1</version>
+					<version>1.72</version>
 				</dependency>
 				<dependency>
 					<groupId>commons-io</groupId>


### PR DESCRIPTION
Makes sure target platform is not using older version than Orbit. See https://github.com/eclipse-equinox/p2/issues/153 for details.