### PR TITLE
OOmph fails "No repository found webtools/CI/3.28.0 (#83)

### DIFF
--- a/oomph/Platform.setup
+++ b/oomph/Platform.setup
@@ -835,7 +835,7 @@
       <repository
           url="https://download.eclipse.org/technology/m2e/snapshots/latest"/>
       <repository
-          url="https://download.eclipse.org/webtools/CI/3.28.0/I-latest/repository"/>
+          url="https://download.eclipse.org/webtools/CI/3.29.0/I-latest/repository"/>
     </setupTask>
     <stream
         name="master"


### PR DESCRIPTION
Use webtools/CI/3.29.0/I-latest repo, 3.28.0 is gone now

Fixes https://github.com/eclipse-platform/.github/issues/83