### PR TITLE
Updates to Jenkins jobs for RC2

### DIFF
--- a/JenkinsJobs/Releng/collectResults.groovy
+++ b/JenkinsJobs/Releng/collectResults.groovy
@@ -78,10 +78,9 @@ ssh genie.releng@projects-storage.eclipse.org wget -O ${workspace}/publish.xml h
 
 cd ${WORKSPACE}
 git clone https://github.com/eclipse-platform/eclipse.platform.releng.aggregator.git
-EBUILDERDIR=${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.tychoeclipsebuilder
-#cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.tychoeclipsebuilder/eclipse
-#scp -r publishingFiles genie.releng@projects-storage.eclipse.org:${workspace}/publishingFiles
-#cd ${WORKSPACE}
+cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.tychoeclipsebuilder
+scp -r eclipse genie.releng@projects-storage.eclipse.org:${workspace}/eclipse
+cd ${WORKSPACE}
 
 
 #triggering ant runner
@@ -109,7 +108,7 @@ ssh genie.releng@projects-storage.eclipse.org  ${javaCMD} -jar ${launcherJar} -n
   -Djob=${triggeringJob} \\
   -DbuildID=${buildID} \\
   -DeclipseStream=${STREAM} 
-  -DEBuilderDir=${EBUILDERDIR}
+  -DEBuilderDir=${workspace}
 
 
 

--- a/JenkinsJobs/Releng/makeVisible.groovy
+++ b/JenkinsJobs/Releng/makeVisible.groovy
@@ -20,6 +20,10 @@ It must match the name of the build on the build machine.
 This is the build type we are promoting TO. 
 I-builds promote to 'S' until 'R'. 
     ''')
+    stringParam('TAG', null, ''' For passing to the tagEclipseRelease job.
+R is used for release builds. For example: R4_25
+S is used for milestones and includes the milestone version. For example: S4_25_0_RC2
+    ''')
   }
 
   logRotator {
@@ -55,9 +59,17 @@ ${WORKSPACE}/makeVisible.sh
       trigger('updateIndex') {
         triggerWithNoParameters(true)
       }
+      trigger('tagEclipseRelease') {
+        parameters {
+          predefinedProp('tag', '$TAG')
+          predefinedProp('buildID', '$DROP_ID')
+          predefinedProp('annotation', '$SIGNOFF_BUG')
+        }
+      }
     }
     extendedEmail {
       recipientList("sravankumarl@in.ibm.com")
     }
   }
 }
+

--- a/cje-production/promotion/makeVisible.sh
+++ b/cje-production/promotion/makeVisible.sh
@@ -61,8 +61,6 @@ fi
 # DL_TYPE ("download type") is the build type we are naming 
 # the build *TO*
 # for main line (master) code, it is always 'S' (from I-build) until it's 'R'
-#export DL_TYPE=S
-#export DL_TYPE=R
 DL_TYPE=$(echo $DL_TYPE|tr -d ' ')
 if [[ -z "${DL_TYPE}" ]]
 then
@@ -140,13 +138,13 @@ then
 fi
 
 #Add to composite
-buildId=${ECLIPSE_DL_DROP_DIR_SEGMENT}
+
 case ${DL_TYPE} in
   "S" )
     export REPO_SITE_SEGMENT=${BUILD_MAJOR}.${BUILD_MINOR}milestones
     ;;
   "R" )
-    export REPO_SITE_SEGMENT=${BUILD_MAJOR}.${BUILD_MINOR}
+    
     ;;
   *)
     echo -e "\n\tERROR: case statement for repo output did not match any pattern."
@@ -154,55 +152,16 @@ case ${DL_TYPE} in
     exit 1
 esac
 
-#if [[ "${DL_TYPE}" != "R" ]]
-#then 
-  #Tag Source
-#  echo "Tag source"
-#  TAG=${DL_TYPE}${BUILD_MAJOR}_${BUILD_MINOR}_${BUILD_SERVICE}_${CHECKPOINT}
+if [[ "${DL_TYPE}" = "R" ]]
+then 
+  buildID=${ECLIPSE_DL_DROP_DIR_SEGMENT}
+  export REPO_SITE_SEGMENT=${BUILD_MAJOR}.${BUILD_MINOR}
 
-#  cd ${WORKSPACE}
-#  git config --global user.email "releng-bot@eclipse.org"
-#  git config --global user.name "Eclipse Releng Bot"
-#  git clone --recurse-submodules git@github.com:eclipse-platform/eclipse.platform.releng.aggregator.git
-
-#  pushd eclipse.platform.releng.aggregator
-#  git checkout master
-#  git submodule foreach git checkout master
-#  git clean -f -d -x
-#  git submodule foreach git clean -f -d -x
-#  git reset --hard
-#  git submodule foreach git reset --hard
-#  git checkout master
-#  git submodule foreach git checkout master
-#  git pull --rebase
-#  git submodule foreach git pull --rebase
-
-#  git tag -a -m "${DL_LABEL}" ${TAG} ${DROP_ID}
-#  git submodule foreach 'git tag -a -m "${DL_LABEL}" ${TAG} ${DROP_ID}; git push --verbose $(toPushRepo $(git config --get remote.origin.url)) tag ${TAG}; || :'
-#  RC=$?
-#  if [[ $RC != 0 ]]
-#  then
-#    printf "\n\t%s\n" "ERROR: Failed to tag aggregator old id, ${DROP_ID}, with new tag, ${TAG} and annotation of ${DL_LABEL}."
-#    popd
-#    exit $RC
-#  fi
-  #git submodule foreach git push --verbose $(toPushRepo $(git config --get remote.origin.url)) tag ${TAG}
-#  git push --verbose $(toPushRepo $(git config --get remote.origin.url)) tag ${TAG}
-
-#  RC=$?
-#  if [[ $RC != 0 ]]
-#  then
-#    printf "\n\t%s\n" "ERROR: Failed to push new tag, ${TAG}."
-#    popd
-#    exit $RC
-#  fi
-#  popd
-#else
   #Repository will be available only for R builds. add it to composite
   epDownloadDir=/home/data/httpd/download.eclipse.org/eclipse
   dropsPath=${epDownloadDir}/downloads/drops4
   p2RepoPath=${epDownloadDir}/updates
-  buildDir=${dropsPath}/${buildId}
+  buildDir=${dropsPath}/${buildID}
 
   workingDir=${epDownloadDir}/workingDir
 
@@ -232,8 +191,8 @@ esac
 
   devworkspace=${workspace}/workspace-antRunner
   devArgs=-Xmx512m
-  extraArgs="addToComposite -Drepodir=${repoDir} -Dcomplocation=${buildId}"
+  extraArgs="addToComposite -Drepodir=${repoDir} -Dcomplocation=${buildID}"
   ssh genie.releng@projects-storage.eclipse.org  ${javaCMD} -jar ${launcherJar} -nosplash -consolelog -debug -data $devworkspace -application org.eclipse.ant.core.antRunner -file ${workspace}/addToComposite.xml ${extraArgs} -vmargs $devArgs
 
   ssh genie.releng@projects-storage.eclipse.org rm -rf ${workingDir}/${JOB_NAME}*
-#fi
+fi

--- a/scripts/newReleasePrep.sh
+++ b/scripts/newReleasePrep.sh
@@ -1,0 +1,55 @@
+#! /bin/bash
+
+Help () {
+    echo "
+    Usage: $0 -v NEXT_STREAM -t NEXT_TRAIN -i PREVIOUS_RELEASE_ISSUE -p PREVIOUS_STREAM
+    Example: $0 -v 4.25 -t (2022-09) -i 48 -p 4.24
+    "
+    exit
+}
+
+if [[ $# -lt 4 ]]; then Help; exit; fi
+
+while getopts "v:t:i:p:" opt
+do
+  case $opt in
+    v) NEXT_STREAM="${OPTARG}";;
+    t) NEXT_TRAIN="${OPTARG}";;
+    i) PREV_ISSUE="${OPTARG}";;
+    p) PREV_MAJOR="${OPTARG%.*}"; PREV_MINOR="${OPTARG#*.}";;
+    \?) Help; exit;;
+  esac
+done
+
+TITLE="Preparation work for ${NEXT_STREAM} (${NEXT_TRAIN}) and open master for development"
+
+BODY="This preparation work involves the following tasks. For previous bug please refer to eclipse-platform/eclipse.platform.releng.aggregator#${PREV_ISSUE}.
+
+- [ ] Create R${PREV_MAJOR}_${PREV_MINOR}_maintenance branch
+- [ ] Move ${PREV_MAJOR}.${PREV_MINOR}-I and ${PREV_MAJOR}.${PREV_MINOR}-Y builds to R${PREV_MAJOR}_${PREV_MINOR}_maintenance branch
+- [ ] Update Parent pom and target sdk deployment jobs for R${PREV_MAJOR}_${PREV_MINOR}_maintenance branch
+- [ ] Create new test jobs for ${NEXT_STREAM}
+- [ ] Configure SWT build scripts for ${NEXT_STREAM}
+- [ ] Splash Screen for ${NEXT_STREAM} (${NEXT_TRAIN})
+- [ ] Create ${NEXT_STREAM}-I-builds repo
+- [ ] POM and product version changes for ${NEXT_STREAM} release
+- [ ] Update product version number to ${NEXT_STREAM} across build scripts
+- [ ] Move previous version to ${PREV_MAJOR}.${PREV_MINOR}RC2 across build scripts
+- [ ] Update version number in Mac's Eclipse.app for ${NEXT_STREAM}
+- [ ] Disable the freeze report for ${NEXT_STREAM}
+- [ ] Clean forceQualifierUpdate files for doc bundles
+- [ ] Cleanup approved api list
+- [ ] Update builds and repo cleanup scripts for ${NEXT_STREAM}
+- [ ] Create new I-build job for ${NEXT_STREAM} release
+- [ ] Update check composites script to verify ${NEXT_STREAM} repositories
+- [ ] Update Comparator repo and eclipse run repo to ${NEXT_STREAM}-I-builds repo
+- [ ] Version bumps for ${NEXT_STREAM} stream
+- [ ] Update previous release version to ${PREV_MAJOR}.${PREV_MINOR} GA across build scripts
+- [ ] Update build calendar for platform ${NEXT_STREAM} release
+- [ ] Deploy ecj compiler from ${PREV_MAJOR}.${PREV_MINOR} GA and use it for ${NEXT_STREAM} M1 build
+- [ ] Update generic repos I-builds, Y-builds, P-builds to point to ${NEXT_STREAM} repos
+"
+
+echo "Creating Issue $TITLE"
+
+gh issue create --title "$TITLE" --body "$BODY" --assignee @me


### PR DESCRIPTION
Changes:
- Updated collectResults with fixes, needed to scp files to projects-storage so the manifest could be found.
- updated makeVisible.groovy to start the tagRelease job automatically since it's only run for releases that need to be tagged.
- Updated the makeVisible sh script to only try to add to composite for major/GA/R releases
- Updated tagEclipseRelease so it actually tags each repo instead of erroring 2 repos in and failing.
- Added a new script that I wrote for making the big checklist issues each release, if you have hub installed locally, it saves time.