### PR TITLE
Fix for "Releng JIPP not connecting to svc cluster"

### DIFF
--- a/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3_java17.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3_java17.groovy
@@ -51,7 +51,8 @@ spec:
         memory: "4096Mi"
         cpu: "1000m"
       requests:
-        memory: "512Mi"
+        # memory needs to be at least 1024Mi, see https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2478
+        memory: "1024Mi"
         cpu: "1000m"
     securityContext:
       privileged: false

--- a/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3_java19.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3_java19.groovy
@@ -51,7 +51,8 @@ spec:
         memory: "4096Mi"
         cpu: "1000m"
       requests:
-        memory: "512Mi"
+        # memory needs to be at least 1024Mi, see https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2478
+        memory: "1024Mi"
         cpu: "1000m"
     securityContext:
       privileged: false

--- a/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3_java20.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3_java20.groovy
@@ -51,7 +51,8 @@ spec:
         memory: "4096Mi"
         cpu: "1000m"
       requests:
-        memory: "512Mi"
+        # memory needs to be at least 1024Mi, see https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2478
+        memory: "1024Mi"
         cpu: "1000m"
     securityContext:
       privileged: false

--- a/JenkinsJobs/YBuilds/Y_unit_cen64_gtk3_java17.groovy
+++ b/JenkinsJobs/YBuilds/Y_unit_cen64_gtk3_java17.groovy
@@ -51,7 +51,8 @@ spec:
         memory: "4096Mi"
         cpu: "1000m"
       requests:
-        memory: "512Mi"
+        # memory needs to be at least 1024Mi, see https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2478
+        memory: "1024Mi"
         cpu: "1000m"
     securityContext:
       privileged: false

--- a/JenkinsJobs/YBuilds/Y_unit_cen64_gtk3_java19.groovy
+++ b/JenkinsJobs/YBuilds/Y_unit_cen64_gtk3_java19.groovy
@@ -51,7 +51,8 @@ spec:
         memory: "4096Mi"
         cpu: "1000m"
       requests:
-        memory: "512Mi"
+        # memory needs to be at least 1024Mi, see https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2478
+        memory: "1024Mi"
         cpu: "1000m"
     securityContext:
       privileged: false

--- a/JenkinsJobs/YBuilds/Y_unit_cen64_gtk3_java20.groovy
+++ b/JenkinsJobs/YBuilds/Y_unit_cen64_gtk3_java20.groovy
@@ -51,7 +51,8 @@ spec:
         memory: "4096Mi"
         cpu: "1000m"
       requests:
-        memory: "512Mi"
+        # memory needs to be at least 1024Mi, see https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2478
+        memory: "1024Mi"
         cpu: "1000m"
     securityContext:
       privileged: false


### PR DESCRIPTION
Increased memory requested by Linux container to avoid container startup issues / aborted jobs on Linux.

See https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2478