### PR TITLE
meta: upgrade jetty version (4.8)

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -186,23 +186,23 @@
          It should be updated when ever this pre-req is updated. 
     -->
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
-      <unit id="org.eclipse.jetty.continuation" version="9.4.48.v20220622"/>
-      <unit id="org.eclipse.jetty.continuation.source" version="9.4.48.v20220622"/>
-      <unit id="org.eclipse.jetty.http" version="9.4.48.v20220622"/>
-      <unit id="org.eclipse.jetty.http.source" version="9.4.48.v20220622"/>
-      <unit id="org.eclipse.jetty.io" version="9.4.48.v20220622"/>
-      <unit id="org.eclipse.jetty.io.source" version="9.4.48.v20220622"/>
-      <unit id="org.eclipse.jetty.security" version="9.4.48.v20220622"/>
-      <unit id="org.eclipse.jetty.security.source" version="9.4.48.v20220622"/>
-      <unit id="org.eclipse.jetty.server" version="9.4.48.v20220622"/>
-      <unit id="org.eclipse.jetty.server.source" version="9.4.48.v20220622"/>
-      <unit id="org.eclipse.jetty.servlet" version="9.4.48.v20220622"/>
-      <unit id="org.eclipse.jetty.servlet.source" version="9.4.48.v20220622"/>
-      <unit id="org.eclipse.jetty.util" version="9.4.48.v20220622"/>
-      <unit id="org.eclipse.jetty.util.source" version="9.4.48.v20220622"/>
-      <unit id="org.eclipse.jetty.util.ajax" version="9.4.48.v20220622"/>
-      <unit id="org.eclipse.jetty.util.ajax.source" version="9.4.48.v20220622"/>
-      <repository location="https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.48.v20220622/"/>
+      <unit id="org.eclipse.jetty.continuation" version="9.4.51.v20230217"/>
+      <unit id="org.eclipse.jetty.continuation.source" version="9.4.51.v20230217"/>
+      <unit id="org.eclipse.jetty.http" version="9.4.51.v20230217"/>
+      <unit id="org.eclipse.jetty.http.source" version="9.4.51.v20230217"/>
+      <unit id="org.eclipse.jetty.io" version="9.4.51.v20230217"/>
+      <unit id="org.eclipse.jetty.io.source" version="9.4.51.v20230217"/>
+      <unit id="org.eclipse.jetty.security" version="9.4.51.v20230217"/>
+      <unit id="org.eclipse.jetty.security.source" version="9.4.51.v20230217"/>
+      <unit id="org.eclipse.jetty.server" version="9.4.51.v20230217"/>
+      <unit id="org.eclipse.jetty.server.source" version="9.4.51.v20230217"/>
+      <unit id="org.eclipse.jetty.servlet" version="9.4.51.v20230217"/>
+      <unit id="org.eclipse.jetty.servlet.source" version="9.4.51.v20230217"/>
+      <unit id="org.eclipse.jetty.util" version="9.4.51.v20230217"/>
+      <unit id="org.eclipse.jetty.util.source" version="9.4.51.v20230217"/>
+      <unit id="org.eclipse.jetty.util.ajax" version="9.4.51.v20230217"/>
+      <unit id="org.eclipse.jetty.util.ajax.source" version="9.4.51.v20230217"/>
+      <repository location="https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.51.v20230217/"/>
     </location>
 
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">


### PR DESCRIPTION
Refs: https://github.com/eclipse/jetty.project/security/advisories/GHSA-p26g-97m4-6q7c


/cc @sravanlakkimsetti @MohananRahul 