### PR TITLE
Use eclipsecbi/jiro-agent-centos-8 image instead of *-jdk11 image

### DIFF
--- a/JenkinsJobs/Builds/I_build.groovy
+++ b/JenkinsJobs/Builds/I_build.groovy
@@ -64,7 +64,7 @@ kind: Pod
 spec:
   containers:
   - name: "jnlp"
-    image: "eclipsecbi/jiro-agent-centos-8-jdk11:latest"
+    image: "eclipsecbi/jiro-agent-centos-8:latest"
     imagePullPolicy: "Always"
     resources:
       limits:

--- a/JenkinsJobs/YBuilds/P_build.groovy
+++ b/JenkinsJobs/YBuilds/P_build.groovy
@@ -40,7 +40,7 @@ kind: Pod
 spec:
   containers:
   - name: "jnlp"
-    image: "eclipsecbi/jiro-agent-centos-8-jdk11:latest"
+    image: "eclipsecbi/jiro-agent-centos-8:latest"
     imagePullPolicy: "Always"
     resources:
       limits:

--- a/JenkinsJobs/YBuilds/Y_build.groovy
+++ b/JenkinsJobs/YBuilds/Y_build.groovy
@@ -60,7 +60,7 @@ kind: Pod
 spec:
   containers:
   - name: "jnlp"
-    image: "eclipsecbi/jiro-agent-centos-8-jdk11:latest"
+    image: "eclipsecbi/jiro-agent-centos-8:latest"
     imagePullPolicy: "Always"
     resources:
       limits:


### PR DESCRIPTION
The `eclipsecbi/jiro-agent-centos-8-jdk11` image is no longer supported and uses an outdated remoting version. It was only used to test for regressions before the `eclipsecbi/jiro-agent-centos-8` image was switched to JDK11 by default.

Please also fix this in any other repo that still uses the `eclipsecbi/jiro-agent-centos-8-jdk11` image.