### PR TITLE
Deploy the poms also on branches that are preparing a release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,7 @@ pipeline {
 				anyOf {
 					branch 'master'
 					branch 'R*_maintenance'
+					branch 'prepare_R*'
 				}
 			}
 			steps {
@@ -39,6 +40,7 @@ pipeline {
 			}
 		}
 		stage('Build') {
+		    when { not { branch pattern: "prepare_R.*", comparator: "REGEXP" } }
 			steps {
 				withCredentials([string(credentialsId: 'gpg-passphrase', variable: 'KEYRING_PASSPHRASE')]) {
 					sh '''


### PR DESCRIPTION
This adds a new condition where poms are deployed when the branch start with the prefix 'prepare_R' and skip the build in such case.

@akurtakov @sravanlakkimsetti what do you think? The idea is that with some automation one can create the `prepare_R...` automatically (I'll prepare a PR for this as well), then a build is triggered and the pom is deployed so it could be used by other steps soon. As other repos needs to be adjusted to use the new master, a build is skipped in this case as this can't work anyways...