### PR TITLE
Copy re-usable license-check GH workflows from eclipse/dash-licenses

### DIFF
--- a/.github/actions/maven-license-check-action/action.yml
+++ b/.github/actions/maven-license-check-action/action.yml
@@ -1,0 +1,48 @@
+# *************************************************************************
+# * Copyright (c) 2022, 2023 Hannes Wellmann and others.
+# *
+# * This program and the accompanying materials are made available under
+# * the terms of the Eclipse Public License 2.0 which accompanies this
+# * distribution, and is available at https://www.eclipse.org/legal/epl-2.0
+# *
+# * SPDX-License-Identifier: EPL-2.0
+# *      Hannes Wellmann - initial API and implementation
+# *************************************************************************
+
+name: 'Check license vetting status'
+description: 'Checks if the licenses of all dependencies are vetted and requests a review in case required and wanted'
+inputs:
+  request-review:
+    description: ''
+    required: false
+  project-id:
+    description: ''
+    required: false
+outputs:
+  licenses-vetted: 
+    description: "True if all licenses are vetted, else false"
+    value: ${{ steps.license-check-with-review-request.outputs.build-succeeded }}
+runs:
+  using: "composite"
+  steps:
+    - id: license-check-with-review-request
+      shell: bash {0} # do not fail-fast
+      run: |
+        mvnArgs="-U -B -ntp org.eclipse.dash:license-tool-plugin:license-check -Ddash.fail=true -Dtycho.target.eager=true --settings $GITHUB_ACTION_PATH/licenseCheckMavenSettings.xml"
+        if [[ ${{ inputs.project-id }} != "" ]]; then
+          mvnArgs+=" -Ddash.projectId=${{ inputs.project-id }}"
+        fi
+        if [ ${{ inputs.request-review }} ]; then
+          mvn ${mvnArgs} -Ddash.iplab.token=$GITLAB_API_TOKEN
+          if [[ $? == 0 ]]; then # All licenses are vetted
+            echo "build-succeeded=1" >> $GITHUB_OUTPUT
+          else
+            echo "build-succeeded=0" >> $GITHUB_OUTPUT
+          fi
+        else
+          mvn ${mvnArgs}
+          if [[ $? != 0 ]]; then
+            echo "Committers can request a review by commenting '/request-license-review'"
+            exit 1
+          fi
+        fi

--- a/.github/actions/maven-license-check-action/licenseCheckMavenSettings.xml
+++ b/.github/actions/maven-license-check-action/licenseCheckMavenSettings.xml
@@ -1,0 +1,29 @@
+<!--
+ * Copyright (C) 2022 Hannes Wellmann and others. 
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-FileType: DOCUMENTATION
+ *
+ * SPDX-FileCopyrightText: 2019 Eclipse Foundation
+ * SPDX-License-Identifier: EPL-2.0
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+	<profiles>
+		<profile>
+			<id>dash-licenses-snapshots</id>
+			<pluginRepositories>
+				<pluginRepository>
+					<id>dash-licenses-snapshots</id>
+					<url>https://repo.eclipse.org/content/repositories/dash-licenses-snapshots/</url>
+				</pluginRepository>
+			</pluginRepositories>
+		</profile>
+	</profiles>
+	<activeProfiles>
+		<activeProfile>dash-licenses-snapshots</activeProfile>
+	</activeProfiles>
+</settings>

--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   call-license-check:
-    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
+    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/mavenLicenseCheck.yml@master
     with:
       projectId: eclipse.platform
       submodules: recursive

