### PR TITLE
Update the Eclipse SDK TP's slf4j-api to 2.0.7 and remove 1.7 version

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -32,7 +32,7 @@
       <unit id="org.apache.lucene.core.source" version="9.4.2.v20221211-0752"/>
       <unit id="org.apache.lucene.analysis-smartcn.source" version="9.4.2.v20221211-0752"/>
       <unit id="org.apache.lucene.analysis-common.source" version="9.4.2.v20221211-0752"/>
-      
+
       <unit id="org.hamcrest.core" version="1.3.0.v20180420-1519"/>
       <unit id="org.hamcrest.core.source" version="1.3.0.v20180420-1519"/>
 
@@ -200,15 +200,20 @@
 			  <dependency>
 				  <groupId>org.slf4j</groupId>
 				  <artifactId>slf4j-api</artifactId>
-				  <version>1.7.36</version>
+				  <version>2.0.7</version>
 				  <type>jar</type>
 			  </dependency>
 			  <!-- slf4j-api requires 1 impl, providing a dummy one... -->
 			  <dependency>
 				  <groupId>org.slf4j</groupId>
 				  <artifactId>slf4j-nop</artifactId>
-				  <version>1.7.36</version>
+				  <version>2.0.7</version>
 				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>org.apache.aries.spifly</groupId>
+				  <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
+				  <version>1.3.6</version>
 			  </dependency>
 			  <dependency>
 				  <groupId>org.tukaani</groupId>
@@ -241,11 +246,6 @@
 					<groupId>commons-io</groupId>
 					<artifactId>commons-io</artifactId>
 					<version>2.11.0</version>
-				</dependency>
-				<dependency>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-api</artifactId>
-					<version>2.0.6</version>
 				</dependency>
 		  </dependencies>
 	  </location>


### PR DESCRIPTION
Since version 2.0.7 the slf4j.api bundle exports the user-api package 'org.slf4j' in version 2.x.y and 1.7.36.
This allows to also use libraries, which are programmed against slf4j-1 and import the package 'org.slf4j' with an exclusive upper bound of 2 like '[1.7,2)', with the slf4-api version 2 in OSGi environments.

According to SLF4J the client/user facing API is compatible with slf4j-1:
- https://www.slf4j.org/faq.html#changesInVersion200
- https://www.slf4j.org/faq.html#compatibility

Only the logging-backends/bindings/providers have match the requirements of the specific slf4j version.

The corresponding SLF4J issue and change is
- https://jira.qos.ch/browse/SLF4J-579
- https://github.com/qos-ch/slf4j/pull/331

Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/588
Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/682