### PR TITLE
Fix maven publish jobs. Move release tagging to after promotion.

### DIFF
--- a/JenkinsJobs/Releng/CBIaggregator.groovy
+++ b/JenkinsJobs/Releng/CBIaggregator.groovy
@@ -73,6 +73,18 @@ ${SCRIPT} ${snapshotOrRelease}
           predefinedProp('REPO_ID', '${BUILD_NUMBER}')
         }
       }
+      trigger('Releng/PublishPDEtoMaven') {
+        condition('SUCCESS')
+        parameters {
+          predefinedProp('REPO_ID', '${BUILD_NUMBER}')
+        }
+      }
+      trigger('Releng/PublishPlatformtoMaven') {
+        condition('SUCCESS')
+        parameters {
+          predefinedProp('REPO_ID', '${BUILD_NUMBER}')
+        }
+      }
     }
     archiveArtifacts {
       pattern('repo-*/**, baseline-next.txt')

--- a/JenkinsJobs/Releng/PublishJDTtoMaven.groovy
+++ b/JenkinsJobs/Releng/PublishJDTtoMaven.groovy
@@ -17,7 +17,7 @@ job('Releng/PublishJDTtoMaven'){
   wrappers { //adds pre/post actions
     preBuildCleanup()
     credentialsBinding {
-      file('KEYRING', 'secret-subkeys.asc (secret-subkeys.asc fpr JDT')
+      file('KEYRING', 'secret-subkeys.asc (secret-subkeys.asc for JDT')
     }
     timestamps()
     sshAgent('git.eclipse.org-bot-ssh', 'github-bot-ssh')
@@ -42,7 +42,7 @@ unset _JAVA_OPTIONS
 
 # Trust GPG keys
 gpg --batch --import "${KEYRING}"
-for fpr in $(gpg --list-keys --with-colons  | awk -F: '/fpr:/ {print $10}' | sort -u)
+for fpr in $(gpg --list-keys --with-colons  | awk -F: '/for:/ {print $10}' | sort -u)
 do
   echo -e "5\\ny\\n" |  gpg --batch --command-fd 0 --expert --edit-key ${fpr} trust
 done
@@ -60,7 +60,7 @@ git clone -b master ${GIT_URL}
 /bin/mv ${GIT_REL_PATH}/${SCRIPT} ${WORKSPACE}/
 /bin/mv ${GIT_REL_PATH}/${BASELINE} ${WORKSPACE}/
 /bin/mv ${GIT_REL_PATH}/${POM} ${WORKSPACE}/
-/bin/rmdir -p ${GIT_REL_PATH}
+/bin/rmdir -p --ignore-fail-on-non-empty ${GIT_REL_PATH}
 
 chmod 744 ${SCRIPT}
 ./${SCRIPT}

--- a/JenkinsJobs/Releng/PublishPDEToMaven.groovy
+++ b/JenkinsJobs/Releng/PublishPDEToMaven.groovy
@@ -17,7 +17,7 @@ job('Releng/PublishPDEToMaven'){
   wrappers { //adds pre/post actions
     preBuildCleanup()
     credentialsBinding {
-      file('KEYRING', 'secret-subkeys.asc (secret-subkeys.asc fpr JDT')
+      file('KEYRING', 'secret-subkeys.asc (secret-subkeys.asc for PDE')
     }
     timestamps()
     sshAgent('git.eclipse.org-bot-ssh', 'github-bot-ssh')
@@ -41,7 +41,7 @@ unset JAVA_TOOL_OPTIONS
 unset _JAVA_OPTIONS
 # Trust GPG keys
 gpg --batch --import "${KEYRING}"
-for fpr in $(gpg --list-keys --with-colons  | awk -F: '/fpr:/ {print $10}' | sort -u)
+for fpr in $(gpg --list-keys --with-colons  | awk -F: '/for:/ {print $10}' | sort -u)
 do
   echo -e "5\\ny\\n" |  gpg --batch --command-fd 0 --expert --edit-key ${fpr} trust
 done
@@ -61,7 +61,7 @@ git clone -b master ${GIT_URL}
 /bin/mv ${GIT_REL_PATH}/${SCRIPT} ${WORKSPACE}/
 /bin/mv ${GIT_REL_PATH}/${BASELINE} ${WORKSPACE}/
 /bin/mv ${GIT_REL_PATH}/${POM} ${WORKSPACE}/
-/bin/rmdir -p ${GIT_REL_PATH}
+/bin/rmdir -p --ignore-fail-on-non-empty ${GIT_REL_PATH}
 
 chmod 744 ${SCRIPT}
 gpg --version

--- a/JenkinsJobs/Releng/PublishPlatformToMaven.groovy
+++ b/JenkinsJobs/Releng/PublishPlatformToMaven.groovy
@@ -17,7 +17,7 @@ job('Releng/PublishPlatformToMaven'){
   wrappers { //adds pre/post actions
     preBuildCleanup()
     credentialsBinding {
-      file('KEYRING', 'secret-subkeys.asc (secret-subkeys.asc fpr JDT')
+      file('KEYRING', 'secret-subkeys.asc (secret-subkeys.asc for Releng')
     }
     timestamps()
     sshAgent('git.eclipse.org-bot-ssh', 'github-bot-ssh')
@@ -41,7 +41,7 @@ unset JAVA_TOOL_OPTIONS
 unset _JAVA_OPTIONS
 # Trust GPG keys
 gpg --batch --import "${KEYRING}"
-for fpr in $(gpg --list-keys --with-colons  | awk -F: '/fpr:/ {print $10}' | sort -u)
+for fpr in $(gpg --list-keys --with-colons  | awk -F: '/for:/ {print $10}' | sort -u)
 do
   echo -e "5\\ny\\n" |  gpg --batch --command-fd 0 --expert --edit-key ${fpr} trust
 done
@@ -60,7 +60,7 @@ git clone -b master ${GIT_URL}
 /bin/mv ${GIT_REL_PATH}/${SCRIPT} ${WORKSPACE}/
 /bin/mv ${GIT_REL_PATH}/${BASELINE} ${WORKSPACE}/
 /bin/mv ${GIT_REL_PATH}/${POM} ${WORKSPACE}/
-/bin/rmdir -p ${GIT_REL_PATH}
+/bin/rmdir -p --ignore-fail-on-non-empty ${GIT_REL_PATH}
 
 env
 

--- a/JenkinsJobs/Releng/makeVisible.groovy
+++ b/JenkinsJobs/Releng/makeVisible.groovy
@@ -59,13 +59,6 @@ ${WORKSPACE}/makeVisible.sh
       trigger('updateIndex') {
         triggerWithNoParameters(true)
       }
-      trigger('tagEclipseRelease') {
-        parameters {
-          predefinedProp('tag', '$TAG')
-          predefinedProp('buildID', '$DROP_ID')
-          predefinedProp('annotation', '$SIGNOFF_BUG')
-        }
-      }
     }
     extendedEmail {
       recipientList("sravankumarl@in.ibm.com")

--- a/JenkinsJobs/Releng/renameAndPromote.groovy
+++ b/JenkinsJobs/Releng/renameAndPromote.groovy
@@ -52,6 +52,15 @@ ${WORKSPACE}/promoteSites.sh
   }
 
   publishers {
+    downstreamParameterized {
+      trigger('tagEclipseRelease') {
+        parameters {
+          predefinedProp('tag', '$TAG')
+          predefinedProp('buildID', '$DROP_ID')
+          predefinedProp('annotation', '$SIGNOFF_BUG')
+        }
+      }
+    }
     archiveArtifacts {
       pattern('**/stage2output*/**')
     }


### PR DESCRIPTION
Credentials now named secret-subkeys.asc for PDE/JDT/Releng, and using the correct one instead of JDT keys for everything. 

Moved the tagging job to run after the promotion job, since for GA release make visible is run later.