### PR TITLE
Update R4_28 maintenance branch with release version for 4.28+ changes

### DIFF
--- a/cje-production/P-build/buildproperties.txt
+++ b/cje-production/P-build/buildproperties.txt
@@ -58,7 +58,7 @@ PREVIOUS_RELEASE_ID="R-4.26-202211231800"
 BUILDTOOLS_REPO="https://download.eclipse.org/eclipse/updates/buildtools/"
 WEBTOOLS_REPO="https://download.eclipse.org/webtools/downloads/drops/R3.27.0/R-3.27.0-20220829002010/repositoryunittests/"
 BASEBUILDER_DIR="tmp/org.eclipse.releng.basebuilder"
-ECLIPSE_RUN_REPO="https://download.eclipse.org/eclipse/updates/4.28-I-builds/"
+ECLIPSE_RUN_REPO="https://download.eclipse.org/eclipse/updates/R-4.28-202306050440/"
 
 #Maven parameters
 MAVEN_OPTS="-Xmx6G"

--- a/cje-production/Y-build/buildproperties.txt
+++ b/cje-production/Y-build/buildproperties.txt
@@ -57,7 +57,7 @@ PREVIOUS_RELEASE_ID="R-4.27-202303020300"
 BUILDTOOLS_REPO="https://download.eclipse.org/eclipse/updates/buildtools/"
 WEBTOOLS_REPO="https://download.eclipse.org/webtools/downloads/drops/R3.22.0/R-3.22.0-20210612170523/repositoryunittests/"
 BASEBUILDER_DIR="tmp/org.eclipse.releng.basebuilder"
-ECLIPSE_RUN_REPO="https://download.eclipse.org/eclipse/updates/4.28-I-builds/"
+ECLIPSE_RUN_REPO="https://download.eclipse.org/eclipse/updates/R-4.28-202306050440/"
 
 #Maven parameters
 MAVEN_OPTS="-Xmx6G"

--- a/cje-production/buildproperties.txt
+++ b/cje-production/buildproperties.txt
@@ -57,7 +57,7 @@ PREVIOUS_RELEASE_ID="R-4.27-202303020300"
 BUILDTOOLS_REPO="https://download.eclipse.org/eclipse/updates/buildtools/"
 WEBTOOLS_REPO="https://download.eclipse.org/webtools/downloads/drops/R3.27.0/R-3.27.0-20220829002010/repositoryunittests/"
 BASEBUILDER_DIR="tmp/org.eclipse.releng.basebuilder"
-ECLIPSE_RUN_REPO="https://download.eclipse.org/eclipse/updates/4.28-I-builds/"
+ECLIPSE_RUN_REPO="https://download.eclipse.org/eclipse/updates/R-4.28-202306050440/"
 
 #Maven parameters
 MAVEN_OPTS="-Xmx6G"

--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -77,9 +77,9 @@
       'eclipiserun-repo' repository, such as for computing .api-descriptions and
       generating API Tools reports.
     -->
-    <eclipserun-repo>https://download.eclipse.org/eclipse/updates/4.28-I-builds/</eclipserun-repo>
+    <eclipserun-repo>https://download.eclipse.org/eclipse/updates/4.28/R-4.28-202306050440/</eclipserun-repo>
     
-    <comparator.repo>https://download.eclipse.org/eclipse/updates/4.28-I-builds</comparator.repo>
+    <comparator.repo>https://download.eclipse.org/eclipse/updates/4.28/R-4.28-202306050440</comparator.repo>
 
     <!-- only used when Tycho snapshot repo is enabled in <pluginRepositories> further down -->
     <tycho-snapshot-repo.url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</tycho-snapshot-repo.url>
@@ -140,7 +140,7 @@
     <tycho.mapP2Dependencies>false</tycho.mapP2Dependencies>
     
     <compare-version-with-baselines.skip>true</compare-version-with-baselines.skip>
-    <previous-release.baseline> https://download.eclipse.org/eclipse/updates/4.27/R-4.27-202303020300/</previous-release.baseline>
+    <previous-release.baseline> https://download.eclipse.org/eclipse/updates/4.28/R-4.28-202306050440/</previous-release.baseline>
 
     <!--
       Declaration of properties that contribute to the arg line for the tycho-surefire-plugin.
@@ -624,12 +624,12 @@
         <!-- Can specify an exact range here, or something of a loose range, depending on what's needed. -->
         <versionRangeForPatch>[3.19.0.v20230302-0300,3.19.49.v20230604-1800)</versionRangeForPatch>
         <!-- Comment this line when a patch is required on top of I-build -->
-        <comparator.repo>https://download.eclipse.org/eclipse/updates/4.27/R-4.27-202303020300/</comparator.repo>
+        <comparator.repo>https://download.eclipse.org/eclipse/updates/4.28/R-4.28-202306050440/</comparator.repo>
       </properties>
       <repositories>
        <repository>
          <id>eclipse-p2-repo-java20patch</id>
-         <url>https://download.eclipse.org/eclipse/updates/4.27/R-4.27-202303020300/</url>
+         <url>https://download.eclipse.org/eclipse/updates/4.28/R-4.28-202306050440/</url>
          <layout>p2</layout>
        </repository>
      </repositories>
@@ -676,7 +676,7 @@
           For maintenance streams should always be "M-builds".
           Ideally, this value would be provided by the environment, see bug 489789.
         -->
-        <eclipse-p2-repo.url>https://download.eclipse.org/eclipse/updates/4.28-I-builds</eclipse-p2-repo.url>
+        <eclipse-p2-repo.url>https://download.eclipse.org/eclipse/updates/4.28/R-4.28-202306050440</eclipse-p2-repo.url>
       </properties>
       <repositories>
         <repository>


### PR DESCRIPTION
Changes Done in 4.28 Maintenance branch Tracked in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1110

@sravanlakkimsetti 