### PR TITLE
Cleanup approved API changes

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list.txt
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list.txt
@@ -1,4 +1,4 @@
-# List of approved API changes after 4.26 RC1
+# List of approved API changes after 4.27 RC2
 
 # The unapproved entry exclude list can be copied from <build>/buildlogs/mb080_publish-eclipse_output.txt
 # Search for: Potential exclude list:


### PR DESCRIPTION
None but changing the version for the sake of readability although I believe this is useless step nowadays.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/941