### PR TITLE
Stop generating OSGi headers from source

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -480,6 +480,7 @@
           </dependencies>
           <configuration>
             <timestampProvider>jgit</timestampProvider>
+            <deriveHeaderFromSource>false</deriveHeaderFromSource>
             <jgit.ignore>
               pom.xml
               .polyglot.build.properties


### PR DESCRIPTION
Temporary disable as we are late in 2022-03 stream and a some things are still work in progress on Tycho and PDE side.
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/853 for details.