### PR TITLE
Removes eclipse.platform.ui.tools from aggregator build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -53,6 +53,3 @@
 [submodule "rt.equinox.p2"]
   path = rt.equinox.p2
   url = https://github.com/eclipse-equinox/p2.git
-[submodule "eclipse.platform.ui.tools"]
-  path = eclipse.platform.ui.tools
-  url = https://github.com/eclipse-platform/eclipse.platform.ui.tools.git

--- a/cje-production/streams/repositories_master.txt
+++ b/cje-production/streams/repositories_master.txt
@@ -17,4 +17,3 @@ eclipse.platform.swt.binaries: master
 eclipse.platform.text: master
 eclipse.platform.ua: master
 eclipse.platform.ui: master
-eclipse.platform.ui.tools: master

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
     <module>eclipse.platform.swt.binaries</module>
     <module>eclipse.platform.text</module>
     <module>eclipse.platform.ua</module>
-    <module>eclipse.platform.ui.tools</module>
 
     <module>equinox</module>
     <module>rt.equinox.p2</module>


### PR DESCRIPTION
eclipse.platform.ui.tools was merged into eclipse.platform.ui so we can remove it from the aggregator build.