### PR TITLE
POM and product version changes for 4.30 release

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse</groupId>
   <artifactId>eclipse-platform-parent</artifactId>
-  <version>4.29.0-SNAPSHOT</version>
+  <version>4.30.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <!--
     See maven-enforcer-plugin configuration to actually break the build if
@@ -64,8 +64,8 @@
       but we'd still want the "marketing number" to be increased to reflect
       "a new yearly release".
     -->
-    <releaseNumberSDK>4.29</releaseNumberSDK>
-    <releaseNumberPlatform>4.29</releaseNumberPlatform>
+    <releaseNumberSDK>4.30</releaseNumberSDK>
+    <releaseNumberPlatform>4.30</releaseNumberPlatform>
 
     <tycho.version>4.0.2</tycho.version>
 
@@ -252,7 +252,7 @@
             <artifact>
               <groupId>org.eclipse</groupId>
               <artifactId>eclipse-sdk-prereqs</artifactId>
-              <version>4.29.0-SNAPSHOT</version>
+              <version>4.30.0-SNAPSHOT</version>
             </artifact>
           </target>
           <environments>

--- a/eclipse-platform-sources/pom.xml
+++ b/eclipse-platform-sources/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>eclipse-platform-parent</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../eclipse-platform-parent</relativePath>
   </parent>
 

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.common</artifactId>
     <groupId>eclipse.platform.common</groupId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.jdt</groupId>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.common</artifactId>
     <groupId>eclipse.platform.common</groupId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.jdt</groupId>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.tips.user/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.tips.user/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>eclipse.platform.common</artifactId>
     <groupId>eclipse.platform.common</groupId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ui</groupId>

--- a/eclipse.platform.common/bundles/org.eclipse.pde.doc.user/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.pde.doc.user/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.common</artifactId>
     <groupId>eclipse.platform.common</groupId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.pde</groupId>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/META-INF/MANIFEST.MF
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.platform.doc.isv; singleton:=true
-Bundle-Version: 4.29.0.qualifier
+Bundle-Version: 4.30.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.2.0,4.0.0)"

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.common</artifactId>
     <groupId>eclipse.platform.common</groupId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.platform</groupId>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.tips/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.tips/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>eclipse.platform.common</artifactId>
     <groupId>eclipse.platform.common</groupId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ui</groupId>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/META-INF/MANIFEST.MF
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.platform.doc.user; singleton:=true
-Bundle-Version: 4.29.0.qualifier
+Bundle-Version: 4.30.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.2.0,4.0.0)"

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.common</artifactId>
     <groupId>eclipse.platform.common</groupId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.platform</groupId>

--- a/eclipse.platform.common/pom.xml
+++ b/eclipse.platform.common/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>eclipse-platform-parent</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../eclipse-platform-parent</relativePath>
   </parent>
 

--- a/eclipse.platform.releng.prereqs.sdk/pom.xml
+++ b/eclipse.platform.releng.prereqs.sdk/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>eclipse-platform-parent</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../eclipse-platform-parent</relativePath>
   </parent>
 

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse-junit-tests/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse-junit-tests/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>eclipse.platform.releng.tychoeclipsebuilder</groupId>
     <artifactId>eclipse.platform.releng.tychoeclipsebuilder</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>eclipse-junit-tests</artifactId>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>eclipse.platform.releng.tychoeclipsebuilder</groupId>
     <artifactId>eclipse.platform.releng.tychoeclipsebuilder</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
   </parent>
   <groupId>eclipse.platform.repository</groupId>
   <artifactId>eclipse.platform.repository</artifactId>

--- a/eclipse.platform.releng.tychoeclipsebuilder/equinox-sdk/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/equinox-sdk/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>eclipse.platform.releng.tychoeclipsebuilder</groupId>
     <artifactId>eclipse.platform.releng.tychoeclipsebuilder</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>equinox-sdk</artifactId>

--- a/eclipse.platform.releng.tychoeclipsebuilder/equinox.starterkit.product/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/equinox.starterkit.product/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>eclipse.platform.releng.tychoeclipsebuilder</groupId>
     <artifactId>eclipse.platform.releng.tychoeclipsebuilder</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.rt.osgistarterkit.product</artifactId>

--- a/eclipse.platform.releng.tychoeclipsebuilder/java21patch/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/java21patch/pom.xml
@@ -18,13 +18,13 @@
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>eclipse-platform-parent</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../eclipse-platform-parent</relativePath>
   </parent>
 
   <groupId>eclipse.platform.releng</groupId>
   <artifactId>eclipse.platform.releng.java21patch</artifactId>
-  <version>4.29.0-SNAPSHOT</version>
+  <version>4.30.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/eclipse.platform.releng.tychoeclipsebuilder/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>eclipse-platform-parent</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../eclipse-platform-parent</relativePath>
   </parent>
 

--- a/eclipse.platform.releng.tychoeclipsebuilder/rcp.config/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/rcp.config/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>eclipse.platform.releng.tychoeclipsebuilder</groupId>
     <artifactId>eclipse.platform.releng.tychoeclipsebuilder</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.rcp.configuration</groupId>

--- a/eclipse.platform.releng.tychoeclipsebuilder/rcp/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/rcp/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>eclipse.platform.releng.tychoeclipsebuilder</groupId>
     <artifactId>eclipse.platform.releng.tychoeclipsebuilder</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.rcp.id</artifactId>

--- a/eclipse.platform.releng/bundles/org.eclipse.ant.optional.junit/pom.xml
+++ b/eclipse.platform.releng/bundles/org.eclipse.ant.optional.junit/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ant</groupId>

