### PR TITLE
Remove Java 20 test run post

### DIFF
--- a/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3_java20.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3_java20.groovy
@@ -160,20 +160,6 @@ spec:
           }
       }
   }
-  post {
-    failure {
-      emailext body: "Please go to <a href='${BUILD_URL}console'>${BUILD_URL}console</a> and check the build failure.<br><br>",
-      subject: "Java 20 Tests - BUILD FAILED", 
-      to: "akurtako@redhat.com","rahul.mohanan@ibm.com"
-      from:"genie.releng@eclipse.org"
-    }
-    success {
-      emailext body: "Link: <a href='${BUILD_URL}'>${BUILD_URL}</a> <br><br>",
-      subject: "Java 20 Tests - BUILD SUCCESS", 
-      to: "akurtako@redhat.com","rahul.mohanan@ibm.com"
-      from:"genie.releng@eclipse.org"
-    }
-	}
 }
         ''')
       }


### PR DESCRIPTION
Java 17/19 have none and what is there in this one just broke running. Tracked in
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1033