### PR TITLE
[Setup] Fix incorrect Working-Set task index and assign IDs to WS-tasks

### DIFF
--- a/oomph/Platform.setup
+++ b/oomph/Platform.setup
@@ -610,7 +610,8 @@
       </targlet>
     </setupTask>
     <setupTask
-        xsi:type="setup.workingsets:WorkingSetTask">
+        xsi:type="setup.workingsets:WorkingSetTask"
+        id="platform.images.workingsets">
       <workingSet
           name="Platform Images">
         <predicate
@@ -718,7 +719,8 @@
       </targlet>
     </setupTask>
     <setupTask
-        xsi:type="setup.workingsets:WorkingSetTask">
+        xsi:type="setup.workingsets:WorkingSetTask"
+        id="releng.workingsets">
       <workingSet
           name="Platform Releng">
         <predicate
@@ -728,7 +730,7 @@
               project="org.eclipse.rcp"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@projects[name='releng']/@setupTasks.2/@workingSets[name='Platform%20Releng%20Tests']"/>
+              excludedWorkingSet="//'releng.workingsets'/@workingSets[name='Platform%20Releng%20Tests']"/>
         </predicate>
       </workingSet>
       <workingSet
@@ -816,7 +818,8 @@
       </targlet>
     </setupTask>
     <setupTask
-        xsi:type="setup.workingsets:WorkingSetTask">
+        xsi:type="setup.workingsets:WorkingSetTask"
+        id="releng.aggregator.workingsets">
       <workingSet
           name="Platform Releng Aggregator">
         <predicate
@@ -826,7 +829,7 @@
               project="org.eclipse.platform.releng.tychoeclipsebuilder"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@projects[name='releng.aggregator']/@setupTasks.3/@workingSets[name='Platform%20Documentation']"/>
+              excludedWorkingSet="//'releng.aggregator.workingsets'/@workingSets[name='Platform%20Documentation']"/>
         </predicate>
       </workingSet>
       <workingSet
@@ -918,7 +921,8 @@
       </targlet>
     </setupTask>
     <setupTask
-        xsi:type="setup.workingsets:WorkingSetTask">
+        xsi:type="setup.workingsets:WorkingSetTask"
+        id="releng.build.workingsets">
       <workingSet
           name="Platform Releng Build Tools">
         <predicate


### PR DESCRIPTION
After https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1180 the excludedWorkingSet of the Platform Releng Aggregator working set seem to be off by one: It was `@setupTasks.3` but probably should have been `@setupTasks.2`.
This caused errors when I opened the Platform setup.

To make this more robust against future changes I added ids to all working-set task and changed the exclusion property to use that reference as @merks advocated somewhere else in the past.