### PR TITLE
[Setup] Add eclipse-sdk-prereqs.target to platform.releng.aggr Targlet and exclude releng.aggregator sub-modules

### DIFF
--- a/oomph/Platform.setup
+++ b/oomph/Platform.setup
@@ -664,54 +664,24 @@
       <targlet
           name="Platform Releng Aggregator">
         <requirement
-            name="org.eclipse.platform.releng.tychoeclipsebuilder.plain.project"/>
-        <requirement
-            name="org.eclipse.platform.setup.plain.project"/>
-        <requirement
-            name="org.eclipse.platform.releng.prereqs.sdk.plain.project"/>
-        <requirement
-            name="org.eclipse.jdt.doc.isv"/>
-        <requirement
-            name="org.eclipse.platform.doc.isv"/>
-        <requirement
-            name="org.eclipse.jdt.tips.user"/>
-        <requirement
-            name="org.eclipse.platform.doc.tips"/>
-        <requirement
-            name="org.eclipse.help.feature.group"/>
-        <requirement
-            name="org.eclipse.platform.feature.group"/>
-        <requirement
-            name="org.eclipse.rcp.feature.group"/>
-        <requirement
-            name="org.eclipse.sdk.examples.feature.group"/>
-        <requirement
-            name="org.eclipse.sdk.feature.group"/>
-        <requirement
-            name="org.eclipse.sdk.tests.feature.group"/>
-        <requirement
-            name="org.eclipse.test.feature.group"/>
-        <requirement
-            name="org.eclipse.ant.optional.junit"/>
-        <requirement
-            name="org.eclipse.rcp"/>
-        <requirement
-            name="org.eclipse.releng.tests"/>
-        <requirement
-            name="org.eclipse.sdk.examples"/>
-        <requirement
-            name="org.eclipse.sdk.tests"/>
-        <requirement
-            name="org.eclipse.test"/>
-        <requirement
-            name="org.eclipse.test.performance"/>
-        <requirement
-            name="org.eclipse.test.performance.win32"/>
-        <requirement
-            name="publish-to-maven-central.plain.project"/>
+            name="*"/>
         <sourceLocator
             rootFolder="${github.clone.platform.releng.aggregator.location}"
-            locateNestedProjects="true"/>
+            locateNestedProjects="true">
+          <excludedPath>eclipse.jdt</excludedPath>
+          <excludedPath>eclipse.jdt.core</excludedPath>
+          <excludedPath>eclipse.jdt.core.binaries</excludedPath>
+          <excludedPath>eclipse.jdt.debug</excludedPath>
+          <excludedPath>eclipse.jdt.ui</excludedPath>
+          <excludedPath>eclipse.pde</excludedPath>
+          <excludedPath>eclipse.platform</excludedPath>
+          <excludedPath>eclipse.platform.swt</excludedPath>
+          <excludedPath>eclipse.platform.swt.binaries</excludedPath>
+          <excludedPath>eclipse.platform.ui</excludedPath>
+          <excludedPath>equinox</excludedPath>
+          <excludedPath>rt.equinox.binaries</excludedPath>
+          <excludedPath>rt.equinox.p2</excludedPath>
+        </sourceLocator>
       </targlet>
       <composedTarget>eclipse-sdk-prereqs</composedTarget>
     </setupTask>

--- a/oomph/Platform.setup
+++ b/oomph/Platform.setup
@@ -6,13 +6,14 @@
     xmlns:git="http://www.eclipse.org/oomph/setup/git/1.0"
     xmlns:jdt="http://www.eclipse.org/oomph/setup/jdt/1.0"
     xmlns:predicates="http://www.eclipse.org/oomph/predicates/1.0"
+    xmlns:projects="http://www.eclipse.org/oomph/setup/projects/1.0"
     xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
     xmlns:setup.p2="http://www.eclipse.org/oomph/setup/p2/1.0"
     xmlns:setup.targlets="http://www.eclipse.org/oomph/setup/targlets/1.0"
     xmlns:setup.workingsets="http://www.eclipse.org/oomph/setup/workingsets/1.0"
     xmlns:workbench="http://www.eclipse.org/oomph/setup/workbench/1.0"
     xmlns:workingsets="http://www.eclipse.org/oomph/workingsets/1.0"
-    xsi:schemaLocation="http://www.eclipse.org/oomph/setup/git/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Git.ecore http://www.eclipse.org/oomph/setup/jdt/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/JDT.ecore http://www.eclipse.org/oomph/predicates/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Predicates.ecore http://www.eclipse.org/oomph/setup/targlets/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/SetupTarglets.ecore http://www.eclipse.org/oomph/setup/workingsets/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/SetupWorkingSets.ecore http://www.eclipse.org/oomph/setup/workbench/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Workbench.ecore http://www.eclipse.org/oomph/workingsets/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/WorkingSets.ecore"
+    xsi:schemaLocation="http://www.eclipse.org/oomph/setup/git/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Git.ecore http://www.eclipse.org/oomph/setup/jdt/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/JDT.ecore http://www.eclipse.org/oomph/predicates/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Predicates.ecore http://www.eclipse.org/oomph/setup/projects/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Projects.ecore http://www.eclipse.org/oomph/setup/targlets/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/SetupTarglets.ecore http://www.eclipse.org/oomph/setup/workingsets/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/SetupWorkingSets.ecore http://www.eclipse.org/oomph/setup/workbench/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Workbench.ecore http://www.eclipse.org/oomph/workingsets/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/WorkingSets.ecore"
     name="platform"
     label="Platform">
   <annotation
@@ -652,7 +653,14 @@
       <description>Platform Releng Aggregator</description>
     </setupTask>
     <setupTask
-        xsi:type="setup.targlets:TargletTask">
+        xsi:type="projects:ProjectsImportTask"
+        id="import.project.eclipse.platform.prereqs.target">
+      <sourceLocator
+          rootFolder="${github.clone.platform.releng.aggregator.location}/eclipse.platform.releng.prereqs.sdk"/>
+    </setupTask>
+    <setupTask
+        xsi:type="setup.targlets:TargletTask"
+        predecessor="import.project.eclipse.platform.prereqs.target">
       <targlet
           name="Platform Releng Aggregator">
         <requirement
@@ -705,6 +713,7 @@
             rootFolder="${github.clone.platform.releng.aggregator.location}"
             locateNestedProjects="true"/>
       </targlet>
+      <composedTarget>eclipse-sdk-prereqs</composedTarget>
     </setupTask>
     <setupTask
         xsi:type="setup.workingsets:WorkingSetTask"


### PR DESCRIPTION
This PR does two things:
1. Add eclipse-sdk-prereqs.target to platform.releng.aggr Targlet
And explicitly import `eclipse.platform.releng.prereqs.sdk` to ensure the `eclipse-sdk-prereqs` target is available in the workspace when the targlet-task is executed.
2. Exclude releng.aggregator sub-modules from releng.aggr Targlet
This prevents the imports of large parts of the SDK even if their setups are not included in the workspace setup.

For example I have eclipse-platform base, ui, releng.aggregator and equinox and p2 in one workspace but not PDE and JDT (I have them in a separate one). Without the exclusion I then get many projects from PDE and JDT imported, when I also apply the releng.aggreator setup to this workspace.