### PR TITLE
Move 'tycho-apitools-plugin:generate' execution to build/plugins section

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -388,6 +388,22 @@
          </execution>
        </executions>
      </plugin>
+     <plugin>
+       <groupId>org.eclipse.tycho</groupId>
+       <artifactId>tycho-apitools-plugin</artifactId>
+       <version>${tycho.version}</version>
+       <executions>
+         <execution>
+           <id>generate</id>
+           <goals>
+             <goal>generate</goal>
+           </goals>
+           <configuration>
+             <projectName>${project.artifactId}_${qualifiedVersion}</projectName>
+           </configuration>
+         </execution>
+       </executions>
+     </plugin>
     </plugins>
     <pluginManagement>
       <plugins>
@@ -761,37 +777,6 @@
           <layout>p2</layout>
         </repository>
       </repositories>
-    </profile>
-    <profile>
-      <id>api-generation</id>
-      <activation>
-        <!-- Does it have to be a profile if we can evaluate condition reliably in antrun? -->
-        <file><exists>META-INF/MANIFEST.MF</exists></file>
-        <property>
-          <name>!longnotexistingproperty</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-			<plugin>
-	            <groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-apitools-plugin</artifactId>
-	            <version>${tycho.version}</version>
-				<executions>
-					<execution>
-						<id>generate</id>
-						<goals>
-							<goal>generate</goal>
-						</goals>
-						<configuration>
-                  			<skip>${skipAPIDescription}</skip>
-                  			<projectName>${project.artifactId}_${qualifiedVersion}</projectName>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-        </plugins>
-      </build>
     </profile>
     <profile>
        <id>api-check</id>


### PR DESCRIPTION
The `tycho-apitools-plugin:generate` mojo already checks if a project has a manifest file and if not silently skips its execution. Therefore it is not necessary to guard it with a profile activated with the condition 
`<file><exists>META-INF/MANIFEST.MF</exists></file>`.
Mojo code:
https://github.com/eclipse-tycho/tycho/blob/757d125589b36f68bd553db9140803ad8c9bcef1/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiFileGenerationMojo.java#L85-L86


See also https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/973.

From the discussion in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/419#issuecomment-1246575930 I wonder if the generate-mojo should skip its execution if the .project files does not have the `org.eclipse.pde.api.tools.apiAnalysisNature` nature.