### PR TITLE
Add org.glassfish.web.javax.servlet.jsp to TP

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -50,7 +50,7 @@
     </location>
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
 
-      <!-- Upstream artifact from Maven Central misses OSGi info, stick to Orbit variant -->
+      <!-- In process of being replaced by org.glassfish.web.javax.servlet.jsp from Central -->
       <unit id="org.apache.jasper.glassfish" version="2.2.2.v201501141630"/>
       <unit id="org.apache.jasper.glassfish.source" version="2.2.2.v201501141630"/>
 
@@ -273,6 +273,11 @@
 				<groupId>org.glassfish</groupId>
 				<artifactId>javax.el</artifactId>
 				<version>3.0.0</version>
+			</dependency>
+			<dependency> <!--- Bundle-SymbolicName: org.glassfish.web.javax.servlet.jsp -->
+				<groupId>org.glassfish.web</groupId>
+				<artifactId>javax.servlet.jsp</artifactId>
+				<version>2.3.4</version>
 			</dependency>
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>

--- a/eclipse.platform.releng.tychoeclipsebuilder/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/pom.xml
@@ -58,6 +58,8 @@
 							<bundle>org.apache.commons.jxpath</bundle>
 							<bundle>org.apache.jasper.glassfish.source</bundle>
 							<bundle>org.apache.jasper.glassfish</bundle>
+							<bundle>org.glassfish.web.javax.servlet.jsp.source</bundle>
+							<bundle>org.glassfish.web.javax.servlet.jsp</bundle>
 							<bundle>org.w3c.dom.smil.source</bundle>
 							<bundle>org.w3c.dom.smil</bundle>
 						</forceSignature>


### PR DESCRIPTION
to progressively replace Orbit's org.apache.jasper.glassfish