### PR TITLE
Migrate the javadoc config from equinox > platform-parent

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -1113,6 +1113,74 @@
 					<configuration>
 						<source>${java.version}</source>
 						<failOnError>false</failOnError>
+						<doclint>reference,html,syntax</doclint>
+						<links>
+							<link>https://docs.osgi.org/javadoc/osgi.core/8.0.0/</link>
+							<link>https://docs.osgi.org/javadoc/osgi.cmpn/8.0.0/</link>
+							<link>https://docs.osgi.org/javadoc/osgi.enterprise/7.0.0/</link>
+						</links>
+						<tags>
+							<tag>
+								<name>noimplement</name>
+								<placement>a</placement>
+								<head>Restriction:</head>
+							</tag>
+							<tag>
+								<name>noextend</name>
+								<placement>a</placement>
+								<head>Restriction:</head>
+							</tag>
+							<tag>
+								<name>noreference</name>
+								<placement>a</placement>
+								<head>Restriction:</head>
+							</tag>
+							<tag>
+								<name>noinstantiate</name>
+								<placement>a</placement>
+								<head>Restriction:</head>
+							</tag>
+							<tag>
+								<name>nooverride</name>
+								<placement>a</placement>
+								<head>Restriction:</head>
+							</tag>
+							<tag>
+								<name>TrackedGetter</name>
+								<placement>cm</placement>
+								<head>"TrackedGetter"</head>
+							</tag>
+							<tag>
+								<name>model</name>
+								<placement>X</placement>
+								<head>"EMF generated tag"</head>
+							</tag>
+							<tag>
+								<name>generated</name>
+								<placement>X</placement>
+								<head>"EMF generated tag"</head>
+							</tag>
+							<tag>
+								<name>ordered</name>
+								<placement>X</placement>
+								<head>"EMF generated tag"</head>
+							</tag>
+							<tag>
+								<name>Immutable</name>
+								<placement>t</placement>
+								<head></head>
+							</tag>
+							<tag>
+								<name>implNote</name>
+								<placement>a</placement>
+								<head><![CDATA[<em>Implementation Note:</em>]]></head>
+							</tag>
+							<tag>
+								<name>implSpec</name>
+								<placement>a</placement>
+								<head>Implementation Requirements:</head>
+							</tag>
+						</tags>
 						<!-- These are provided by PDE/Tycho by default but javadoc do not know that ... -->
 						<additionalDependencies>
 							<additionalDependency>


### PR DESCRIPTION
This migrates some javadoc config that is generic enough from equinox to the platform parent.