### PR TITLE
Update target platform to RedDeer 4.4.0

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -124,18 +124,18 @@
     </location>
 
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
-      <repository location="https://download.eclipse.org/reddeer/releases/4.2.0/"/>
-      <unit id="org.eclipse.reddeer.workbench" version="4.2.0.v20220607-1145"/>
-      <unit id="org.eclipse.reddeer.jface" version="4.2.0.v20220607-1145"/>
-      <unit id="org.eclipse.reddeer.swt" version="4.2.0.v20220607-1145"/>
-      <unit id="org.eclipse.reddeer.uiforms" version="4.2.0.v20220607-1145"/>
-      <unit id="org.eclipse.reddeer.eclipse" version="4.2.0.v20220607-1145"/>
-      <unit id="org.eclipse.reddeer.core" version="4.2.0.v20220607-1145"/>
-      <unit id="org.eclipse.reddeer.common" version="4.2.0.v20220607-1145"/>
-      <unit id="org.eclipse.reddeer.junit" version="4.2.0.v20220607-1145"/>
-      <unit id="org.eclipse.reddeer.junit.extension" version="4.2.0.v20220607-1145"/>
-      <unit id="org.eclipse.reddeer.workbench.core" version="4.2.0.v20220607-1145"/>
-      <unit id="org.eclipse.reddeer.direct" version="4.2.0.v20220607-1145"/>
+      <repository location="https://download.eclipse.org/reddeer/releases/4.4.0/"/>
+      <unit id="org.eclipse.reddeer.workbench" version="4.4.0.v20221129-1611"/>
+      <unit id="org.eclipse.reddeer.jface" version="4.4.0.v20221129-1611"/>
+      <unit id="org.eclipse.reddeer.swt" version="4.4.0.v20221129-1611"/>
+      <unit id="org.eclipse.reddeer.uiforms" version="4.4.0.v20221129-1611"/>
+      <unit id="org.eclipse.reddeer.eclipse" version="4.4.0.v20221129-1611"/>
+      <unit id="org.eclipse.reddeer.core" version="4.4.0.v20221129-1611"/>
+      <unit id="org.eclipse.reddeer.common" version="4.4.0.v20221129-1611"/>
+      <unit id="org.eclipse.reddeer.junit" version="4.4.0.v20221129-1611"/>
+      <unit id="org.eclipse.reddeer.junit.extension" version="4.4.0.v20221129-1611"/>
+      <unit id="org.eclipse.reddeer.workbench.core" version="4.4.0.v20221129-1611"/>
+      <unit id="org.eclipse.reddeer.direct" version="4.4.0.v20221129-1611"/>
     </location>
 
     <!-- uncomment 'eclipse_home' location, with text editor, for use in Eclipse IDE
@@ -679,5 +679,5 @@
 		</dependencies>
     </location>
   </locations>
-  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 </target>


### PR DESCRIPTION
Moves targetJRE to Java 17 as this version requires it. First step towards
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/648