### PR TITLE
Update Batik to 1.15

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -13,16 +13,16 @@
 
       <unit id="org.apache.ant" version="1.10.12.v20211102-1452"/>
       <unit id="org.apache.ant.source" version="1.10.12.v20211102-1452"/>
-      <unit id="org.apache.batik.css" version="1.14.0.v20210324-0332"/>
-      <unit id="org.apache.batik.util" version="1.14.0.v20210324-0332"/>
-      <unit id="org.apache.batik.i18n" version="1.14.0.v20210324-0332"/>
-      <unit id="org.apache.batik.constants" version="1.14.0.v20210324-0332"/>
-      <unit id="org.apache.batik.css.source" version="1.14.0.v20210324-0332"/>
-      <unit id="org.apache.batik.util.source" version="1.14.0.v20210324-0332"/>
-      <unit id="org.apache.batik.i18n.source" version="1.14.0.v20210324-0332"/>
-      <unit id="org.apache.batik.constants.source" version="1.14.0.v20210324-0332"/>
-      <unit id="org.apache.xmlgraphics" version="2.6.0.v20210409-0748"/>
-      <unit id="org.apache.xmlgraphics.source" version="2.6.0.v20210409-0748"/>
+      <unit id="org.apache.batik.css" version="1.15.0.v20221018-0736"/>
+      <unit id="org.apache.batik.util" version="1.15.0.v20221018-0736"/>
+      <unit id="org.apache.batik.i18n" version="1.15.0.v20221018-0736"/>
+      <unit id="org.apache.batik.constants" version="1.15.0.v20221018-0736"/>
+      <unit id="org.apache.batik.css.source" version="1.15.0.v20221018-0736"/>
+      <unit id="org.apache.batik.util.source" version="1.15.0.v20221018-0736"/>
+      <unit id="org.apache.batik.i18n.source" version="1.15.0.v20221018-0736"/>
+      <unit id="org.apache.batik.constants.source" version="1.15.0.v20221018-0736"/>
+      <unit id="org.apache.xmlgraphics" version="2.7.0.v20221018-0736"/>
+      <unit id="org.apache.xmlgraphics.source" version="2.7.0.v20221018-0736"/>
       <unit id="org.apache.commons.logging" version="1.2.0.v20180409-1502"/>
       <unit id="org.apache.commons.logging.source" version="1.2.0.v20180409-1502"/>
 
@@ -45,7 +45,7 @@
       <!-- This is the "normal" Orbit repository. During development on Bug 568936 this repo is the EBR (git)
            sourced bundles of Orbit from 2022-03. This is the sub-p2-repo of the 2022-03 recommended build.
            This is the repo that is expected to be updated on milestones based on Orbit deliveries. -->
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/S20220927175816/repository/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/I20221018093115/repository/"/>
     </location>
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
 


### PR DESCRIPTION
Fixes the following CVEs:
https://www.cvedetails.com/cve/CVE-2022-40146/
https://www.cvedetails.com/cve/CVE-2022-38648/
https://www.cvedetails.com/cve/CVE-2022-38398/