### PR TITLE
Trying to fix Windows test execution (#190)

### DIFF
--- a/JenkinsJobs/AutomatedTests/I_unit_win32_java17.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_win32_java17.groovy
@@ -115,9 +115,9 @@ For /F "tokens=1* delims==" %%A IN (buildProperties.properties) DO (
 echo on
 set STREAM
 set EBUILDER_HASH
-set JAVA_HOME="C:\\PROGRA~1\\ECLIPS~1\\jdk-17.0.5.8-hotspot\\"
+set JAVA_HOME=C:\\PROGRA~1\\ECLIPS~1\\jdk-17.0.5.8-hotspot\\
 set JAVA_HOME
-set Path="C:\\PROGRA~1\\ECLIPS~1\\jdk-17.0.5.8-hotspot\\bin";C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\ProgramData\\chocolatey\\bin;C:\\tools\\cygwin\\bin;C:\\Program Files\\IcedTeaWeb\\WebStart\\bin;C:\\WINDOWS\\system32;C:\\WINDOWS;C:\\WINDOWS\\System32\\Wbem;C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\;C:\\WINDOWS\\System32\\OpenSSH\\;C:\\Users\\jenkins_vnc\\AppData\\Local\\Microsoft\\WindowsApps;%PATH%
+set Path="C:\\PROGRA~1\\ECLIPS~1\\jdk-17.0.5.8-hotspot\\bin";C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\ProgramData\\chocolatey\\bin;C:\\tools\\cygwin\\bin;C:\\Program Files\\IcedTeaWeb\\WebStart\\bin;C:\\WINDOWS\\System32\\OpenSSH\\;C:\\Users\\jenkins_vnc\\AppData\\Local\\Microsoft\\WindowsApps;%PATH%
 
 ant -f getEBuilder.xml -Djava.io.tmpdir=%WORKSPACE%\\tmp -Djvm="C:\\PROGRA~1\\ECLIPS~1\\jdk-17.0.5.8-hotspot\\bin\\java.exe" -DbuildId=%buildId%  -DeclipseStream=%STREAM% -DEBUILDER_HASH=%EBUILDER_HASH%  -DdownloadURL="https://download.eclipse.org/eclipse/downloads/drops4/%buildId%" -Dargs=all -Dosgi.os=win32 -Dosgi.ws=win32 -Dosgi.arch=x86_64 -DtestSuite=all
 


### PR DESCRIPTION
- removed quotes around set JAVA_HOME, that broke java startup from Ant
- removed duplicated PATH entries (cleanup only)

See https://github.com/eclipse-platform/eclipse.platform.releng/issues/190