### PR TITLE
Force PGP signatures of old Orbit bundles unsigned in LST Java versions

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/pom.xml
@@ -48,6 +48,18 @@
 						<forceSignature>
 							<bundle>bcpg</bundle>
 							<bundle>bcprov</bundle>
+							<bundle>com.sun.el.source</bundle>
+							<bundle>com.sun.el</bundle>
+							<bundle>javax.el.source</bundle>
+							<bundle>javax.el</bundle>
+							<bundle>org.apache.commons.codec.source</bundle>
+							<bundle>org.apache.commons.codec</bundle>
+							<bundle>org.apache.commons.jxpath.source</bundle>
+							<bundle>org.apache.commons.jxpath</bundle>
+							<bundle>org.apache.jasper.glassfish.source</bundle>
+							<bundle>org.apache.jasper.glassfish</bundle>
+							<bundle>org.w3c.dom.smil.source</bundle>
+							<bundle>org.w3c.dom.smil</bundle>
 						</forceSignature>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/661