### PR TITLE
[Setup] Import Doc-Projects and restory Platform Doc Working Set

### DIFF
--- a/oomph/Platform.setup
+++ b/oomph/Platform.setup
@@ -802,6 +802,18 @@
             name="org.eclipse.platform.setup.plain.project"/>
         <requirement
             name="org.eclipse.platform.releng.prereqs.sdk.plain.project"/>
+        <requirement
+            name="org.eclipse.jdt.doc.isv.plain.project"/>
+        <requirement
+            name="org.eclipse.jdt.doc.user.plain.project"/>
+        <requirement
+            name="org.eclipse.jdt.tips.user.plain.project"/>
+        <requirement
+            name="org.eclipse.pde.doc.user.plain.project"/>
+        <requirement
+            name="org.eclipse.platform.doc.tips.plain.project"/>
+        <requirement
+            name="org.eclipse.platform.doc.user.plain.project"/>
         <sourceLocator
             rootFolder="${github.clone.platform.releng.aggregator.location}"
             locateNestedProjects="true"/>
@@ -816,6 +828,24 @@
           <operand
               xsi:type="predicates:RepositoryPredicate"
               project="org.eclipse.platform.releng.tychoeclipsebuilder"/>
+          <operand
+              xsi:type="predicates:NotPredicate">
+            <operand
+                xsi:type="workingsets:InclusionPredicate"
+                includedWorkingSet="//@projects[name='releng.aggregator']/@setupTasks.3/@workingSets[name='Platform%20Documentation']"/>
+          </operand>
+        </predicate>
+      </workingSet>
+      <workingSet
+          name="Platform Documentation">
+        <predicate
+            xsi:type="predicates:AndPredicate">
+          <operand
+              xsi:type="predicates:RepositoryPredicate"
+              project="org.eclipse.platform.doc.user"/>
+          <operand
+              xsi:type="predicates:LocationPredicate"
+              pattern="${github.clone.platform.releng.aggregator.location/eclipse.platform.common|path}/*"/>
         </predicate>
       </workingSet>
     </setupTask>


### PR DESCRIPTION
As discussed in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1176 this restores the Platform Doc Working set.
Additionally it ensures that the doc bundles are also imported.

I currently have problems to test this, because with this change many more than just the intended doc-bundles are imported into the workspace (i.e. all projects that I don't have imported through the sub-module setups directly).

@merks can you tell what I'm doing wrong?