### PR TITLE
Ignore generated/copied samples doc-html directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ workspace/
 .metadata/
 RemoteSystemsTempFiles/
 /apiAnalyzer-workspace/
+eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/samples/*/doc-html


### PR DESCRIPTION
Multiple doc-html directories shown as untracked after SDK build:

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/samples/org.eclipse.compare.examples.xml/
        eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/samples/org.eclipse.compare.examples/
        eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/samples/org.eclipse.swt.examples.launcher/
        eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/samples/org.eclipse.swt.examples.ole.win32/
        eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/samples/org.eclipse.swt.examples.views/
        eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/samples/org.eclipse.swt.examples/
        eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/samples/org.eclipse.team.examples.filesystem/
        eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/samples/org.eclipse.ui.examples.fieldassist/
        eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/samples/org.eclipse.ui.examples.javaeditor/
        eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/samples/org.eclipse.ui.examples.multipageeditor/
        eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/samples/org.eclipse.ui.examples.propertysheet/
        eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/samples/org.eclipse.ui.examples.readmetool/
        eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/samples/org.eclipse.ui.examples.undo/