### PR TITLE
Revert "Replace jxpath by upstream one from Maven Central"

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -65,11 +65,10 @@
       <unit id="org.w3c.dom.svg" version="1.1.0.v201011041433"/>
       <unit id="org.w3c.dom.svg.source" version="1.1.0.v201011041433"/>
 
-      <!-- Transitive dependency of jxpath, not available as OSGi bundle on Maven Central -->
-      <unit id="org.jdom" version="1.1.1.v201101151400"/>
-      <unit id="org.jdom.source" version="1.1.1.v201101151400"/>
-      <unit id="org.apache.commons.beanutils" version="1.8.0.v201205091237"/>
-      <unit id="org.apache.commons.beanutils.source" version="1.8.0.v201205091237"/>
+      <!-- part of e4 ui tools. See bug 422102 -->
+      <!-- Has Maven deps on non-OSGi jdom, cannot easily use Maven artifact yet -->
+      <unit id="org.apache.commons.jxpath" version="1.3.0.v200911051830"/>
+      <unit id="org.apache.commons.jxpath.source" version="1.3.0.v200911051830"/>
 
       <!-- RedDeer deps-->
       <unit id="org.json" version="1.0.0.v201011060100"/>
@@ -711,23 +710,7 @@
 				<type>jar</type>
 			</dependency>
 		</dependencies>
-	</location>
-	<location includeDependencyDepth="none" includeSource="true" label="jxpath" missingManifest="ignore" type="Maven">
-		<dependencies>
-			<dependency>
-				<groupId>commons-jxpath</groupId>
-				<artifactId>commons-jxpath</artifactId>
-				<version>1.3</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>commons-collections</groupId>
-				<artifactId>commons-collections</artifactId>
-				<version>3.2.2</version>
-				<type>jar</type>
-			</dependency>
-		</dependencies>
-	</location>
+    </location>
   </locations>
   <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 </target>


### PR DESCRIPTION
This reverts commit 644c8ab54506ec0c1333d74eb3ad7a0c37abe3c3.

This commit breaks SDK building with error

```
[ERROR] Failed to execute goal
org.eclipse.tycho:tycho-p2-repository-plugin:4.0.0-SNAPSHOT:assemble-repository
(default-assemble-repository) on project eclipse.platform.repository:
Could not assemble p2 repository: Mirroring failed: Messages while
mirroring artifact descriptors.: [Failed to transfer artifact packed:
osgi.bundle,org.jdom.source,1.1.1.v201101151400.: [Download of
osgi.bundle,org.jdom.source,1.1.1.v201101151400 failed on repository
file:/resolution-context-artifacts@%252Fdata%252F4x_platform%252Feclipse.platform.releng.aggregator%252Feclipse.platform.releng.tychoeclipsebuilder%252Feclipse.platform.repository.
```

See discussion on
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/773