### PR TITLE
Fix tag definition and make the build more quiet

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -1031,6 +1031,7 @@
 					<configuration>
 						<source>${java.version}</source>
 						<failOnError>false</failOnError>
+						<quiet>true</quiet>
 						<doclint>reference,html,syntax</doclint>
 						<links>
 							<link>https://docs.osgi.org/javadoc/osgi.core/8.0.0/</link>
@@ -1066,22 +1067,22 @@
 							<tag>
 								<name>TrackedGetter</name>
 								<placement>cm</placement>
-								<head>"TrackedGetter"</head>
+								<head>TrackedGetter</head>
 							</tag>
 							<tag>
 								<name>model</name>
 								<placement>X</placement>
-								<head>"EMF generated tag"</head>
+								<head>EMF generated tag</head>
 							</tag>
 							<tag>
 								<name>generated</name>
 								<placement>X</placement>
-								<head>"EMF generated tag"</head>
+								<head>EMF generated tag</head>
 							</tag>
 							<tag>
 								<name>ordered</name>
 								<placement>X</placement>
-								<head>"EMF generated tag"</head>
+								<head>EMF generated tag</head>
 							</tag>
 							<tag>
 								<name>Immutable</name>


### PR DESCRIPTION
Since the transition to Java 17 certain things previously handled as a warning are now hard errors in the javadoc tool what currently makes the javadoc profile quite unusable.

