### PR TITLE
Remove all javax bundles provided by Eclipse-Orbit

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -7,9 +7,6 @@
         by glassfish. Should we use it? -->
       <unit id="com.jcraft.jsch" version="0.1.55.v20221112-0806"/>
       <unit id="com.jcraft.jsch.source" version="0.1.55.v20221112-0806"/>
-      <!-- Upstream Maven artifact using javax.annotation-api as bundle name, need to update customers -->
-      <unit id="javax.annotation" version="1.3.5.v20221203-1659"/>
-      <unit id="javax.annotation.source" version="1.3.5.v20221203-1659"/>
 
       <unit id="org.apache.ant" version="1.10.12.v20211102-1452"/>
       <unit id="org.apache.ant.source" version="1.10.12.v20211102-1452"/>
@@ -38,10 +35,6 @@
       
       <unit id="org.hamcrest.core" version="1.3.0.v20180420-1519"/>
       <unit id="org.hamcrest.core.source" version="1.3.0.v20180420-1519"/>
-      <unit id="javax.xml" version="1.4.1.v20220503-2331"/>
-      <!-- To remove when all features/bundles move to Import-Package or jakarta.inject -->
-      <unit id="javax.inject" version="1.0.0.v20220405-0441"/>
-      <unit id="javax.inject.source" version="1.0.0.v20220405-0441"/>
 
       <!-- This is the "normal" Orbit repository. During development on Bug 568936 this repo is the EBR (git)
            sourced bundles of Orbit from 2022-06. This is the sub-p2-repo of the 2022-06 recommended build.

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
@@ -46,7 +46,4 @@
    <!-- Will be removed soon, once integrated in an appropriate feature -->
    <bundle id="org.eclipse.unittest.ui"/>
    <bundle id="org.eclipse.unittest.ui.source"/>
-   <!-- Will be removed as soon as it is pulled in transitivly, when javax-bundles are removed. -->
-   <bundle id="jakarta.inject.jakarta.inject-api"/>
-   <bundle id="jakarta.annotation-api"/>
 </site>


### PR DESCRIPTION
Follow up on https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1057 to remove the now unused javax.xml bundle, the modern JREs provide the contained packages by default.

Also revert explicit inclusion of jakarta.inject/annotation bundles in eclipse.platform.repository, because they will be transitively included from now on.

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1056

This probably requires the currently running I-build to succeed first (see https://github.com/eclipse-platform/eclipse.platform.common/pull/145#issuecomment-1535932554).
