### PR TITLE
Updated build paths in scripts to use Java 17

### DIFF
--- a/JenkinsJobs/Builds/AddToPComposite.groovy
+++ b/JenkinsJobs/Builds/AddToPComposite.groovy
@@ -17,7 +17,7 @@ for (STREAM in STREAMS){
       numToKeep(5)
     }
 
-    jdk('openjdk-jdk11-latest')
+    jdk('openjdk-jdk17-latest')
 
     wrappers { //adds pre/post actions
       timestamps()
@@ -68,7 +68,7 @@ for (STREAM in STREAMS){
 
         #triggering ant runner
         baseBuilderDir=${workspace}/eclipse
-        javaCMD=/opt/public/common/java/openjdk/jdk-11_x64-latest/bin/java
+        javaCMD=/opt/public/common/java/openjdk/jdk-17_x64-latest/bin/java
 
         launcherJar=$(ssh genie.releng@projects-storage.eclipse.org find ${baseBuilderDir}/. -name "org.eclipse.equinox.launcher_*.jar" | sort | head -1 )
 

--- a/JenkinsJobs/Builds/markStable.groovy
+++ b/JenkinsJobs/Builds/markStable.groovy
@@ -13,7 +13,7 @@ job('Builds/markStable'){
     numToKeep(5)
   }
 
-  jdk('openjdk-jdk11-latest')
+  jdk('openjdk-jdk17-latest')
 
   wrappers { //adds pre/post actions
     timestamps()
@@ -61,7 +61,7 @@ job('Builds/markStable'){
 
       #triggering ant runner
       baseBuilderDir=${workspace}/eclipse
-      javaCMD=/opt/public/common/java/openjdk/jdk-11_x64-latest/bin/java
+      javaCMD=/opt/public/common/java/openjdk/jdk-17_x64-latest/bin/java
 
       launcherJar=$(ssh genie.releng@projects-storage.eclipse.org find ${baseBuilderDir}/. -name "org.eclipse.equinox.launcher_*.jar" | sort | head -1 )
 

--- a/JenkinsJobs/Builds/markUnstable.groovy
+++ b/JenkinsJobs/Builds/markUnstable.groovy
@@ -15,7 +15,7 @@ job('Builds/markUnstable'){
     numToKeep(5)
   }
 
-  jdk('openjdk-jdk11-latest')
+  jdk('openjdk-jdk17-latest')
 
   wrappers { //adds pre/post actions
     timestamps()
@@ -66,7 +66,7 @@ job('Builds/markUnstable'){
 
       #triggering ant runner
       baseBuilderDir=${workspace}/eclipse
-      javaCMD=/opt/public/common/java/openjdk/jdk-11_x64-latest/bin/java
+      javaCMD=/opt/public/common/java/openjdk/jdk-17_x64-latest/bin/java
 
       launcherJar=$(ssh genie.releng@projects-storage.eclipse.org find ${baseBuilderDir}/. -name "org.eclipse.equinox.launcher_*.jar" | sort | head -1 )
 

--- a/JenkinsJobs/Releng/collectPerfResults.groovy
+++ b/JenkinsJobs/Releng/collectPerfResults.groovy
@@ -39,6 +39,7 @@ set -e
 buildID=$(echo $buildID|tr -d ' ')
 buildURL=$(echo $buildURL|tr -d ' ')
 triggeringJob=$(echo $triggeringJob|tr -d ' ')
+java_home=/opt/public/common/java/openjdk/jdk-17_x64-latest/bin
 
 wget -O ${WORKSPACE}/buildproperties.shsource --no-check-certificate http://download.eclipse.org/eclipse/downloads/drops4/${buildID}/buildproperties.shsource
 cat ${WORKSPACE}/buildproperties.shsource
@@ -60,7 +61,7 @@ ssh genie.releng@projects-storage.eclipse.org mkdir -p ${workspace}
 epRelDir=$(ssh genie.releng@projects-storage.eclipse.org ls -d --format=single-column ${dropsPath}/R-*|sort|tail -1)
 ssh genie.releng@projects-storage.eclipse.org tar -C ${workspace} -xzf ${epRelDir}/eclipse-platform-*-linux-gtk-x86_64.tar.gz
 
-ssh genie.releng@projects-storage.eclipse.org PATH=/opt/tools/java/openjdk/jdk-17/17/bin:$PATH ${workspace}/eclipse/eclipse -nosplash \\
+ssh genie.releng@projects-storage.eclipse.org PATH=${java_home}:$PATH ${workspace}/eclipse/eclipse -nosplash \\
   -debug -consolelog -data ${workspace}/workspace-toolsinstall \\
   -application org.eclipse.equinox.p2.director \\
   -repository ${ECLIPSE_RUN_REPO},${BUILDTOOLS_REPO},${WEBTOOLS_REPO} \\
@@ -82,7 +83,7 @@ cd ${WORKSPACE}
 
 #triggering ant runner
 baseBuilderDir=${workspace}/basebuilder
-javaCMD=/opt/public/common/java/openjdk/jdk-17_x64-latest/bin/java
+javaCMD=${java_home}/java
 
 launcherJar=$(ssh genie.releng@projects-storage.eclipse.org find ${baseBuilderDir}/. -name "org.eclipse.equinox.launcher_*.jar" | sort | head -1 )
 

--- a/JenkinsJobs/Releng/collectResults.groovy
+++ b/JenkinsJobs/Releng/collectResults.groovy
@@ -15,7 +15,7 @@ job('Releng/ep-collectResults'){
     numToKeep(10)
   }
 
-  jdk('openjdk-jdk11-latest')
+  jdk('openjdk-jdk17-latest')
 
   authenticationToken('collectResults')
 
@@ -40,6 +40,8 @@ buildID=$(echo $buildID|tr -d ' ')
 buildURL=$(echo $buildURL|tr -d ' ')
 triggeringJob=$(echo $triggeringJob|tr -d ' ')
 
+java_home=/opt/public/common/java/openjdk/jdk-17_x64-latest/bin
+
 wget -O ${WORKSPACE}/buildproperties.shsource --no-check-certificate http://download.eclipse.org/eclipse/downloads/drops4/${buildID}/buildproperties.shsource
 cat ${WORKSPACE}/buildproperties.shsource
 source ${WORKSPACE}/buildproperties.shsource
@@ -62,7 +64,7 @@ ssh genie.releng@projects-storage.eclipse.org cd ${workspace}
 epRelDir=$(ssh genie.releng@projects-storage.eclipse.org ls -d --format=single-column ${dropsPath}/R-*|sort|tail -1)
 ssh genie.releng@projects-storage.eclipse.org tar -C ${workspace} -xzf ${epRelDir}/eclipse-platform-*-linux-gtk-x86_64.tar.gz
 
-ssh genie.releng@projects-storage.eclipse.org PATH=/opt/tools/java/openjdk/jdk-17/17/bin:$PATH ${workspace}/eclipse/eclipse -nosplash \\
+ssh genie.releng@projects-storage.eclipse.org PATH=${java_home}:$PATH ${workspace}/eclipse/eclipse -nosplash \\
   -debug -consolelog -data ${workspace}/workspace-toolsinstall \\
   -application org.eclipse.equinox.p2.director \\
   -repository ${ECLIPSE_RUN_REPO},${BUILDTOOLS_REPO},${WEBTOOLS_REPO} \\
@@ -85,7 +87,7 @@ cd ${WORKSPACE}
 
 #triggering ant runner
 baseBuilderDir=${workspace}/basebuilder
-javaCMD=/opt/public/common/java/openjdk/jdk-17_x64-latest/bin/java
+javaCMD=${java_home}/java
 
 launcherJar=$(ssh genie.releng@projects-storage.eclipse.org find ${baseBuilderDir}/. -name "org.eclipse.equinox.launcher_*.jar" | sort | head -1 )
 

--- a/JenkinsJobs/YBuilds/collectYbuildResults.groovy
+++ b/JenkinsJobs/YBuilds/collectYbuildResults.groovy
@@ -15,7 +15,7 @@ job('YPBuilds/ep-collectYbuildResults'){
     numToKeep(10)
   }
 
-  jdk('openjdk-jdk11-latest')
+  jdk('openjdk-jdk17-latest')
 
   authenticationToken('collectResults')
 
@@ -42,6 +42,7 @@ job('YPBuilds/ep-collectYbuildResults'){
 buildID=$(echo $buildID|tr -d ' ')
 buildURL=$(echo $buildURL|tr -d ' ')
 triggeringJob=$(echo $triggeringJob|tr -d ' ')
+java_home=/opt/public/common/java/openjdk/jdk-17_x64-latest/bin
 
 wget -O ${WORKSPACE}/buildproperties.shsource --no-check-certificate http://download.eclipse.org/eclipse/downloads/drops4/${buildID}/buildproperties.shsource
 cat ${WORKSPACE}/buildproperties.shsource
@@ -65,7 +66,7 @@ ssh genie.releng@projects-storage.eclipse.org cd ${workspace}
 epRelDir=$(ssh genie.releng@projects-storage.eclipse.org ls -d --format=single-column ${dropsPath}/R-*|sort|tail -1)
 ssh genie.releng@projects-storage.eclipse.org tar -C ${workspace} -xzf ${epRelDir}/eclipse-platform-*-linux-gtk-x86_64.tar.gz
 
-ssh genie.releng@projects-storage.eclipse.org PATH=/opt/public/common/java/openjdk/jdk-11_x64-latest/bin:$PATH ${workspace}/eclipse/eclipse -nosplash \\
+ssh genie.releng@projects-storage.eclipse.org PATH=${java_home}:$PATH ${workspace}/eclipse/eclipse -nosplash \\
   -debug -consolelog -data ${workspace}/workspace-toolsinstall \\
   -application org.eclipse.equinox.p2.director \\
   -repository ${ECLIPSE_RUN_REPO},${BUILDTOOLS_REPO},${WEBTOOLS_REPO} \\
@@ -87,7 +88,7 @@ cd ${WORKSPACE}
 
 #triggering ant runner
 baseBuilderDir=${workspace}/basebuilder
-javaCMD=/opt/public/common/java/openjdk/jdk-11_x64-latest/bin/java
+javaCMD=${java_home}/java
 
 launcherJar=$(ssh genie.releng@projects-storage.eclipse.org find ${baseBuilderDir}/. -name "org.eclipse.equinox.launcher_*.jar" | sort | head -1 )
 

--- a/cje-production/cleaners/cleanupNightlyRepo.sh
+++ b/cje-production/cleaners/cleanupNightlyRepo.sh
@@ -159,7 +159,7 @@ function cleanRepo ()
     echo -e "\t${eclipseexe}"
     exit 1
   fi
-  javaexe=/opt/public/common/java/openjdk/jdk-11_x64-latest/bin/java
+  javaexe=/opt/public/common/java/openjdk/jdk-17_x64-latest/bin/java
   if [[ ! -x ${javaexe} ]]
   then
     echo -e "\n\tERROR: expected java location not found, or not executable"

--- a/cje-production/mbscripts/mb620_promoteUpdateSite.sh
+++ b/cje-production/mbscripts/mb620_promoteUpdateSite.sh
@@ -26,6 +26,8 @@ source $1
 epUpdateDir=/home/data/httpd/download.eclipse.org/eclipse/updates
 dropsPath=${epUpdateDir}/${STREAMMajor}.${STREAMMinor}-${BUILD_TYPE}-builds
 latestRelDir=/home/data/httpd/download.eclipse.org/eclipse/downloads/drops4
+java_home=/opt/public/common/java/openjdk/jdk-17_x64-latest/bin
+
 pushd $CJE_ROOT/$UPDATES_DIR
 scp -r ${BUILD_ID} genie.releng@projects-storage.eclipse.org:${dropsPath}/.
 popd
@@ -51,7 +53,7 @@ ssh genie.releng@projects-storage.eclipse.org wget -O ${workspace}/addToComposit
 
 #triggering ant runner
 baseBuilderDir=${workspace}/eclipse
-javaCMD=/opt/public/common/java/openjdk/jdk-11_x64-latest/bin/java
+javaCMD=${java_home}/java
 
 launcherJar=$(ssh genie.releng@projects-storage.eclipse.org find ${baseBuilderDir}/. -name "org.eclipse.equinox.launcher_*.jar" | sort | head -1 )
 

--- a/cje-production/promotion/makeVisible.sh
+++ b/cje-production/promotion/makeVisible.sh
@@ -181,7 +181,7 @@ then
 
   #triggering ant runner
   baseBuilderDir=${workspace}/eclipse
-  javaCMD=/opt/public/common/java/openjdk/jdk-11_x64-latest/bin/java
+  javaCMD=/opt/public/common/java/openjdk/jdk-17_x64-latest/bin/java
 
   launcherJar=$(ssh genie.releng@projects-storage.eclipse.org find ${baseBuilderDir}/. -name "org.eclipse.equinox.launcher_*.jar" | sort | head -1 )
 


### PR DESCRIPTION
Should fix SDK build fails after I20230609-1800.

Looks like some environment or build script change finally caused latest 4.28 SDK builds to be used for building 4.29, and antRunner application requires Java 17 since 4.28.

See https://github.com/eclipse-platform/eclipse.platform.releng/issues/240