### PR TITLE
Add Lucene 9.4.2 to target platform

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -35,6 +35,12 @@
       <unit id="org.apache.lucene.core.source" version="8.4.1.v20221112-0806"/>
       <unit id="org.apache.lucene.analyzers-smartcn.source" version="8.4.1.v20221112-0806"/>
       <unit id="org.apache.lucene.analyzers-common.source" version="8.4.1.v20221112-0806"/>
+      <unit id="org.apache.lucene.core" version="9.4.2.v20221211-0752"/>
+      <unit id="org.apache.lucene.analysis-smartcn" version="9.4.2.v20221211-0752"/>
+      <unit id="org.apache.lucene.analysis-common" version="9.4.2.v20221211-0752"/>
+      <unit id="org.apache.lucene.core.source" version="9.4.2.v20221211-0752"/>
+      <unit id="org.apache.lucene.analysis-smartcn.source" version="9.4.2.v20221211-0752"/>
+      <unit id="org.apache.lucene.analysis-common.source" version="9.4.2.v20221211-0752"/>
       
       <unit id="org.hamcrest.core" version="1.3.0.v20180420-1519"/>
       <unit id="org.hamcrest.core.source" version="1.3.0.v20180420-1519"/>
@@ -46,7 +52,7 @@
       <!-- This is the "normal" Orbit repository. During development on Bug 568936 this repo is the EBR (git)
            sourced bundles of Orbit from 2022-03. This is the sub-p2-repo of the 2022-03 recommended build.
            This is the repo that is expected to be updated on milestones based on Orbit deliveries. -->
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/I20221207195208/repository/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/I20221214155248/repository/"/>
     </location>
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
 


### PR DESCRIPTION
To allow building against it.
Tracked in
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/136