### PR TITLE
Add a profile to bump versions

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -619,6 +619,33 @@
      </repositories>
    </profile>
    <profile>
+	  <!-- This provile enables automatic version bumps when running the build -->
+      <id>vb</id>
+      <properties>
+		  <compare-version-with-baselines.skip>false</compare-version-with-baselines.skip>
+      </properties>
+       <build>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.tycho</groupId>
+            <artifactId>tycho-versions-plugin</artifactId>
+            <version>${tycho.version}</version>
+             <executions>
+              <execution>
+                <id>bump</id>
+                <goals>
+                  <goal>bump-versions</goal>
+                </goals>
+                <configuration>
+					<increment>100</increment>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+       </build>
+   </profile>
+   <profile>
       <id>build-individual-bundles</id>
       <activation>
         <property>


### PR DESCRIPTION
If running a build, one can specify `-Pvb` to automatically bump the version(s) of plugins that have changed.