### PR TITLE
Use older jakarta.el version

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -270,15 +270,16 @@
 				<artifactId>javax.servlet.jsp-api</artifactId>
 				<version>2.3.3</version>
 			</dependency>
+			<!-- Sticking to 3.x release to keep javax.el packages -->
 			<dependency>
 				<groupId>jakarta.el</groupId>
 				<artifactId>jakarta.el-api</artifactId>
-				<version>4.0.0</version>
+				<version>3.0.3</version>
 			</dependency>
 			<dependency>
 				<groupId>org.glassfish</groupId>
-				<artifactId>jakarta.el</artifactId>
-				<version>4.0.2</version>
+				<artifactId>javax.el</artifactId>
+				<version>3.0.0</version>
 			</dependency>
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
The package names are still javax.el in older version, so keeping the package name will facilitate a milestone.