### PR TITLE
Update sshAgent to use IDs so jobs are configured correctly.

### DIFF
--- a/JenkinsJobs/Builds/AddToPComposite.groovy
+++ b/JenkinsJobs/Builds/AddToPComposite.groovy
@@ -21,7 +21,7 @@ for (STREAM in STREAMS){
 
     wrappers { //adds pre/post actions
       timestamps()
-      sshAgent('ssh://genie.releng@projects-storage.eclipse.org')
+      sshAgent('projects-storage.eclipse.org-bot-ssh')
     }
 
     steps {

--- a/JenkinsJobs/Builds/markStable.groovy
+++ b/JenkinsJobs/Builds/markStable.groovy
@@ -17,7 +17,7 @@ job('Builds/markStable'){
 
   wrappers { //adds pre/post actions
     timestamps()
-    sshAgent('ssh://genie.releng@projects-storage.eclipse.org')
+    sshAgent('projects-storage.eclipse.org-bot-ssh')
   }
 
   steps {

--- a/JenkinsJobs/Builds/markUnstable.groovy
+++ b/JenkinsJobs/Builds/markUnstable.groovy
@@ -19,7 +19,7 @@ job('Builds/markUnstable'){
 
   wrappers { //adds pre/post actions
     timestamps()
-    sshAgent('ssh://genie.releng@projects-storage.eclipse.org')
+    sshAgent('projects-storage.eclipse.org-bot-ssh')
   }
 
   steps {

--- a/JenkinsJobs/Cleanup/cleanupDLsite.groovy
+++ b/JenkinsJobs/Cleanup/cleanupDLsite.groovy
@@ -12,7 +12,7 @@ job('rt.equinox.releng.cleanupDLsite'){
  
   wrappers { //adds pre/post actions
     timestamps()
-    sshAgent('ssh://genie.releng@projects-storage.eclipse.org')
+    sshAgent('projects-storage.eclipse.org-bot-ssh')
   }
   
   steps {

--- a/JenkinsJobs/Cleanup/cleanupReleaseArtifacts.groovy
+++ b/JenkinsJobs/Cleanup/cleanupReleaseArtifacts.groovy
@@ -34,7 +34,7 @@ job('Cleanup/cleanupReleaseArtifacts'){
   wrappers { //adds pre/post actions
     preBuildCleanup()
     timestamps()
-    sshAgent('ssh://genie.releng@projects-storage.eclipse.org')
+    sshAgent('projects-storage.eclipse.org-bot-ssh')
   }
 
   steps {

--- a/JenkinsJobs/Cleanup/dailyCleanOldBuilds.groovy
+++ b/JenkinsJobs/Cleanup/dailyCleanOldBuilds.groovy
@@ -26,7 +26,7 @@ and other such scripts.
   wrappers { //adds pre/post actions
     timestamps()
     preBuildCleanup()
-    sshAgent('ssh://genie.releng@projects-storage.eclipse.org')
+    sshAgent('projects-storage.eclipse.org-bot-ssh')
     timeout {
       absolute(30)
     }

--- a/JenkinsJobs/Releng/CBIaggregator.groovy
+++ b/JenkinsJobs/Releng/CBIaggregator.groovy
@@ -19,7 +19,7 @@ job('Releng/CBIaggregator'){
       remote{
         name('origin')
         url('git@github.com:eclipse-platform/eclipse.platform.releng.git')
-        credentials('GitHub bot (SSH)')
+        credentials('github-bot-ssh')
       }
       branch('master')
       browser {
@@ -41,7 +41,7 @@ job('Releng/CBIaggregator'){
   wrappers { //adds pre/post actions
     preBuildCleanup()
     timestamps()
-    sshAgent('ssh://genie.releng@projects-storage.eclipse.org', 'ssh://genie.releng@git.eclipse.org', 'GitHub bot (SSH)')
+    sshAgent('projects-storage.eclipse.org-bot-ssh', 'git.eclipse.org-bot-ssh', 'github-bot-ssh')
   }
   
   steps {

--- a/JenkinsJobs/Releng/PublishJDTtoMaven.groovy
+++ b/JenkinsJobs/Releng/PublishJDTtoMaven.groovy
@@ -20,7 +20,7 @@ job('Releng/PublishJDTtoMaven'){
       file('KEYRING', 'secret-subkeys.asc (secret-subkeys.asc fpr JDT')
     }
     timestamps()
-    sshAgent( 'ssh://genie.releng@git.eclipse.org', 'GitHub bot (SSH)')
+    sshAgent('git.eclipse.org-bot-ssh', 'github-bot-ssh')
   }
   
   steps {

--- a/JenkinsJobs/Releng/PublishPDEToMaven.groovy
+++ b/JenkinsJobs/Releng/PublishPDEToMaven.groovy
@@ -20,7 +20,7 @@ job('Releng/PublishPDEToMaven'){
       file('KEYRING', 'secret-subkeys.asc (secret-subkeys.asc fpr JDT')
     }
     timestamps()
-    sshAgent( 'ssh://genie.releng@git.eclipse.org', 'GitHub bot (SSH)')
+    sshAgent('git.eclipse.org-bot-ssh', 'github-bot-ssh')
   }
   
   steps {

--- a/JenkinsJobs/Releng/PublishPlatformToMaven.groovy
+++ b/JenkinsJobs/Releng/PublishPlatformToMaven.groovy
@@ -20,7 +20,7 @@ job('Releng/PublishPlatformToMaven'){
       file('KEYRING', 'secret-subkeys.asc (secret-subkeys.asc fpr JDT')
     }
     timestamps()
-    sshAgent( 'ssh://genie.releng@git.eclipse.org', 'GitHub bot (SSH)')
+    sshAgent('git.eclipse.org-bot-ssh', 'github-bot-ssh')
   }
   
   steps {

--- a/JenkinsJobs/Releng/checkCompositesValidity.groovy
+++ b/JenkinsJobs/Releng/checkCompositesValidity.groovy
@@ -18,7 +18,7 @@ job('Releng/checkCompositesValidity'){
 
   wrappers { //adds pre/post actions
     timestamps()
-    sshAgent('ssh://genie.releng@projects-storage.eclipse.org')
+    sshAgent('projects-storage.eclipse.org-bot-ssh')
     buildTimeoutWrapper{
       strategy {
         absoluteTimeOutStrategy {

--- a/JenkinsJobs/Releng/cleanupReleaseArtifacts.groovy
+++ b/JenkinsJobs/Releng/cleanupReleaseArtifacts.groovy
@@ -34,7 +34,7 @@ job('Releng/cleanupReleaseArtifacts'){
   wrappers { //adds pre/post actions
     preBuildCleanup()
     timestamps()
-    sshAgent('ssh://genie.releng@projects-storage.eclipse.org')
+    sshAgent('projects-storage.eclipse.org-bot-ssh')
   }
 
   steps {

--- a/JenkinsJobs/Releng/collectResults.groovy
+++ b/JenkinsJobs/Releng/collectResults.groovy
@@ -25,7 +25,7 @@ job('Releng/ep-collectResults'){
   wrappers { //adds pre/post actions
     timestamps()
     preBuildCleanup()
-    sshAgent('ssh://genie.releng@git.eclipse.org', 'ssh://genie.releng@projects-storage.eclipse.org')
+    sshAgent('git.eclipse.org-bot-ssh', 'projects-storage.eclipse.org-bot-ssh')
     timeout {
       absolute(30)
     }

--- a/JenkinsJobs/Releng/createGenericComposites.groovy
+++ b/JenkinsJobs/Releng/createGenericComposites.groovy
@@ -18,7 +18,7 @@ job('Releng/createGenericComposites'){
 
   wrappers { //adds pre/post actions
     timestamps()
-    sshAgent('ssh://genie.releng@projects-storage.eclipse.org')
+    sshAgent('projects-storage.eclipse.org-bot-ssh')
   }
   
   steps {

--- a/JenkinsJobs/Releng/createMaintenanceBranch.groovy
+++ b/JenkinsJobs/Releng/createMaintenanceBranch.groovy
@@ -18,7 +18,7 @@ job('Releng/createMaintenanceBranch'){
 
   wrappers { //adds pre/post actions
     timestamps()
-    sshAgent('ssh://genie.releng@git.eclipse.org', 'GitHub bot (SSH)')
+    sshAgent('git.eclipse.org-bot-ssh', 'github-bot-ssh')
   }
   
   steps {

--- a/JenkinsJobs/Releng/makeVisible.groovy
+++ b/JenkinsJobs/Releng/makeVisible.groovy
@@ -32,7 +32,7 @@ I-builds promote to 'S' until 'R'.
 
   wrappers { //adds pre/post actions
     timestamps()
-    sshAgent('ssh://genie.releng@projects-storage.eclipse.org', 'ssh://genie.releng@git.eclipse.org', 'GitHub bot (SSH)')
+    sshAgent('projects-storage.eclipse.org-bot-ssh', 'git.eclipse.org-bot-ssh', 'github-bot-ssh')
     timeout {
       absolute(60)
     }

--- a/JenkinsJobs/Releng/newStreamRepos.groovy
+++ b/JenkinsJobs/Releng/newStreamRepos.groovy
@@ -15,7 +15,7 @@ job('Releng/newStreamRepos'){
 
   wrappers { //adds pre/post actions
     timestamps()
-    sshAgent('ssh://genie.releng@projects-storage.eclipse.org')
+    sshAgent('projects-storage.eclipse.org-bot-ssh')
   }
   
   steps {

--- a/JenkinsJobs/Releng/renameAndPromote.groovy
+++ b/JenkinsJobs/Releng/renameAndPromote.groovy
@@ -32,7 +32,7 @@ I-builds promote to 'S' until 'R'.
 
   wrappers { //adds pre/post actions
     timestamps()
-    sshAgent('ssh://genie.releng@projects-storage.eclipse.org')
+    sshAgent('projects-storage.eclipse.org-bot-ssh')
     timeout {
       absolute(60)
     }

--- a/JenkinsJobs/Releng/tagEclipseRelease.groovy
+++ b/JenkinsJobs/Releng/tagEclipseRelease.groovy
@@ -25,7 +25,7 @@ GitHub issue (or legacy bugzilla bug ID) to track tagging the release, for examp
 
   wrappers { //adds pre/post actions
     timestamps()
-    sshAgent('ssh://genie.releng@git.eclipse.org', 'GitHub bot (SSH)')
+    sshAgent('git.eclipse.org-bot-ssh', 'github-bot-ssh')
     preBuildCleanup()
   }
   

--- a/JenkinsJobs/Releng/updateIndex.groovy
+++ b/JenkinsJobs/Releng/updateIndex.groovy
@@ -12,7 +12,7 @@ job('Releng/updateIndex'){
 
   wrappers { //adds pre/post actions
     timestamps()
-    sshAgent('ssh://genie.releng@projects-storage.eclipse.org')
+    sshAgent('projects-storage.eclipse.org-bot-ssh')
   }
   
   steps {

--- a/JenkinsJobs/YBuilds/collectYbuildResults.groovy
+++ b/JenkinsJobs/YBuilds/collectYbuildResults.groovy
@@ -25,7 +25,7 @@ job('Releng/ep-collectYbuildResults'){
   wrappers { //adds pre/post actions
     timestamps()
     preBuildCleanup()
-    sshAgent('ssh://genie.releng@git.eclipse.org', 'ssh://genie.releng@projects-storage.eclipse.org')
+    sshAgent('git.eclipse.org-bot-ssh', 'projects-storage.eclipse.org-bot-ssh')
     xvnc {
       useXauthority()
     }


### PR DESCRIPTION
Currently the jobs are created and set to use the first SSH agent on the list, but using the IDs set in jenkins instead of the name should fix that.