### PR TITLE
Move to latest Orbit I-build

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -8,8 +8,8 @@
       <unit id="com.jcraft.jsch" version="0.1.55.v20221112-0806"/>
       <unit id="com.jcraft.jsch.source" version="0.1.55.v20221112-0806"/>
       <!-- Upstream Maven artifact using javax.annotation-api as bundle name, need to update customers -->
-      <unit id="javax.annotation" version="1.3.5.v20221112-0806"/>
-      <unit id="javax.annotation.source" version="1.3.5.v20221112-0806"/>
+      <unit id="javax.annotation" version="1.3.5.v20221203-1659"/>
+      <unit id="javax.annotation.source" version="1.3.5.v20221203-1659"/>
 
       <unit id="org.apache.ant" version="1.10.12.v20211102-1452"/>
       <unit id="org.apache.ant.source" version="1.10.12.v20211102-1452"/>
@@ -46,7 +46,7 @@
       <!-- This is the "normal" Orbit repository. During development on Bug 568936 this repo is the EBR (git)
            sourced bundles of Orbit from 2022-03. This is the sub-p2-repo of the 2022-03 recommended build.
            This is the repo that is expected to be updated on milestones based on Orbit deliveries. -->
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20221123021534/repository/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/I20221207195208/repository/"/>
     </location>
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
 


### PR DESCRIPTION
So changes due to Orbit rebuilds are separated from dependency updates.