### PR TITLE
Add o.e.pde.spies feature to eclipse/updates repo

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
@@ -40,6 +40,8 @@
    <feature id="org.eclipse.ecf.filetransfer.httpclient5.feature.source" version="0.0.0"/>
    <feature id="org.eclipse.ecf.filetransfer.ssl.feature" version="0.0.0"/>
    <feature id="org.eclipse.ecf.filetransfer.ssl.feature.source" version="0.0.0"/>
+   <feature id="org.eclipse.pde.spies"/>
+   <feature id="org.eclipse.pde.spies.source"/>
    <bundle id="org.eclipse.jdt.core.compiler.batch" version="0.0.0"/>
    <bundle id="org.eclipse.e4.ui.progress"/>
    <bundle id="org.eclipse.e4.ui.progress.source"/>


### PR DESCRIPTION
With https://github.com/eclipse-pde/eclipse.pde/pull/479 the PDE-spies have been moved into a dedicated feature, which has to be added to the eclipse/updates p2-repo.

Can anybody verify that with this change the new feature ends up in the next I-builds repo at https://download.eclipse.org/eclipse/updates/4.28-I-builds ?

I don't think we should add it to the o.e.sdk feature.