### PR TITLE
Update ECJ to RC1 version from I20230524-0600 (same as I202305250350)

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -86,7 +86,7 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cbi-jdt-repo.url>https://repo.eclipse.org/content/repositories/eclipse-staging/</cbi-jdt-repo.url>
-    <cbi-ecj-version>3.34.0.v20230516-0809</cbi-ecj-version>
+    <cbi-ecj-version>3.34.0.v20230523-1233</cbi-ecj-version>
 
     <!--
       Production bundles are produced by ignoring the compiler warnings specified


### PR DESCRIPTION
This version contains ECJ changes made after M3 build, no other ECJ changes are planned as of today.