### PR TITLE
Add metatype annotation to target

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -397,6 +397,12 @@
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
+				    <groupId>org.osgi</groupId>
+				    <artifactId>org.osgi.service.metatype.annotations</artifactId>
+				    <version>1.4.1</version>
+				    <type>jar</type>
+			  </dependency>
+			  <dependency>
 				  <groupId>org.osgi</groupId>
 				  <artifactId>org.osgi.service.component</artifactId>
 				  <version>1.5.0</version>


### PR DESCRIPTION
The [Metatype Service Specification](https://docs.osgi.org/specification/osgi.cmpn/7.0.0/service.metatype.html) defines a set of [annotations](https://docs.osgi.org/specification/osgi.cmpn/7.0.0/service.metatype.html#service.metatype-metatype.annotations) to allow defining possible configuration options of a service as code.

These annotations are only retained at class level and can the used at build time to generate the proper XML definition, we should enable PDE users to use these annotations as well, so this information can then be used for example in Tycho or BND builds.