### PR TITLE
Enable collectResults by default.

### DIFF
--- a/JenkinsJobs/Releng/collectResults.groovy
+++ b/JenkinsJobs/Releng/collectResults.groovy
@@ -2,9 +2,6 @@ job('Releng/ep-collectResults'){
   displayName('Collect Results')
   description('This job is to perform some summary analysis and then write unit test results to the download page.')
 
-  //disabling for now so we keep using the original ones
-  disabled()
-
   parameters {
     stringParam('triggeringJob', null, 'Name of the job to collect results from: i.e. \'ep425I-unit-cen64-gtk3-java11\'.')
     stringParam('triggeringBuildNumber', null, 'Build number of the triggering job.')


### PR DESCRIPTION
I had previously added a line to disable the new Collect Results job by default while it was broken and that is no longer needed. 