### PR TITLE
Update ECF to 3.14.38

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -90,18 +90,18 @@
     </location>
 
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
-      <unit id="org.eclipse.ecf.core.feature.feature.group" version="1.6.1.v20211005-1944"/>
-      <unit id="org.eclipse.ecf.core.feature.source.feature.group" version="1.6.1.v20211005-1944"/>
-      <unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="1.1.501.v20210409-2301"/>
-      <unit id="org.eclipse.ecf.core.ssl.feature.source.feature.group" version="1.1.501.v20210409-2301"/>
-      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.14.1800.v20220215-0126"/>
-      <unit id="org.eclipse.ecf.filetransfer.feature.source.feature.group" version="3.14.1800.v20220215-0126"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" version="1.1.701.v20221112-0806"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.source.feature.group" version="1.1.701.v20221112-0806"/>
-      <unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.1.401.v20210409-2301"/>
-      <unit id="org.eclipse.ecf.filetransfer.ssl.feature.source.feature.group" version="1.1.401.v20210409-2301"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclientjava.feature.feature.group" version="1.0.0.v20221113-0354"/>
-      <repository location="https://download.eclipse.org/rt/ecf/3.14.37/site.p2/3.14.37.v20221119-2038/"/>
+      <unit id="org.eclipse.ecf.core.feature.feature.group" version="1.6.1.v20230507-1923"/>
+      <unit id="org.eclipse.ecf.core.feature.source.feature.group" version="1.6.1.v20230507-1923"/>
+      <unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="1.1.501.v20230507-1921"/>
+      <unit id="org.eclipse.ecf.core.ssl.feature.source.feature.group" version="1.1.501.v20230507-1921"/>
+      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.14.1800.v20230422-0242"/>
+      <unit id="org.eclipse.ecf.filetransfer.feature.source.feature.group" version="3.14.1800.v20230422-0242"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" version="1.1.701.v20230423-0417"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.source.feature.group" version="1.1.701.v20230423-0417"/>
+      <unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.1.401.v20230422-0242"/>
+      <unit id="org.eclipse.ecf.filetransfer.ssl.feature.source.feature.group" version="1.1.401.v20230422-0242"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclientjava.feature.feature.group" version="1.0.0.v20230423-0417"/>
+      <repository location="https://download.eclipse.org/rt/ecf/3.14.38/site.p2/3.14.38.v20230507-1923/"/>
     </location>
 
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">


### PR DESCRIPTION
Fix for both eclipse/ecf#26 and eclipse/ecf#27 are included in 3.14.38.

Tracked in
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/997