### PR TITLE
Properly exclude native libs from source tarball

### DIFF
--- a/eclipse-platform-sources/sources.xml
+++ b/eclipse-platform-sources/sources.xml
@@ -22,21 +22,19 @@
       <directory>${project.basedir}/..</directory>
       <excludes>
         <!-- Exclude pre-built binary artifacts -->
-        <exclude>eclipse.platform.resources/**/*.dll</exclude>
-        <exclude>eclipse.platform.resources/**/*.jnilib</exclude>
-        <exclude>eclipse.platform.resources/**/*.so</exclude>
+        <exclude>eclipse.platform/**/*.dll</exclude>
+        <exclude>eclipse.platform/**/*.jnilib</exclude>
+        <exclude>eclipse.platform/**/*.so</exclude>
         <exclude>eclipse.platform.swt.binaries/**/*.dll</exclude>
         <exclude>eclipse.platform.swt.binaries/**/*.jnilib</exclude>
         <exclude>eclipse.platform.swt.binaries/**/*.so</exclude>
-        <exclude>eclipse.platform.team/**/*.dll</exclude>
-        <exclude>eclipse.platform.team/**/*.so</exclude>
         <exclude>rt.equinox.binaries/org.eclipse.equinox.executable/bin/**</exclude>
         <exclude>rt.equinox.binaries/org.eclipse.equinox.executable/contributed/**</exclude>
         <exclude>rt.equinox.binaries/**/*.dll</exclude>
         <exclude>rt.equinox.binaries/**/*.so</exclude>
-        <exclude>rt.equinox.bundles/**/*.dll</exclude>
-        <exclude>rt.equinox.bundles/**/*.jnilib</exclude>
-        <exclude>rt.equinox.bundles/**/*.so</exclude>
+        <exclude>equinox/**/*.dll</exclude>
+        <exclude>equinox/**/*.jnilib</exclude>
+        <exclude>equinox/**/*.so</exclude>
         <!-- Exclude scripts and stuff that distro integrators don't need -->
         <exclude>production/**</exclude>
         <exclude>scripts/**</exclude>


### PR DESCRIPTION
Should have been done long ago when repos were merged.