### PR TITLE
Deploy platform-parent pom and platform-releng target in 'master' build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,15 @@ pipeline {
 				sh 'git submodule foreach "git fetch origin master; git checkout FETCH_HEAD"'
 			}
 		}
+		stage('Deploy eclipse-platform-parent pom and eclipse-sdk target') {
+			when {
+				branch 'master'
+			}
+			steps {
+				sh 'mvn clean deploy -f eclipse-platform-parent/pom.xml'
+				sh 'mvn clean deploy -f eclipse.platform.releng.prereqs.sdk/pom.xml'
+			}
+		}
 		stage('Build') {
 			steps {
 				withCredentials([string(credentialsId: 'gpg-passphrase', variable: 'KEYRING_PASSPHRASE')]) {


### PR DESCRIPTION
As discussed in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/653#issuecomment-1306869654 this PR changes the Jenkins-Pipeline of the `eclipse.platform.releng.aggregator` to deploy the `eclipse-platform-parent/pom.xml` and `eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target` in the beginning of the master-branch build of this repo.
This makes the following two Jenkins jobs obsolete and also speeds up the deployment of the mentioned files but at the same time reduces the number of deployments:
- https://ci.eclipse.org/releng/job/deploy-eclipse-platform-parent-pom/
- https://ci.eclipse.org/releng/job/deploy-eclipse-sdk-target-pom/

From looking at those jobs it looks like nothing more has to be done. Maybe only some credentials are missing, but we will see.