### PR TITLE
Adding SmokeTest for Java 19 ppcle and Java 20 #868

### DIFF
--- a/JenkinsJobs/SmokeTests/StartSmokeTests.groovy
+++ b/JenkinsJobs/SmokeTests/StartSmokeTests.groovy
@@ -54,33 +54,60 @@ pipeline {
                         build job: 'SmokeTests/ep-smoke-test-arm64', parameters: [string(name: 'buildId', value: "${params.buildId}"), string(name: 'javaDownload', value: "${params.java19arm64}")]
                   }
               }
+              stage('Centos 8.x ppc64le Java19'){
+				  steps {
+						build job: 'SmokeTests/ep-smoke-test-ppcle', parameters: [string(name: 'buildId', value: "${params.buildId}"), string(name: 'javaDownload', value: "${params.java19ppcle}")]
+				  }
+			  }
+          	  stage('Ubuntu 22.04 Java20'){
+				  steps {
+						build job: 'SmokeTests/ep-smoke-test-ubuntu22', parameters: [string(name: 'buildId', value: "${params.buildId}"), string(name: 'javaDownload', value: "${params.java20x64}")]
+				  }
+			  }
+			  stage('Opensuse Leap Java20'){
+				  steps {
+						build job: 'SmokeTests/ep-smoke-test-opensuse-leap', parameters: [string(name: 'buildId', value: "${params.buildId}"), string(name: 'javaDownload', value: "${params.java20x64}")]
+				  }
+			  }
+			  stage('Centos 9.x Java20'){
+				  steps {
+						build job: 'SmokeTests/ep-smoke-test-centos9', parameters: [string(name: 'buildId', value: "${params.buildId}"), string(name: 'javaDownload', value: "${params.java20x64}")]
+				  }
+			  }
+			  stage('Centos 8 arm64 Java20'){
+				  steps {
+						build job: 'SmokeTests/ep-smoke-test-arm64', parameters: [string(name: 'buildId', value: "${params.buildId}"), string(name: 'javaDownload', value: "${params.java20arm64}")]
+				  }
+			  }          
           }
+          
 		}
 	}
 	post {
         aborted {
             emailext body: "Smoke Tests failed. Please go to ${BUILD_URL} and check the build failure",
             subject: "Smoke test for ${buildId} - ABORTED", 
-            to: "sravankumarl@in.ibm.com sravan.lakkimsetti@gmail.com",
+            to: "sravankumarl@in.ibm.com sravan.lakkimsetti@gmail.com rahul.mohanan@ibm.com",
             from:"genie.releng@eclipse.org"
         }
         failure {
             emailext body: "Smoke Tests failed. Please go to ${BUILD_URL} and check the build failure",
             subject: "Smoke test for ${buildId} - FAILED", 
-            to: "sravankumarl@in.ibm.com sravan.lakkimsetti@gmail.com",
+            to: "sravankumarl@in.ibm.com sravan.lakkimsetti@gmail.com rahul.mohanan@ibm.com",
             from:"genie.releng@eclipse.org"
         }
         unstable {
             emailext body: "Smoke Tests failed. Please go to ${BUILD_URL} and check the test failures",
             subject: "Smoke test for ${buildId} - UNSTABLE", 
-            to: "sravankumarl@in.ibm.com sravan.lakkimsetti@gmail.com",
+            to: "sravankumarl@in.ibm.com sravan.lakkimsetti@gmail.com rahul.mohanan@ibm.com",
             from:"genie.releng@eclipse.org"
         }
         success {
             emailext body: "Smoke Tests successful",
             subject: "Smoke test for ${buildId} - SUCCESS", 
-            to: "sravankumarl@in.ibm.com sravan.lakkimsetti@gmail.com",
+            to: "sravankumarl@in.ibm.com sravan.lakkimsetti@gmail.com rahul.mohanan@ibm.com",
             from:"genie.releng@eclipse.org"
         }
 	}
 }
+


### PR DESCRIPTION
1. Added Java 19 ppcle job (Centos 8.x ppc64le Java19')
2. Java 20 Smoke Test Job(Ubuntu 22.04 Java20,Opensuse Leap Java20,Centos 9.x Java20,Centos 8 arm64 Java20).
3. Added Email in Different Failure and success.

Fixes #868
@sravanlakkimsetti Please review the PR