### PR TITLE
Fix: Updating publish.xml to use a variable instead of relying on current directory

### DIFF
--- a/JenkinsJobs/Releng/collectResults.groovy
+++ b/JenkinsJobs/Releng/collectResults.groovy
@@ -78,9 +78,10 @@ ssh genie.releng@projects-storage.eclipse.org wget -O ${workspace}/publish.xml h
 
 cd ${WORKSPACE}
 git clone https://github.com/eclipse-platform/eclipse.platform.releng.aggregator.git
-cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.tychoeclipsebuilder/eclipse
-scp -r publishingFiles genie.releng@projects-storage.eclipse.org:${workspace}/publishingFiles
-cd ${WORKSPACE}
+EBUILDERDIR=${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.tychoeclipsebuilder
+#cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.tychoeclipsebuilder/eclipse
+#scp -r publishingFiles genie.releng@projects-storage.eclipse.org:${workspace}/publishingFiles
+#cd ${WORKSPACE}
 
 
 #triggering ant runner
@@ -108,6 +109,7 @@ ssh genie.releng@projects-storage.eclipse.org  ${javaCMD} -jar ${launcherJar} -n
   -Djob=${triggeringJob} \\
   -DbuildID=${buildID} \\
   -DeclipseStream=${STREAM} 
+  -DEBuilderDir=${EBUILDERDIR}
 
 
 

--- a/cje-production/scripts/publish.xml
+++ b/cje-production/scripts/publish.xml
@@ -119,14 +119,14 @@
 
     <condition
       property="dropTemplateFileName"
-      value="${basedir}/templateFiles/performance.php">
+      value="${EBuilderDir}/eclipse/publishingFiles/templateFiles/performance.php">
       <contains
         string="${job}"
         substring="-perf-" />
     </condition>
     <condition
       property="dropTemplateFileName"
-      value="${basedir}/staticDropFiles/testResults.php">
+      value="${EBuilderDir}/eclipse/publishingFiles/staticDropFiles/testResults.php">
       <contains
         string="${job}"
         substring="-unit-" />
@@ -134,7 +134,7 @@
     <!-- else standard default for download index.php page -->
     <property
       name="dropTemplateFileName"
-      value="${basedir}/templateFiles/index.template.php" />
+      value="${EBuilderDir}/eclipse/publishingFiles/templateFiles/index.template.php" />
 
     <condition
       property="testResultsHtmlFileName"
@@ -167,8 +167,8 @@
     
     <condition
       property="manifestFile"
-      value="${basedir}/publishingFiles/performanceTestManifest.xml"
-      else="${basedir}/publishingFiles/testManifest.xml">
+      value="${EBuilderDir}/eclipse/publishingFiles/performanceTestManifest.xml"
+      else="${EBuilderDir}/eclipse/publishingFiles/testManifest.xml">
       <contains
         string="${job}"
         substring="-perf-" />

--- a/scripts/collectResultsLocal.sh
+++ b/scripts/collectResultsLocal.sh
@@ -81,9 +81,10 @@ fi
 
 cd ${workspace}
 git clone https://github.com/eclipse-platform/eclipse.platform.releng.aggregator.git
-cd ${workspace}/eclipse.platform.releng.aggregator/eclipse.platform.releng.tychoeclipsebuilder/eclipse
-scp -r publishingFiles ${workspace}/publishingFiles
-cd ${workspace}
+EBUILDERDIR=${workspace}/eclipse.platform.releng.aggregator/eclipse.platform.releng.tychoeclipsebuilder
+#cd ${workspace}/eclipse.platform.releng.aggregator/eclipse.platform.releng.tychoeclipsebuilder/eclipse
+#scp -r publishingFiles ${workspace}/publishingFiles
+#cd ${workspace}
 
 #triggering ant runner
 baseBuilderDir=${workspace}/basebuilder
@@ -98,6 +99,7 @@ java -jar ${launcherJar} -nosplash -consolelog -debug -data $devworkspace -appli
   -DbuildURL=${buildURL} \
   -DbuildID=${buildID} \
   -DEBUILDER_HASH=${EBUILDER_HASH}
+  -DEBuilderDir=${EBUILDERDIR}
   
 devworkspace=${workspace}/workspace-updateTestResults
 


### PR DESCRIPTION
Should address:
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/680


https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/master/cje-production/mbscripts/mb300_gatherEclipseParts.sh already passes -DEBuilderDir to helper.xml