### PR TITLE
Fix for #668

### DIFF
--- a/JenkinsJobs/Releng/collectResults.groovy
+++ b/JenkinsJobs/Releng/collectResults.groovy
@@ -96,6 +96,7 @@ devworkspace=${workspace}/workspace-antRunner
 
 ssh genie.releng@projects-storage.eclipse.org  ${javaCMD} -jar ${launcherJar} -nosplash -consolelog -debug -data $devworkspace -application org.eclipse.ant.core.antRunner -file ${workspace}/collectTestResults.xml \\
   -DpostingDirectory=${dropsPath} \\
+  -Djob=${triggeringJob} \\
   -DbuildURL=${buildURL} \\
   -DbuildID=${buildID} \\
   -DEBUILDER_HASH=${EBUILDER_HASH}

--- a/cje-production/scripts/collectTestResults.xml
+++ b/cje-production/scripts/collectTestResults.xml
@@ -87,13 +87,19 @@
         to="*" />
     </unzip>
 
-    <!--<retry
+    <!-- This is needed for the summary table on the I-build download page -->
+    <property
+      name="jenkinsResultXML"
+      value="${jenkinsJobURL}/testReport/api/xml?tree=failCount,passCount,skipCount,duration" />
+    <echo message="jenkinsResultXML ${jenkinsResultXML} " />
+
+    <retry
       retrycount="3"
       retrydelay="1000">
       <get
         src="${jenkinsResultXML}"
-        dest="${resultsDir}/${job}-${buildNumber}.xml" />
-    </retry> -->
+        dest="${resultsDir}/${job}.xml" />
+    </retry> 
 
     <delete failonerror="false">
       <fileset dir="${resultsDir}">

--- a/scripts/collectResultsLocal.sh
+++ b/scripts/collectResultsLocal.sh
@@ -82,9 +82,6 @@ fi
 cd ${workspace}
 git clone https://github.com/eclipse-platform/eclipse.platform.releng.aggregator.git
 EBUILDERDIR=${workspace}/eclipse.platform.releng.aggregator/eclipse.platform.releng.tychoeclipsebuilder
-#cd ${workspace}/eclipse.platform.releng.aggregator/eclipse.platform.releng.tychoeclipsebuilder/eclipse
-#scp -r publishingFiles ${workspace}/publishingFiles
-#cd ${workspace}
 
 #triggering ant runner
 baseBuilderDir=${workspace}/basebuilder
@@ -96,10 +93,11 @@ devworkspace=${workspace}/workspace-antRunner
 
 java -jar ${launcherJar} -nosplash -consolelog -debug -data $devworkspace -application org.eclipse.ant.core.antRunner -file ${workspace}/collectTestResults.xml \
   -DpostingDirectory=${postingDirectory} \
+  -Djob=${triggeringJob} \
   -DbuildURL=${buildURL} \
   -DbuildID=${buildID} \
   -DEBUILDER_HASH=${EBUILDER_HASH}
-  -DEBuilderDir=${EBUILDERDIR}
+  
   
 devworkspace=${workspace}/workspace-updateTestResults
 
@@ -107,4 +105,5 @@ java -jar ${launcherJar} -nosplash -consolelog -debug -data $devworkspace -appli
   -DpostingDirectory=${postingDirectory} \
   -Djob=${triggeringJob} \
   -DbuildID=${buildID} \
-  -DeclipseStream=${STREAM} 
+  -DeclipseStream=${STREAM} \
+  -DEBuilderDir=${EBUILDERDIR}


### PR DESCRIPTION
I commented out an xml download in collectTestResults.xml because I did not know what it does.
Turns out it is used for the test summary table. 

I've updated collectResults to get the xml again and added a comment stating why it's still needed.