### PR TITLE
Fix checkComposites script

### DIFF
--- a/cje-production/scripts/checkComposites/checkComposites.sh
+++ b/cje-production/scripts/checkComposites/checkComposites.sh
@@ -26,12 +26,8 @@ repoHttpAccess=https://download.eclipse.org
 repoAccess=${repoHttpAccess}
 # TODO: reduce this list soon
 repoList="\
-/eclipse/updates/4.26/ \
-/eclipse/updates/4.26-I-builds/ \
-/eclipse/updates/4.26-Y-builds/ \
 /eclipse/updates/4.27/ \
-/eclipse/updates/4.27-Y-builds/ \
-/eclipse/updates/4.27-P-builds/ \
+/eclipse/updates/4.27-I-builds/ \
 "
 
 


### PR DESCRIPTION
Only 4.27 and 4.27-I-builds exist and are in development so nothing else should be checked.