### PR TITLE
Remove SWT-Natives build step from I/Y-builds pipelines

### DIFF
--- a/JenkinsJobs/Builds/I_build.groovy
+++ b/JenkinsJobs/Builds/I_build.groovy
@@ -230,11 +230,6 @@ spec:
                 }
             }
         }
-	  stage('Swt build input') {
-	      steps {
-	          build 'SWT-Increment_if_needed'
-	      }
-	    }
 	  stage('Create Base builder'){
           steps {
               container('jnlp') {

--- a/JenkinsJobs/YBuilds/Y_build.groovy
+++ b/JenkinsJobs/YBuilds/Y_build.groovy
@@ -225,11 +225,6 @@ spec:
                 }
             }
         }
-	  stage('Swt build input') {
-	      steps {
-	          build 'SWT-Increment_if_needed'
-	      }
-	    }
 	  stage('Create Base builder'){
           steps {
               container('jnlp') {


### PR DESCRIPTION
With https://github.com/eclipse-platform/eclipse.platform.swt/pull/514 SWT-natives are build as part of the SWT master-branch build.

@SDawley I'm not sure if it is sufficient to change the scripts here or if they have to be deployed to the Releng Jenkins in order to take effect? Are there more places that have to be adjusted?