### PR TITLE
Filter out the workspace content of folders that are nested projects

### DIFF
--- a/.project
+++ b/.project
@@ -8,4 +8,15 @@
 	</buildSpec>
 	<natures>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1692173149981</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-true-true-(eclipse.platform.releng.prereqs.sdk|eclipse.platform.releng.tychoeclipsebuilder|oomph)/.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>


### PR DESCRIPTION
This is particularly relevant to avoid eclipse-sdk-prereqs.target appearing twice in the workspace.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1197