### PR TITLE
Use JavaSE-17 EE for eclipserun tycho plugin

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -397,7 +397,7 @@
           <!-- this is actually present in any 0.14+ version -->
           <version>${tycho.version}</version>
           <configuration>
-            <executionEnvironment>JavaSE-11</executionEnvironment>
+            <executionEnvironment>JavaSE-17</executionEnvironment>
             <repositories>
               <repository>
                 <id>eclipse</id>


### PR DESCRIPTION
Preliminary step for Eclipse requiring Java 17 for 2023-06 release