### PR TITLE
Revert "Add o.e.pde.spies feature to eclipse/updates repo"

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
@@ -40,8 +40,6 @@
    <feature id="org.eclipse.ecf.filetransfer.httpclient5.feature.source" version="0.0.0"/>
    <feature id="org.eclipse.ecf.filetransfer.ssl.feature" version="0.0.0"/>
    <feature id="org.eclipse.ecf.filetransfer.ssl.feature.source" version="0.0.0"/>
-   <feature id="org.eclipse.pde.spies"/>
-   <feature id="org.eclipse.pde.spies.source"/>
    <bundle id="org.eclipse.jdt.core.compiler.batch" version="0.0.0"/>
    <bundle id="org.eclipse.e4.ui.progress"/>
    <bundle id="org.eclipse.e4.ui.progress.source"/>


### PR DESCRIPTION
Reverts eclipse-platform/eclipse.platform.releng.aggregator#951

With https://github.com/eclipse-platform/eclipse.platform.releng/pull/212 the new pde.spies feature is included in the `o.e.sdk` and therefore is transitively included into the eclipse-sdk repo.