### PR TITLE
Update cbi-ecj-version from M1

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -86,7 +86,7 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cbi-jdt-repo.url>https://repo.eclipse.org/content/repositories/eclipse-staging/</cbi-jdt-repo.url>
-    <cbi-ecj-version>3.33.0.v20230218-1114</cbi-ecj-version>
+    <cbi-ecj-version>3.34.0.v20230405-0323</cbi-ecj-version>
 
     <!--
       Production bundles are produced by ignoring the compiler warnings specified


### PR DESCRIPTION
Current Version :
org.eclipse.jdt.core.compiler.batch_3.34.0.v20230405-0323