### PR TITLE
[SDK-TP] Remove javax.servlet.jsp from Eclipse-Orbit

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -56,8 +56,6 @@
       <!-- Upstream artifact from Maven Central misses OSGi info, stick to Orbit variant -->
       <unit id="javax.el" version="2.2.0.v201303151357"/>
       <unit id="javax.el.source" version="2.2.0.v201303151357"/>
-      <unit id="javax.servlet.jsp" version="2.2.0.v201112011158"/>
-      <unit id="javax.servlet.jsp.source" version="2.2.0.v201112011158"/>
       <unit id="org.apache.jasper.glassfish" version="2.2.2.v201501141630"/>
       <unit id="org.apache.jasper.glassfish.source" version="2.2.2.v201501141630"/>
 


### PR DESCRIPTION
A more recent javax.servlet.jsp from Maven-Central was added in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/407 so the old one from Eclipse-Orbit is probably obsolete.

But the build will tell if not.