### PR TITLE
Update beanutils to 1.9.4

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -68,8 +68,6 @@
       <!-- Transitive dependency of jxpath, not available as OSGi bundle on Maven Central -->
       <unit id="org.jdom" version="1.1.1.v201101151400"/>
       <unit id="org.jdom.source" version="1.1.1.v201101151400"/>
-      <unit id="org.apache.commons.beanutils" version="1.8.0.v201205091237"/>
-      <unit id="org.apache.commons.beanutils.source" version="1.8.0.v201205091237"/>
 
       <!-- RedDeer deps-->
       <unit id="org.json" version="1.0.0.v201011060100"/>
@@ -724,6 +722,12 @@
 				<groupId>commons-collections</groupId>
 				<artifactId>commons-collections</artifactId>
 				<version>3.2.2</version>
+				<type>jar</type>
+			</dependency>
+			<dependency>
+				<groupId>commons-beanutils</groupId>
+				<artifactId>commons-beanutils</artifactId>
+				<version>1.9.4</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
Multiple CVEs are fixed compared to 1.8.0 used and it removes one more dependency from ancient Orbit that had to special treated to get signed. Tracked in
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/870