### PR TITLE
Fix performance test location in I-builds

### DIFF
--- a/JenkinsJobs/Builds/I_build.groovy
+++ b/JenkinsJobs/Builds/I_build.groovy
@@ -516,7 +516,7 @@ spec:
               build job: 'AutomatedTests/ep426I-unit-macM1-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
               build job: 'AutomatedTests/ep426I-unit-mac64-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
               build job: 'AutomatedTests/ep426I-unit-win32-java11', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
-              build job: 'AutomatedTests/ep426I-perf-lin64-baseline', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
+              build job: 'ep426I-perf-lin64-baseline', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
               build job: 'Start-smoke-tests', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
             }
 		}

--- a/JenkinsJobs/Releng/collectResults.groovy
+++ b/JenkinsJobs/Releng/collectResults.groovy
@@ -54,9 +54,9 @@ buildDir=${dropsPath}/${buildId}
 
 workingDir=${epDownloadDir}/workingDir
 
-workspace=${workingDir}/${JOB_NAME}-${BUILD_NUMBER}
+workspace=${workingDir}/${JOB_BASE_NAME}-${BUILD_NUMBER}
 
-ssh genie.releng@projects-storage.eclipse.org rm -rf ${workingDir}/${JOB_NAME}*
+ssh genie.releng@projects-storage.eclipse.org rm -rf ${workingDir}/${JOB_BASE_NAME}*
 
 ssh genie.releng@projects-storage.eclipse.org mkdir -p ${workspace}
 ssh genie.releng@projects-storage.eclipse.org cd ${workspace}
@@ -119,7 +119,7 @@ ssh genie.releng@projects-storage.eclipse.org  ${javaCMD} -jar ${launcherJar} -n
 
 
 #Delete Workspace
-ssh genie.releng@projects-storage.eclipse.org rm -rf ${workingDir}/${JOB_NAME}*
+ssh genie.releng@projects-storage.eclipse.org rm -rf ${workingDir}/${JOB_BASE_NAME}*
     ''')
   }
 

--- a/JenkinsJobs/Releng/collectYbuildResults.groovy
+++ b/JenkinsJobs/Releng/collectYbuildResults.groovy
@@ -54,9 +54,9 @@ buildDir=${dropsPath}/${buildId}
 
 workingDir=${epDownloadDir}/workingDir
 
-workspace=${workingDir}/${JOB_NAME}-${BUILD_NUMBER}
+workspace=${workingDir}/${JOB_BASE_NAME}-${BUILD_NUMBER}
 
-ssh genie.releng@projects-storage.eclipse.org rm -rf ${workingDir}/${JOB_NAME}*
+ssh genie.releng@projects-storage.eclipse.org rm -rf ${workingDir}/${JOB_BASE_NAME}*
 
 ssh genie.releng@projects-storage.eclipse.org mkdir -p ${workspace}
 ssh genie.releng@projects-storage.eclipse.org cd ${workspace}
@@ -117,7 +117,7 @@ ssh genie.releng@projects-storage.eclipse.org  ${javaCMD} -jar ${launcherJar} -n
 
 
 #Delete Workspace
-ssh genie.releng@projects-storage.eclipse.org rm -rf ${workingDir}/${JOB_NAME}*
+ssh genie.releng@projects-storage.eclipse.org rm -rf ${workingDir}/${JOB_BASE_NAME}*
     ''')
   }
 


### PR DESCRIPTION
Fix performance test location in I-builds.
Change the collect result jobs to use JOB_BASE_NAME since JOB_NAME includes folder.

Tracked in #568 