### PR TITLE
Add a workflow to prepare the next release cycle

### DIFF
--- a/.github/workflows/prepareRelease.yml
+++ b/.github/workflows/prepareRelease.yml
@@ -1,0 +1,43 @@
+name: Prepare Next Release
+on:
+  milestone:
+    types: [created]
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    if: contains(github.event.milestone.description, 'Release')
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+    - id: get-release-name
+      run: |
+        name=$(echo ${{ github.event.milestone.due_on }} | cut -d- -f-2)
+        echo "name=$name" >> $GITHUB_OUTPUT
+    - uses: actions/checkout@v3
+      with:
+        ref: master
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Update Main Versions
+      run: mvn -U -ntp -f eclipse-platform-parent org.eclipse.tycho:tycho-versions-plugin:4.0.0-SNAPSHOT:set-version -DnewVersion=${{ github.event.milestone.title }}.0-SNAPSHOT -Dmodules=../eclipse.platform.releng.prereqs.sdk
+    - name: Update Release Versions
+      run: mvn -ntp -f eclipse-platform-parent/pom.xml --non-recursive org.eclipse.tycho:tycho-versions-plugin:4.0.0-SNAPSHOT:set-property -Dproperties=releaseNumberSDK,releaseNumberPlatform,releaseName -DnewReleaseName=${{ steps.get-release-name.outputs.name }} -DnewReleaseNumberSDK=${{ github.event.milestone.title }} -DnewReleaseNumberPlatform=${{ github.event.milestone.title }}
+    - name: Create Pull Request for Release ${{ github.event.milestone.title }}
+      uses: peter-evans/create-pull-request@v4
+      with:
+        commit-message: Prepare Release ${{ github.event.milestone.title }}
+        branch: prepare_R${{ github.event.milestone.title }}
+        title: Prepare Release ${{ github.event.milestone.title }}
+        body: A new Release Milstone was created, please review the changes and merge if appropriate.
+        delete-branch: true
+        milestone: ${{ github.event.milestone.number }}
+        add-paths: |
+            eclipse-platform-parent/pom.xml
+            eclipse.platform.releng.prereqs.sdk/pom.xml
+


### PR DESCRIPTION
This workflow is triggered by the milestone creation and automatically performs the updates of the master pom and target to be prepared for usage in the submodules and creates a PR. This PR will then trigger the deploy of the changed xmls, so it can be used immediately to adjust the sub-projects.

FYI @akurtakov @sravanlakkimsetti this is the workflow mentioned here:
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/875

It then creates a PR automatically once the milestone is created and the description of the milestone includes "Release" in the description like this:
- https://github.com/laeubi/eclipse.platform.releng.aggregator/pull/7

If you agree, I'd like to merge this (together with the Jenkins file) and create a new milestone 4.28 in this repository (we can delete it afterwards before the final milestone creation script runs) so I can prototype and verify an automated update for e.g. the eclipse.platform sub repo.

There are two things to improve:
- `releaseName` is not updated automatically, but it is only used on two places in platform repo, I'm working on that part and probably push an update here soon
- `previous-release.baseline` can not be automatically derived as it includes a timestamp, my idea would be that there will be a link that is more script friendly, e.g `https://download.eclipse.org/eclipse/updates/4.26/baseline/` (instead of currently used https://download.eclipse.org/eclipse/updates/4.26/R-4.26-202211231800/) would this be possible?