### PR TITLE
Use Maven 3.9.1 in mavenBuild workflows

### DIFF
--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Set up Maven
       uses: stCarolas/setup-maven@v4.5
       with:
-        maven-version: 3.8.8
+        maven-version: 3.9.1
     - name: Download the API Tools matcher
       uses: suisei-cn/actions-download-file@v1.3.0
       id: api-tools-matcher


### PR DESCRIPTION
- Update mavenBuild workflow to use maven 3.9.1

- Ignore Maven test errors and failures in mavenBuild workflow
This allows the Maven build check itself to pass and have a green check mark in the GH UI if there are only test errors/failures. The test errors/failures themself are still reported via the 'Publish Test Results' checks that is shown as failure if there are test failures/errors. This setup simplifies to distinguish between only test errors/failures in the build and more severe failures like compilation failures.