### PR TITLE
Force Java 17 source for javadoc profile

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -1029,7 +1029,7 @@
 						</execution>
 					</executions>
 					<configuration>
-						<source>${java.version}</source>
+						<source>17</source>
 						<failOnError>false</failOnError>
 						<quiet>true</quiet>
 						<doclint>reference,html,syntax</doclint>


### PR DESCRIPTION
Currently it fails with "pattern matching in instanceof is not supported in -source 11" or similar in builds.