### PR TITLE
Enforce qualifier update to pick-up JDT extension-point doc fixes

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/forceQualifierUpdate.txt
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/forceQualifierUpdate.txt
@@ -1,1 +1,2 @@
 https://github.com/eclipse-platform/.github/issues/130
+https://github.com/eclipse-platform/eclipse.platform/issues/561


### PR DESCRIPTION
So that the changes from https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/278 are picked up to fix https://github.com/eclipse-platform/eclipse.platform/issues/561.