### PR TITLE
Add javax.inject/annotation provided by Jakarta from Maven-Central and include all sources in Eclipse SDK repo

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -157,6 +157,18 @@
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
+				  <groupId>jakarta.annotation</groupId>
+				  <artifactId>jakarta.annotation-api</artifactId>
+				  <version>1.3.5</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>jakarta.inject</groupId>
+				  <artifactId>jakarta.inject-api</artifactId>
+				  <version>1.0.5</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
 				  <groupId>net.java.dev.jna</groupId>
 				  <artifactId>jna-platform</artifactId>
 				  <version>5.13.0</version>
@@ -246,12 +258,6 @@
 	  </location>
 	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="Jetty and servlet API" missingManifest="error" type="Maven">
 		  <dependencies>
-			  <dependency>
-				  <groupId>jakarta.inject</groupId>
-				  <artifactId>jakarta.inject-api</artifactId>
-				  <version>1.0.5</version>
-				  <type>jar</type>
-			  </dependency>
 			  <dependency>
 				  <groupId>jakarta.servlet</groupId>
 				  <artifactId>jakarta.servlet-api</artifactId>
@@ -399,7 +405,7 @@
 	  </location>
 	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="OSGi" missingManifest="error" type="Maven">
 		  <dependencies>
-  			  <dependency>
+			  <dependency>
 				  <groupId>org.osgi</groupId>
 				  <artifactId>org.osgi.annotation.versioning</artifactId>
 				  <version>1.1.2</version>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
@@ -46,4 +46,7 @@
    <!-- Will be removed soon, once integrated in an appropriate feature -->
    <bundle id="org.eclipse.unittest.ui"/>
    <bundle id="org.eclipse.unittest.ui.source"/>
+   <!-- Will be removed as soon as it is pulled in transitivly, when javax-bundles are removed. -->
+   <bundle id="jakarta.inject.jakarta.inject-api"/>
+   <bundle id="jakarta.annotation-api"/>
 </site>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/pom.xml
@@ -45,7 +45,8 @@
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-p2-repository-plugin</artifactId>
         <configuration>
-        	<includeAllDependencies>true</includeAllDependencies>
+          <includeAllDependencies>true</includeAllDependencies>
+          <includeAllSources>true</includeAllSources>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Use the javax namespace bundles provided by Jakarta.
Remove all javax bundles provided by Orbit.

Remove the unused javax.xml bundle, the modern JREs provide the contained packages by default.

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1056

Additionally configure the `tycho-p2-repository-plugin` to include all sources. This allows to remove the javax-bundles from containing features (see https://github.com/eclipse-platform/eclipse.platform.ui/pull/745) and at the same time to keep the main artifacts (which are pulled in as transitive dependencies) plus their sources in the created p2-repo for the Eclipse SDK.

