### PR TITLE
meta: bump jetty version (4.23)

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -244,43 +244,43 @@
         <dependency>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-http</artifactId>
-          <version>10.0.11</version>
+          <version>10.0.15</version>
           <type>jar</type>
         </dependency>
         <dependency>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-io</artifactId>
-          <version>10.0.11</version>
+          <version>10.0.15</version>
           <type>jar</type>
         </dependency>
         <dependency>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-security</artifactId>
-          <version>10.0.11</version>
+          <version>10.0.15</version>
           <type>jar</type>
         </dependency>
         <dependency>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-server</artifactId>
-          <version>10.0.11</version>
+          <version>10.0.15</version>
           <type>jar</type>
         </dependency>
         <dependency>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-servlet</artifactId>
-          <version>10.0.11</version>
+          <version>10.0.15</version>
           <type>jar</type>
         </dependency>
         <dependency>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-util-ajax</artifactId>
-          <version>10.0.11</version>
+          <version>10.0.15</version>
           <type>jar</type>
         </dependency>
         <dependency>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-util</artifactId>
-          <version>10.0.11</version>
+          <version>10.0.15</version>
           <type>jar</type>
         </dependency>
       </dependencies>


### PR DESCRIPTION
Refs: https://github.com/eclipse/jetty.project/security/advisories/GHSA-p26g-97m4-6q7c

/cc @sravanlakkimsetti @MohananRahul 