### PR TITLE
Adjust the setup to use a specific maven version

### DIFF
--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -44,6 +44,10 @@ jobs:
           17
         distribution: 'temurin'
         cache: maven
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4.5
+      with:
+        maven-version: 3.8.8
     - name: Download the API Tools matcher
       uses: suisei-cn/actions-download-file@v1.3.0
       id: api-tools-matcher


### PR DESCRIPTION
Currently we use the maven version of the runner what could produce some confusion if different runners use different maven versions, therefore we now use a fixed maven version to install for all runners.