### PR TITLE
Investigate freeze-period check malfunction

### DIFF
--- a/.github/workflows/verifyFreezePeriod.yml
+++ b/.github/workflows/verifyFreezePeriod.yml
@@ -12,10 +12,15 @@ jobs:
       - name: Checking whether Eclipse project is currently in stabilization/code-freeze period ...
         run: |
           today=$(TZ=UTC date "+%Y-%m-%d")
+          echo $today
           tomorrow=$(TZ=UTC date -d "+1 days" "+%Y-%m-%d")
+          echo $tomorrow
           calId="calendarId=prfk26fdmpru1mptlb06p0jh4s@group.calendar.google.com"
           calURL="https://clients6.google.com/calendar/v3/calendars/group.calendar.google.com/events?${calId}&singleEvents=true&timeZone=UTC&maxResults=250&sanitizeHtml=true&timeMin=${today}T00:00:00Z&timeMax=${tomorrow}T00:00:00Z&key=AIzaSyBNlYH01_9Hc5S1J9vuFmu2nUqBZJNAXxs"
+          echo $calURL
           echo "Querying calendar https://calendar.google.com/calendar/u/0/r?cid=${calId}"
+          echo "curl return"
+          echo $(curl "${calURL}")
           curl "${calURL}" | grep -i -e "stabilization" -e "signoff" -e "promotion"
           if [[ $? == 0 ]]; then
             echo "::error::Today is a freeze day"


### PR DESCRIPTION
At the moment the freez-period check workflow does not fail and indicates that there is no freeze period although we are actually in that time.
To me it is unclear why the workflow succeeds at the moment. This PR is to investigate the cause and eventually fix it.