--- a/.github/workflows/mavenLicenseCheck.yml
+++ b/.github/workflows/mavenLicenseCheck.yml
@@ -1,0 +1,187 @@
+# *************************************************************************
+# * Copyright (c) 2022, 2023 Hannes Wellmann and others.
+# *
+# * This program and the accompanying materials are made available under
+# * the terms of the Eclipse Public License 2.0 which accompanies this
+# * distribution, and is available at https://www.eclipse.org/legal/epl-2.0
+# *
+# * SPDX-License-Identifier: EPL-2.0
+# *      Hannes Wellmann - initial API and implementation
+# *************************************************************************
+
+# This workflow will check for Maven projects if the licenses of all (transitive) dependencies are vetted.
+
+name: License vetting status check
+
+on:
+  workflow_call:
+    inputs:
+      projectId:
+        description: 'The "projectId" used when license vetting is requested'
+        type: string
+        required: false
+        default: ''
+      setupScript:
+        description: 'Optional bash script that is executed before the license check and is intended to prepare the checked out project if necessary'
+        type: string
+        required: false
+        default: ''
+      submodules:
+        description: |
+          Whether to checkout submodules: `true` to checkout submodules or `recursive` to recursively checkout submodules.
+          When the `ssh-key` input is not provided, SSH URLs beginning with `git@github.com:` are converted to HTTPS.
+          The value is just passed as it is to the github/actions/checkout action: https://github.com/actions/checkout#usage
+        type: string
+        required: false
+        default: 'false'
+      mavenVersion: 
+        description: 'The version of Maven set up to run to license-check build'
+        type: string
+        required: false
+        default: '3.9.2'
+    secrets:
+      gitlabAPIToken:
+        description: 'The authentication token (scope: api) from gitlab.eclipse.org of the calling repository. Only required if license vetting is requested'
+        required: false
+
+jobs:
+  check-licenses:
+    if: github.event_name != 'issue_comment' || ( github.event.issue.pull_request != '' && (github.event.comment.body == '/request-license-review') )
+    # Run on all non-comment events specified by the calling workflow and for comments on PRs that have a corresponding body.
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Check dependabot PR 
+      run: echo "isDependabotPR=1" >> $GITHUB_ENV
+      if: >
+        github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened')
+        && github.actor == 'dependabot[bot]' && github.actor_id == '49699333'
+      # For 'issue_comment'-events this job only runs if a comment was added to a PR with body specified above
+
+    - name: Set review request
+      run: echo "request-review=1" >> $GITHUB_ENV
+      if: github.event_name == 'issue_comment' || env.isDependabotPR
+      # For 'issue_comment'-events this job only runs if a comment was added to a PR with body specified above
+
+    - name: Process license-vetting request
+      if: env.request-review && (!env.isDependabotPR)
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const payload = await github.rest.repos.getCollaboratorPermissionLevel({
+            ...context.repo, username: context.actor
+          });
+          const userPermission = payload?.data?.permission;
+          let reaction = 'rocket'
+          if (!(userPermission == 'write' || userPermission == 'admin')) { // not a committer
+            // Not a committer -> abort workflow
+            core.setFailed("Only committers are permitted to request license vetting and " + context.actor + " isn't one.")
+            reaction = '-1'
+          }
+          // react on comment to give early feedback that the request was understood
+          await github.rest.reactions.createForIssueComment({
+            ...context.repo, comment_id: context.payload?.comment?.id, content: reaction
+          });
+
+    # By default the git-ref checked out for events triggered by comments to PRs is 'refs/heads/master'
+    # and for events triggered by PR creation/updates the ref is 'refs/pull/<PR-number>/merge'.
+    # So by default only the master-branch would be considered when requesting license-reviews, but we want the PR's state.
+    # Unless the PR is closed, then we want the master-branch, which allows subsequent license review requests.
+    - uses: actions/checkout@v3
+      # use default ref 'refs/pull/<PR-number>/merge' for PR-events and 'refs/heads/master' for comments if the PR is closed
+      if: github.event.issue.pull_request == '' || github.event.issue.state != 'open'
+      with:
+        submodules: ${{ inputs.submodules }}
+    - uses: actions/checkout@v3
+      with:
+        ref: 'refs/pull/${{ github.event.issue.number }}/merge'
+        submodules: ${{ inputs.submodules }}
+      if: github.event.issue.pull_request != '' && github.event.issue.state == 'open'
+
+    - uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - name: Cache local Maven repository
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2/repository
+        # re-cache on changes in the pom and target files
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '**/*.target') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4.5
+      with:
+        maven-version: ${{ inputs.mavenVersion }}
+
+    - name: Prepare for license check
+      run: ${{ inputs.setupScript }}
+      if: inputs.setupScript !=''
+
+    - name: Check license vetting status (and ask for review if requested)
+      id: check-license-vetting
+      uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/actions/maven-license-check-action@master
+      with:
+        request-review: ${{ env.request-review }}
+        project-id: ${{ inputs.projectId }}
+      env:
+        GITLAB_API_TOKEN: ${{ secrets.gitlabAPIToken }}
+
+    - name: Process license check results
+      if: env.request-review
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const fs = require('fs')
+          
+          const licenesVetted = ${{ steps.check-license-vetting.outputs.licenses-vetted }}
+          let commentBody = ''
+          if ( context.payload.comment ) {
+            commentBody += '> ' + context.payload.comment.body + '\n\n'
+          } else if ( licenesVetted ){
+            core.info('License review request made automatically but all licenses are already vetted.')
+            return; // Don't create a comment in this case, the checks in the UI indicate the state already.
+          }
+          
+          if( licenesVetted ) {
+            commentBody += ':heavy_check_mark: All licenses already successfully vetted.\n'
+          } else {
+            
+            const reviewSummaryFile = process.env.GITHUB_WORKSPACE + '/target/dash/review-summary'
+            core.info("Read review summary at " + reviewSummaryFile)
+            let content = "";
+            if ( fs.existsSync( reviewSummaryFile )) {
+              content = fs.readFileSync( reviewSummaryFile, {encoding: 'utf8'}).trim();
+            }
+            
+            if ( content ) { // not empty
+              commentBody += 'License review requests:\n'
+              const lines = content.split('\n')
+              for(var line = 0; line < lines.length; line++){
+                commentBody += ('- ' + lines[line] + '\n')
+              }
+              commentBody += '\n'
+              commentBody += 'After all reviews have concluded, re-run the license-vetting check from the Github Actions web-interface to update its status.\n'
+              
+            } else {
+              core.setFailed("License vetting build failed, but no reviews are created")
+              commentBody += ':warning: Failed to request review of not vetted licenses.\n'
+            }
+          }
+          commentBody += '\n'
+          commentBody += 'Workflow run (with attached summary files):\n'
+          commentBody += context.serverUrl + "/" + process.env.GITHUB_REPOSITORY + "/actions/runs/" + context.runId
+          
+          github.rest.issues.createComment({
+            issue_number: context.issue.number, ...context.repo, body: commentBody
+          })
+
+    - uses: actions/upload-artifact@v3
+      if: always() && env.request-review
+      with:
+        name: '${{ inputs.projectId }}-license-vetting-summary'
+        path: |
+          target/dash/review-summary
+          target/dash/summary


### PR DESCRIPTION
As discussed in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1163#issuecomment-1599258027 this PR copies the re-usable license-check GH workflows from https://github.com/eclipse/dash-licenses/tree/master/.github (with the state of https://github.com/eclipse/dash-licenses/pull/247) into this repository in order to have the necessary fixes faster.

In my opinion this is only a temporary solution and the workflow is still best placed at `eclipse/dash-licesens`, but until that project is more active we maintain the copy of the workflow here in order to use it for eclipse-platform (or others that need it). But he ultimate goal should be to make `dash-licenes` more active so that we can consume it from there and can revert this again. So everybody that want's to use the copy from here in their project, should check for the original if this is vanished one day.
