### PR TITLE
Unify the platform workflow by defining reusable workflows

### DIFF
--- a/.github/matcher/api-tools.json
+++ b/.github/matcher/api-tools.json
@@ -1,0 +1,16 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "api-problems",
+      "pattern": [
+        {
+          "regexp": "^\\[API\\s(\\w+)\\].*line\\s(\\d+):\\s(.+)\\(location:\\s(.+)\\)$",
+          "severity": 1,
+          "line": 2,
+          "message": 3,
+          "file": 4
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/README.MD
+++ b/.github/workflows/README.MD
@@ -13,3 +13,20 @@ Workflow that can be used to trigger an automatic update to the next release whe
 ## checkMergeCommits.yml
 
 Check if a PR contains unwanted merge commits.
+
+## publishTestResults.yml
+
+Publish the test results of a ci action.
+
+It has the follwoing inputs:
+
+- gist-url - if given creates a badge to publish the test results
+- gist-file - if a gist-url is given, this can control the name of the created file, defaults to badge.svg
+
+If a gist-url is given it requires the follwoing secret:
+
+- gist-token - the token for the gist, must be requested with the eclipse help-desk to be added as a secret to the repository
+
+## mavenBuild.yml
+
+A unified maven matrix build that covers the usual workflow for a build verification of a platform repository.

--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -1,0 +1,72 @@
+name: Maven Build
+on:
+  workflow_call:
+    inputs:
+      maven-goals:
+        description: maven goals to use, defaults to 'clean verify'
+        required: false
+        default: 'clean verify'
+        type: string
+
+permissions: {}
+
+jobs:
+  event_file:
+    name: "Upload Event File"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload
+      uses: actions/upload-artifact@v3
+      with:
+        name: Event File
+        path: ${{ github.event_path }}
+  build:
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config: 
+          - { name: Linux,   os: ubuntu-latest  }
+          - { name: Windows, os: windows-latest }
+          - { name: MacOS,   os: macos-latest   }
+    name: Verify ${{ matrix.config.name }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+       fetch-depth: 0 # required for jgit timestamp provider to work
+    - name: Set up Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: |
+          8
+          11
+          17
+        distribution: 'temurin'
+        cache: maven
+    - name: Download the API Tools matcher
+      uses: suisei-cn/actions-download-file@v1.3.0
+      id: api-tools-matcher
+      with:
+        url: "https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.releng.aggregator/master/.github/matcher/api-tools.json"
+        target: .github/matcher
+    - run: echo "::add-matcher::.github/matcher/${{ steps.api-tools-matcher.outputs.filename }}"
+    - name: Build with Maven
+      uses: coactions/setup-xvfb@v1
+      with:
+       run: >- 
+        mvn --batch-mode -V -U
+        -ntp
+        -Dcompare-version-with-baselines.skip=false
+        -Pbree-libs
+        -Papi-check
+        --fail-at-end
+        ${{ inputs.maven-goals }}
+    - name: Upload Test Results for ${{ matrix.config.name }}
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-results-${{ matrix.config.native }}-java${{ matrix.java }}
+        if-no-files-found: warn
+        path: |
+          ${{ github.workspace }}/**/target/surefire-reports/*.xml

--- a/.github/workflows/publishTestResults.yml
+++ b/.github/workflows/publishTestResults.yml
@@ -1,0 +1,90 @@
+name: Publish Test Results
+on:
+  workflow_call:
+    inputs:
+      gist-url:
+        description: passing an url to the gist where results should be published as a badge
+        required: false
+        default: ''
+        type: string
+      gist-file:
+        description: passing the name of the gist file to update, defaults to badge.svg
+        required: false
+        default: 'badge.svg'
+        type: string
+    secrets:
+      gist-token:
+        required: false
+
+permissions: {}
+
+jobs:
+  unit-test-results:
+    name: Publish Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: read
+      issues: read
+      actions: read
+
+    steps:
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+           mkdir -p artifacts && cd artifacts
+
+           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+           gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+           do
+             IFS=$'\t' read name url <<< "$artifact"
+             gh api $url > "$name.zip"
+             unzip -d "$name" "$name.zip"
+           done
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        id: test-results
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "artifacts/**/*.xml"
+      - name: Set badge color
+        if: github.ref == 'refs/heads/master' && inputs.config-path != ''
+        shell: bash
+        run: |
+          case ${{ fromJSON( steps.test-results.outputs.json ).conclusion }} in
+            success)
+              echo "BADGE_COLOR=31c653" >> $GITHUB_ENV
+              ;;
+            failure)
+              echo "BADGE_COLOR=800000" >> $GITHUB_ENV
+              ;;
+            neutral)
+              echo "BADGE_COLOR=696969" >> $GITHUB_ENV
+              ;;
+          esac
+
+      - name: Create badge
+        if: github.ref == 'refs/heads/master' && inputs.config-path != ''
+        uses: emibcn/badge-action@4209421db54c8764d8932070ffd0f81715a629bf
+        with:
+          label: Tests
+          status: '${{ fromJSON( steps.test-results.outputs.json ).formatted.stats.tests_succ }} passed, ${{ fromJSON( steps.test-results.outputs.json ).formatted.stats.tests_fail }} failed'
+          color: ${{ env.BADGE_COLOR }}
+          path: badge.svg
+
+      - name: Upload badge to Gist
+        if: github.ref == 'refs/heads/master' && inputs.config-path != ''
+        uses: andymckay/append-gist-action@1fbfbbce708a39bd45846f0955ed5521f2099c6d
+        with:
+          token: ${{ secrets.gist-token }}
+          gistURL: ${{ inputs.gist-url }}
+          file: ${{ inputs.gist-file }}
+
+


### PR DESCRIPTION
Currently there is a quite inconsitent mixture of ci workflows, some are outdated or use different aproaches and configs, some have no workflow defined at all.

This defines (and documents) a set of reusable workflows that can be adjusted / updated at a central place and then reused in the platform repositories.