### PR TITLE
Remove Ubuntu 18/20 from aggregator scripts too

### DIFF
--- a/cje-production/dockerfiles/buildDockerImages.sh
+++ b/cje-production/dockerfiles/buildDockerImages.sh
@@ -30,16 +30,6 @@ echo "Building Centos 8 docker image"
 docker build --pull -t eclipse/platformreleng-centos-gtk3-metacity:8 .
 popd
 
-pushd ubuntu-gtk3-metacity/18.04-gtk3
-echo "Building Ubuntu 18.04 docker image"
-docker build --pull -t eclipse/platformreleng-ubuntu-gtk3-metacity:18.04 .
-popd
-
-pushd ubuntu-gtk3-metacity/20.04-gtk3
-echo "Building Ubuntu 20.04 docker image"
-docker build --pull -t eclipse/platformreleng-ubuntu-gtk3-metacity:20.04 .
-popd
-
 pushd ubuntu-gtk3-metacity/22.04-gtk3
 echo "Building Ubuntu 22.04 docker image"
 docker build --pull -t eclipse/platformreleng-ubuntu-gtk3-metacity:22.04 .

--- a/cje-production/dockerfiles/pushDockerImages.sh
+++ b/cje-production/dockerfiles/pushDockerImages.sh
@@ -18,6 +18,4 @@ set -e
 docker push eclipse/platformreleng-centos-gtk3-metacity:8
 docker push eclipse/platformreleng-centos-gtk3-metacity:7
 docker push eclipse/platformreleng-centos-swt-build:8
-docker push eclipse/platformreleng-ubuntu-gtk3-metacity:18.04
-docker push eclipse/platformreleng-ubuntu-gtk3-metacity:20.04
 docker push eclipse/platformreleng-ubuntu-gtk3-metacity:22.04


### PR DESCRIPTION
Missed in previous patch