### PR TITLE
Remove Orbit's org.apache.jasper.glassfish

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -49,11 +49,6 @@
       <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20230302014618/repository/"/>
     </location>
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
-
-      <!-- In process of being replaced by org.glassfish.web.javax.servlet.jsp from Central -->
-      <unit id="org.apache.jasper.glassfish" version="2.2.2.v201501141630"/>
-      <unit id="org.apache.jasper.glassfish.source" version="2.2.2.v201501141630"/>
-
       <unit id="org.w3c.css.sac" version="1.3.1.v200903091627"/>
       <unit id="org.w3c.css.sac.source" version="1.3.1.v200903091627"/>
       <unit id="org.w3c.dom.events" version="3.0.0.draft20060413_v201105210656"/>

--- a/eclipse.platform.releng.tychoeclipsebuilder/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/pom.xml
@@ -56,8 +56,6 @@
 							<bundle>org.apache.commons.codec</bundle>
 							<bundle>org.apache.commons.jxpath.source</bundle>
 							<bundle>org.apache.commons.jxpath</bundle>
-							<bundle>org.apache.jasper.glassfish.source</bundle>
-							<bundle>org.apache.jasper.glassfish</bundle>
 							<bundle>org.glassfish.web.javax.servlet.jsp.source</bundle>
 							<bundle>org.glassfish.web.javax.servlet.jsp</bundle>
 							<bundle>org.jdom.source</bundle>


### PR DESCRIPTION
Replaced by newer org.glassfish.web.javax.servlet.jsp from Maven Central


Requires:

- [ ] https://github.com/eclipse-platform/eclipse.platform.common/pull/106
- [ ] https://github.com/eclipse-platform/eclipse.platform.releng/pull/175
- [ ] https://github.com/eclipse-platform/eclipse.platform.ua/pull/76
- [ ] https://github.com/eclipse-equinox/equinox/pull/174