### PR TITLE
Manage version of maven-toolchains-plugin.

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -573,6 +573,11 @@
           <artifactId>xml-maven-plugin</artifactId>
           <version>1.0.2</version>
         </plugin>
+        <plugin>
+		    <groupId>org.apache.maven.plugins</groupId>
+		    <artifactId>maven-toolchains-plugin</artifactId>
+		    <version>3.1.0</version>
+		</plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
It's used for running tests in jdt.core and jdt.debug but all at different version.
This is first step towards standardizing.