### PR TITLE
Corrected eclipse p2 repo url

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -77,9 +77,9 @@
       'eclipiserun-repo' repository, such as for computing .api-descriptions and
       generating API Tools reports.
     -->
-    <eclipserun-repo>https://download.eclipse.org/eclipse/updates/R-4.26-202211231800/</eclipserun-repo>
+    <eclipserun-repo>https://download.eclipse.org/eclipse/updates/4.26/R-4.26-202211231800/</eclipserun-repo>
     
-    <comparator.repo>https://download.eclipse.org/eclipse/updates/R-4.26-202211231800</comparator.repo>
+    <comparator.repo>https://download.eclipse.org/eclipse/updates/4.26/R-4.26-202211231800</comparator.repo>
 
     <!-- only used when Tycho snapshot repo is enabled in <pluginRepositories> further down -->
     <tycho-snapshot-repo.url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</tycho-snapshot-repo.url>
@@ -632,7 +632,7 @@
           For maintenance streams should always be "M-builds".
           Ideally, this value would be provided by the environment, see bug 489789.
         -->
-        <eclipse-p2-repo.url>https://download.eclipse.org/eclipse/updates/R-4.26-202211231800</eclipse-p2-repo.url>
+        <eclipse-p2-repo.url>https://download.eclipse.org/eclipse/updates/4.26/R-4.26-202211231800</eclipse-p2-repo.url>
       </properties>
       <repositories>
         <repository>


### PR DESCRIPTION
Updated the wrong eclipse repo url.
From https://download.eclipse.org/eclipse/updates/R-4.26-202211231800/ to https://download.eclipse.org/eclipse/updates/4.26/R-4.26-202211231800/