### PR TITLE
Revert "Revert "Replace jxpath by upstream one from Maven Central""

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -65,10 +65,11 @@
       <unit id="org.w3c.dom.svg" version="1.1.0.v201011041433"/>
       <unit id="org.w3c.dom.svg.source" version="1.1.0.v201011041433"/>
 
-      <!-- part of e4 ui tools. See bug 422102 -->
-      <!-- Has Maven deps on non-OSGi jdom, cannot easily use Maven artifact yet -->
-      <unit id="org.apache.commons.jxpath" version="1.3.0.v200911051830"/>
-      <unit id="org.apache.commons.jxpath.source" version="1.3.0.v200911051830"/>
+      <!-- Transitive dependency of jxpath, not available as OSGi bundle on Maven Central -->
+      <unit id="org.jdom" version="1.1.1.v201101151400"/>
+      <unit id="org.jdom.source" version="1.1.1.v201101151400"/>
+      <unit id="org.apache.commons.beanutils" version="1.8.0.v201205091237"/>
+      <unit id="org.apache.commons.beanutils.source" version="1.8.0.v201205091237"/>
 
       <!-- RedDeer deps-->
       <unit id="org.json" version="1.0.0.v201011060100"/>
@@ -710,7 +711,23 @@
 				<type>jar</type>
 			</dependency>
 		</dependencies>
-    </location>
+	</location>
+	<location includeDependencyDepth="none" includeSource="true" label="jxpath" missingManifest="ignore" type="Maven">
+		<dependencies>
+			<dependency>
+				<groupId>commons-jxpath</groupId>
+				<artifactId>commons-jxpath</artifactId>
+				<version>1.3</version>
+				<type>jar</type>
+			</dependency>
+			<dependency>
+				<groupId>commons-collections</groupId>
+				<artifactId>commons-collections</artifactId>
+				<version>3.2.2</version>
+				<type>jar</type>
+			</dependency>
+		</dependencies>
+	</location>
   </locations>
   <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 </target>


### PR DESCRIPTION
This reverts commit cd659acf75ce18b5ee79dfe0a7bdf1fa0f9a9e82.i Now that jxpath isn't directly included anymore (comes transitively) and Tycho issues are resolved, we can finally re-try this.