### PR TITLE
Run the p2analyze report using the latest JustJ Java 17 JRE

### DIFF
--- a/cje-production/mbscripts/mb500_createRepoReports.sh
+++ b/cje-production/mbscripts/mb500_createRepoReports.sh
@@ -30,12 +30,21 @@ output_dir=$CJE_ROOT/$DROP_DIR/$BUILD_ID/buildlogs
 tar_name=org.eclipse.cbi.p2repo.analyzers.product-linux.gtk.x86_64.tar.gz
 report_app_dir=$CJE_ROOT/$TMP_DIR/reportApplication
 
-wget --no-proxy --no-verbose --no-cache -O $CJE_ROOT/$TMP_DIR/$tar_name https://download.eclipse.org/cbi/updates/p2-analyzers/products/nightly/latest/org.eclipse.cbi.p2repo.analyzers.product-linux.gtk.x86_64.tar.gz
+wget --no-proxy --no-verbose --no-cache -O $CJE_ROOT/$TMP_DIR/$tar_name https://download.eclipse.org/cbi/updates/p2-analyzers/products/nightly/latest/$tar_name
 
 mkdir -p $report_app_dir
 tar -xf $CJE_ROOT/$TMP_DIR/$tar_name -C $report_app_dir
 
-$report_app_dir/p2analyze/p2analyze -data $CJE_ROOT/$TMP_DIR/workspace-report -vm $JAVA_HOME/bin -vmargs -Xmx1g \
+# Get the latest JustJ 17 JRE and package it.
+justj_jre_url=https://download.eclipse.org/justj/jres/17/downloads/latest
+justj_jre_relative_path=$(curl -s  $justj_jre_url/justj.manifest | grep -E org.eclipse.justj.openjdk.hotspot.jre.full-[0-9.]+-linux-x86_64.tar.gz)
+justj_jre_name=$(basename $justj_jre_relative_path)
+
+wget --no-proxy --no-verbose --no-cache -O $CJE_ROOT/$TMP_DIR/$justj_jre_name $justj_jre_url}/$justj_jre_relative_path
+mkdir -p $report_app_dir/jre
+tar -xf $CJE_ROOT/$TMP_DIR/$justj_jre_name -C $report_app_dir/jre
+
+$report_app_dir/p2analyze/p2analyze -data $CJE_ROOT/$TMP_DIR/workspace-report -vm $report_app_dir/jre/bin -vmargs -Xmx1g \
   -DreferenceRepo=$CJE_ROOT/$TMP_DIR/$BUILD_TO_COMPARE_SITE/$PREVIOUS_RELEASE_VER/$BASEBUILD_ID \
   -DreportRepoDir=$buildToTest \
   -DreportOutputDir=$output_dir


### PR DESCRIPTION
This is a Temurin-derived JRE and is same JRE that is used with all the SimRel products.  Using this URL avoids rate limits that often affect direct Temurin JREs.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/870