### PR TITLE
Add biz.aQute.repository to the target for usage by PDE

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -570,6 +570,16 @@
 				  <artifactId>biz.aQute.bnd.annotation</artifactId>
 				  <version>6.4.0</version>
   			  </dependency>
+  			  <dependency>
+				  <groupId>biz.aQute.bnd</groupId>
+				  <artifactId>biz.aQute.repository</artifactId>
+				  <version>6.4.0</version>
+  			  </dependency>
+  			  <dependency>
+				  <groupId>biz.aQute.bnd</groupId>
+				  <artifactId>biz.aQute.bnd.embedded-repo</artifactId>
+				  <version>6.4.0</version>
+  			  </dependency>
 		  </dependencies>
 	  </location>
 	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="Reddeer Deps" missingManifest="error" type="Maven">


### PR DESCRIPTION
Contains some useful bnd-plugins to read repositories ... as I plan to enhance BND support in PDE this will be required then.