### PR TITLE
Adjust the path of the results

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ git submodule update
 mvn clean verify  -DskipTests=true
 
 # find the results in
-# eclipse.platform.releng.tychoeclipsebuilder/sdk/target/products/*
+# eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/target/products
 ```
 
 Build requirements


### PR DESCRIPTION
The mentioned path in the readme does not exits and results seem to be moved under eclipse.platform.repository now.

@akurtakov can you verify this? At least for my local build I did not find the mentioned location but the proposed new one here where some products are located.