### PR TITLE
Add BND lib to the target

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -368,11 +368,6 @@
 	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="OSGi" missingManifest="error" type="Maven">
 		  <dependencies>
   			  <dependency>
-				  <groupId>biz.aQute.bnd</groupId>
-				  <artifactId>biz.aQute.bnd.annotation</artifactId>
-				  <version>6.3.1</version>
-  			  </dependency>
-  			  <dependency>
 				  <groupId>org.osgi</groupId>
 				  <artifactId>org.osgi.annotation.versioning</artifactId>
 				  <version>1.1.2</version>
@@ -516,6 +511,33 @@
 				  <version>1.0.2</version>
 				  <type>jar</type>
 			  </dependency>
+			  <dependency>
+					<groupId>org.osgi</groupId>
+					<artifactId>org.osgi.service.repository</artifactId>
+					<version>1.1.0</version>
+					<type>jar</type>
+			  </dependency>
+		  </dependencies>
+	  </location>
+	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="BND" missingManifest="error" type="Maven">
+		  <dependencies>
+			  <dependency>
+					<groupId>biz.aQute.bnd</groupId>
+					<artifactId>biz.aQute.bnd.util</artifactId>
+					<version>6.3.1</version>
+					<type>jar</type>
+			  </dependency>
+			  <dependency>
+					<groupId>biz.aQute.bnd</groupId>
+					<artifactId>biz.aQute.bndlib</artifactId>
+					<version>6.3.1</version>
+					<type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>biz.aQute.bnd</groupId>
+				  <artifactId>biz.aQute.bnd.annotation</artifactId>
+				  <version>6.3.1</version>
+  			  </dependency>
 		  </dependencies>
 	  </location>
 	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="Reddeer Deps" missingManifest="error" type="Maven">


### PR DESCRIPTION
m2eclipse already uses BND for a while to generate missing manifest for maven dependencies and PDE can (re-)use BND as well for different tasks.

This also moves the bnd annotations to the new BND section and adds org.osgi.service.repository API bundle as it is a dependency of BND lib.

@akurtakov WDYT? 
FYI @HannesWell 