### PR TITLE
Add silent slf4j-simple to Platform/SDK-products and auto-start Aries SPI Fly and slf4j-simple

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -206,7 +206,7 @@
 			  <!-- slf4j-api requires 1 impl, providing a dummy one... -->
 			  <dependency>
 				  <groupId>org.slf4j</groupId>
-				  <artifactId>slf4j-nop</artifactId>
+				  <artifactId>slf4j-simple</artifactId>
 				  <version>2.0.7</version>
 				  <type>jar</type>
 			  </dependency>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Eclipse Platform" uid="org.eclipse.platform.ide" id="org.eclipse.platform.ide" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" useFeatures="true" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Eclipse Platform" uid="org.eclipse.platform.ide" id="org.eclipse.platform.ide" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <configIni use="default">
    </configIni>
@@ -9,7 +9,7 @@
    <launcherArgs>
       <programArgs>--launcher.defaultAction openFile --launcher.appendVmargs
       </programArgs>
-      <vmArgs>-Dosgi.requiredJavaVersion=17 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true -Xms40m -Xmx512m --add-modules=ALL-SYSTEM
+      <vmArgs>-Dosgi.requiredJavaVersion=17 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true -Xms40m -Xmx512m --add-modules=ALL-SYSTEM -Dorg.slf4j.simpleLogger.defaultLogLevel=off
       </vmArgs>
       <vmArgsMac>-Xdock:icon=../Resources/Eclipse.icns -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
@@ -183,12 +183,14 @@ United States, other countries, or both.
    </features>
 
    <configurations>
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="1" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <plugin id="slf4j.simple" autoStart="true" startLevel="1" />
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.sdk.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.sdk.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Eclipse Platform SDK" uid="org.eclipse.platform.sdk" id="org.eclipse.platform.sdk" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" useFeatures="true" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Eclipse Platform SDK" uid="org.eclipse.platform.sdk" id="org.eclipse.platform.sdk" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <configIni use="default">
    </configIni>
@@ -9,7 +9,7 @@
    <launcherArgs>
       <programArgs>--launcher.defaultAction openFile --launcher.appendVmargs
       </programArgs>
-      <vmArgs>-Dosgi.requiredJavaVersion=17 -Xms40m -Xmx384m --add-modules=ALL-SYSTEM
+      <vmArgs>-Dosgi.requiredJavaVersion=17 -Xms40m -Xmx384m --add-modules=ALL-SYSTEM -Dorg.slf4j.simpleLogger.defaultLogLevel=off
       </vmArgs>
       <vmArgsMac>-Xdock:icon=../Resources/Eclipse.icns -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
@@ -185,12 +185,14 @@ United States, other countries, or both.
    </features>
 
    <configurations>
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="1" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <plugin id="slf4j.simple" autoStart="true" startLevel="1" />
    </configurations>
 
 </product>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Eclipse SDK" uid="org.eclipse.sdk.ide" id="org.eclipse.sdk.ide" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" useFeatures="true" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Eclipse SDK" uid="org.eclipse.sdk.ide" id="org.eclipse.sdk.ide" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <configIni use="default">
    </configIni>
@@ -9,7 +9,7 @@
    <launcherArgs>
       <programArgs>--launcher.defaultAction openFile  --launcher.appendVmargs
       </programArgs>
-      <vmArgs>-Dosgi.requiredJavaVersion=17 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true -Xms256m -Xmx2048m --add-modules=ALL-SYSTEM
+      <vmArgs>-Dosgi.requiredJavaVersion=17 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true -Xms256m -Xmx2048m --add-modules=ALL-SYSTEM -Dorg.slf4j.simpleLogger.defaultLogLevel=off
       </vmArgs>
       <vmArgsMac>-Xdock:icon=../Resources/Eclipse.icns -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
@@ -188,12 +188,14 @@ United States, other countries, or both.
    </features>
 
    <configurations>
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="1" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <plugin id="slf4j.simple" autoStart="true" startLevel="1" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="org.eclipse.update.reconcile" value="false" />


### PR DESCRIPTION
This allows the slf4j-api bundle to find the nop binding and thus prevents error messages about missing bindings.

Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1094

@jonahgraham I'm a bit unhappy that the slf4j.nop bundle also has to be auto-started, but unfortunately spi-fly only considers bundles that are in STARTING or ACTIVE (i.e. have been started successfully).
Equinox sets bundles with `Bundle-ActivationPolicy: lazy` automatically in the STARTING state. So at least for Equinox a solution would be to add `Bundle-ActivationPolicy: lazy` to the slf4j-providers (i.e. slf4j.nop, slf4j.simple, logback, ...).
Alternativly one could ask in Apache aries to also consider bundles in resolved state, but I guess they have a reason for that behavior.

If we want a solution that redirects all slf4j-logging to an Eclipse ILog, we could at least control the starting behavior.


Btw. can you tell what the `platform.product` and `platform.sdk.product` are used for? As far as I can tell, the sdk.product is the one that is provided as the Eclipse SDK download, but what are the former two used for?

Furthermore I recently made/started a few changes in PDE regarding the product configuration, maybe this is also interesting for you:
- https://github.com/eclipse-pde/eclipse.pde/pull/642
- https://github.com/eclipse-pde/eclipse.pde/pull/643
- https://github.com/eclipse-pde/eclipse.pde/pull/644
