### PR TITLE
Fix extra line in arm64 and ppcle smoke tests

### DIFF
--- a/JenkinsJobs/SmokeTests/smoke_test_arm64.groovy
+++ b/JenkinsJobs/SmokeTests/smoke_test_arm64.groovy
@@ -32,8 +32,7 @@ job('SmokeTests/ep-smoke-test-arm64'){
   }
   
   steps {
-    shell('''
-#!/usr/bin/env bash
+    shell('''#!/usr/bin/env bash
 
 buildId=$(echo $buildId|tr -d ' ')
 

--- a/JenkinsJobs/SmokeTests/smoke_test_ppcle.groovy
+++ b/JenkinsJobs/SmokeTests/smoke_test_ppcle.groovy
@@ -34,8 +34,7 @@ job('SmokeTests/ep-smoke-test-ppcle'){
   }
   
   steps {
-    shell('''
-#!/usr/bin/env bash
+    shell('''#!/usr/bin/env bash
 
 buildId=$(echo $buildId|tr -d ' ')
 


### PR DESCRIPTION
Formatting resulted in an extra space at the top of the script in Jenkins which broke the arm64 and ppcle builds.