### PR TITLE
Use org.hamcrest.core 1.3.0.v20230806-0849

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -32,12 +32,13 @@
       <unit id="org.apache.lucene.analysis-smartcn.source" version="9.7.0.v20230703-0758"/>
       <unit id="org.apache.lucene.analysis-common.source" version="9.7.0.v20230703-0758"/>
 
-      <unit id="org.hamcrest.core" version="1.3.0.v20230721-0740"/>
-      <unit id="org.hamcrest.core.source" version="1.3.0.v20230721-0740"/>
+      <unit id="org.hamcrest.core" version="1.3.0.v20230806-0849"/>
+      <unit id="org.hamcrest.core.source" version="1.3.0.v20230806-0849"/>
 
       <!-- This is the "normal" Orbit repository. During development on Bug 568936 this repo is the EBR (git)
            sourced bundles of Orbit from 2022-06. This is the sub-p2-repo of the 2022-06 recommended build.
            This is the repo that is expected to be updated on milestones based on Orbit deliveries. -->
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/maven-bnd/nightly/latest"/>
       <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202307260741"/>
     </location>
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">


### PR DESCRIPTION
Temporarily use an Orbit maven-bnd nightly build repository. This will be fixed to use the aggregation milestone when one is available with the fixed org.hamcrest.core version and it's confirmed to fix the reported problems.

https://github.com/eclipse-orbit/orbit-simrel/issues/8 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1245