--- a/eclipse.platform.releng/bundles/org.eclipse.rcp/META-INF/MANIFEST.MF
+++ b/eclipse.platform.releng/bundles/org.eclipse.rcp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.rcp; singleton:=true
-Bundle-Version: 4.29.0.qualifier
+Bundle-Version: 4.30.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy

--- a/eclipse.platform.releng/bundles/org.eclipse.rcp/pom.xml
+++ b/eclipse.platform.releng/bundles/org.eclipse.rcp/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.rcp</groupId>

--- a/eclipse.platform.releng/bundles/org.eclipse.releng.tests/pom.xml
+++ b/eclipse.platform.releng/bundles/org.eclipse.releng.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.releng</groupId>

--- a/eclipse.platform.releng/bundles/org.eclipse.sdk.examples/META-INF/MANIFEST.MF
+++ b/eclipse.platform.releng/bundles/org.eclipse.sdk.examples/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.sdk.examples; singleton:=true
-Bundle-Version: 4.29.0.qualifier
+Bundle-Version: 4.30.0.qualifier
 Bundle-Localization: plugin

--- a/eclipse.platform.releng/bundles/org.eclipse.sdk.examples/pom.xml
+++ b/eclipse.platform.releng/bundles/org.eclipse.sdk.examples/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.sdk</groupId>

--- a/eclipse.platform.releng/bundles/org.eclipse.sdk.tests/META-INF/MANIFEST.MF
+++ b/eclipse.platform.releng/bundles/org.eclipse.sdk.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests
 Bundle-SymbolicName: org.eclipse.sdk.tests; singleton:=true
-Bundle-Version: 4.29.0.qualifier
+Bundle-Version: 4.30.0.qualifier
 Eclipse-BundleShape: dir
 

--- a/eclipse.platform.releng/bundles/org.eclipse.sdk.tests/pom.xml
+++ b/eclipse.platform.releng/bundles/org.eclipse.sdk.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.sdk</groupId>

--- a/eclipse.platform.releng/bundles/org.eclipse.test.performance.win32/pom.xml
+++ b/eclipse.platform.releng/bundles/org.eclipse.test.performance.win32/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.test</groupId>

--- a/eclipse.platform.releng/bundles/org.eclipse.test.performance/pom.xml
+++ b/eclipse.platform.releng/bundles/org.eclipse.test.performance/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.test</groupId>

--- a/eclipse.platform.releng/bundles/org.eclipse.test/pom.xml
+++ b/eclipse.platform.releng/bundles/org.eclipse.test/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.test</groupId>

--- a/eclipse.platform.releng/features/org.eclipse.help-feature/pom.xml
+++ b/eclipse.platform.releng/features/org.eclipse.help-feature/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.help.feature</groupId>

--- a/eclipse.platform.releng/features/org.eclipse.platform-feature/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.platform-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.platform"
       label="%featureName"
-      version="4.29.0.qualifier"
+      version="4.30.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/eclipse.platform.releng/features/org.eclipse.platform-feature/pom.xml
+++ b/eclipse.platform.releng/features/org.eclipse.platform-feature/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.platform.feature</groupId>

--- a/eclipse.platform.releng/features/org.eclipse.rcp/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.rcp/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.rcp"
       label="%featureName"
-      version="4.29.0.qualifier"
+      version="4.30.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.rcp"
       license-feature="org.eclipse.license"

--- a/eclipse.platform.releng/features/org.eclipse.rcp/pom.xml
+++ b/eclipse.platform.releng/features/org.eclipse.rcp/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.rcp.feature</groupId>

--- a/eclipse.platform.releng/features/org.eclipse.sdk.examples-feature/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.sdk.examples-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.sdk.examples"
       label="%featureName"
-      version="4.29.0.qualifier"
+      version="4.30.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/eclipse.platform.releng/features/org.eclipse.sdk.examples-feature/pom.xml
+++ b/eclipse.platform.releng/features/org.eclipse.sdk.examples-feature/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.sdk.feature</groupId>

--- a/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.sdk.tests"
       label="%featureName"
-      version="4.29.0.qualifier"
+      version="4.30.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/eclipse.platform.releng/features/org.eclipse.sdk.tests/pom.xml
+++ b/eclipse.platform.releng/features/org.eclipse.sdk.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.sdk.feature</groupId>

--- a/eclipse.platform.releng/features/org.eclipse.sdk/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.sdk"
       label="%featureName"
-      version="4.29.0.qualifier"
+      version="4.30.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/eclipse.platform.releng/features/org.eclipse.sdk/pom.xml
+++ b/eclipse.platform.releng/features/org.eclipse.sdk/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.sdk.feature</groupId>

--- a/eclipse.platform.releng/features/org.eclipse.test-feature/pom.xml
+++ b/eclipse.platform.releng/features/org.eclipse.test-feature/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.test.feature</groupId>

--- a/eclipse.platform.releng/pom.xml
+++ b/eclipse.platform.releng/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>eclipse-platform-parent</artifactId>
-    <version>4.29.0-SNAPSHOT</version>
+    <version>4.30.0-SNAPSHOT</version>
     <relativePath>../eclipse-platform-parent</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <groupId>org.eclipse.platform</groupId>
   <artifactId>platform-aggregator</artifactId>
-  <version>4.29.0-SNAPSHOT</version>
+  <version>4.30.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <properties>
     <!--Property used in parent pom which if defined disables activation of build-individual-bundles profile -->


### PR DESCRIPTION
Tracked in
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1289

workflow failure so updating manually