### PR TITLE
Deploy platform-parent-pom/eclipse-sdk-target in 'maintance' build too

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,10 @@ pipeline {
 		}
 		stage('Deploy eclipse-platform-parent pom and eclipse-sdk target') {
 			when {
-				branch 'master'
+				anyOf {
+					branch 'master'
+					branch 'R*_maintenance'
+				}
 			}
 			steps {
 				sh 'mvn clean deploy -f eclipse-platform-parent/pom.xml'


### PR DESCRIPTION
As suggested in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/657#issuecomment-1309274976, a follow up to automatically have maintenance branches prepared to deploy the `eclipse-platform-parent/pom.xml` and `eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target` in the beginning of the build.