### PR TITLE
Update to ECJ from M1

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -86,7 +86,7 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cbi-jdt-repo.url>https://repo.eclipse.org/content/repositories/eclipse-staging/</cbi-jdt-repo.url>
-    <cbi-ecj-version>3.32.0.v20221108-1853</cbi-ecj-version>
+    <cbi-ecj-version>3.33.0.v20221222-1640</cbi-ecj-version>
 
     <!--
       Production bundles are produced by ignoring the compiler warnings specified


### PR DESCRIPTION
Prep work for https://github.com/eclipse-platform/eclipse.platform.ui/pull/527 due to https://github.com/eclipse-jdt/eclipse.jdt.core/issues/585