### PR TITLE
Update Apache SSHD OSGi to 2.10.0

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -176,7 +176,7 @@
 			  <dependency>
 				  <groupId>org.apache.sshd</groupId>
 				  <artifactId>sshd-osgi</artifactId>
-				  <version>2.9.2</version>
+				  <version>2.10.0</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>


### PR DESCRIPTION
Required for https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/981.

@tomaswolf FYI