### PR TITLE
Mention reopening of the master branch after freeze week

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -62,6 +62,7 @@
          - Parameters should match Rename and Promote job
        * Send email that the M1 build is available
          - Use the mail template from the promotion build [artifacts](https://ci.eclipse.org/releng/job/eclipse.releng.renameAndPromote/lastSuccessfulBuild/artifact/) in Jenkins to get the download urls.
+         - Make sure to mention that the Master branch is now again open for development.
        * For **Milestone builds** return the I-builds to the normal schedule.
      * **Update ECJ compiler** in the platform build (if it needs to be updated).
        * To find the new compiler version:


### PR DESCRIPTION
At the moment it seems unclear when the master branches will reopen after a freeze period.
After the RC freeze period there is a dedicated mail that announces the reopening of the master branch after all preparation work has completed. As far as I understand there is no preparation work form M1 to M2 and therefore the master branch is open as as soon as M1 has been officially released/declared.
Therefore it would be good if the mail to announce the M1 release will also mention that the master branch is now open again.
In case there wont be a M1 freeze in the future this section can be removed again (https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/discussions/863).

@MohananRahul, @sravanlakkimsetti can you please check if that is correct?