### PR TITLE
Missing migration files for the 4.29rc2a

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/4.28/incompatibilities.html
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/4.28/incompatibilities.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
 <html lang="en">
 <head>
-<meta name="copyright" content="Copyright (c) 2022 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta name="copyright" content="Copyright (c) 2023 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <meta http-equiv="Content-Style-Type" content="text/css">
 <link rel="STYLESHEET" href="../../book.css" type="text/css">
@@ -9,6 +9,11 @@
 </head>
 <body>
 <h1>Incompatibilities between Eclipse 4.27 and 4.28</h1>
+
+<p>
+  So far Eclipse did not change incompatibly between 4.27 and 4.28 in ways that affect
+  plug-ins. Plug-ins that ran on 4.27 should run on 4.28 without any problems.
+</p>
 
 </body>
 </html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.29/faq.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.29/faq.html
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2023 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../../book.css" charset="ISO-8859-1" type="text/css">
+<title>Eclipse 4.29 Plug-in Migration FAQ</title>
+</head>
+<body>
+<h1>Eclipse 4.29 Plug-in Migration FAQ</h1>
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.29/incompatibilities.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.29/incompatibilities.html
@@ -11,8 +11,13 @@
 <h1>Incompatibilities between Eclipse 4.28 and 4.29</h1>
 
 <p>
-  So far Eclipse did not change incompatibly between 4.28 and 4.29 in ways that affect
-  plug-ins. Plug-ins that ran on 4.28 should run on 4.29 without any problems.
+  Eclipse changed in incompatible ways between 4.28 and 4.29 in ways that affect
+  plug-ins. The following entries describe the areas that changed and provide
+  instructions for migrating 4.28 plug-ins to 4.29. Note that you only need to look
+  here if you are experiencing problems running your 4.28 plug-in on 4.29.
+</p>
+<p>
+See also the list of <a href="../removals.html">deprecated API removals</a> for this release.
 </p>
 
 </body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.29/recommended.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.29/recommended.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+
+<head>
+	<meta name="copyright"
+		content="Copyright (c) 2023 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+	<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+	<meta http-equiv="Content-Style-Type" content="text/css">
+	<link rel="STYLESHEET" href="../../book.css" type="text/css">
+	<title>Adopting 4.29 mechanisms and APIs</title>
+</head>
+
+<body>
+	<h1>Adopting 4.29 mechanisms and APIs</h1>
+
+	<p>This section describes changes that are required if you are
+		trying to change your 4.28 plug-in to adopt the 4.29 mechanisms and
+		APIs.</p>
+
+	<!-- ##############################################
+	 ############################################## -->
+
+</body>
+
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/eclipse_4_29_porting_guide.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/eclipse_4_29_porting_guide.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2023 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
+<title>Eclipse 4.29 Plug-in Migration Guide</title>
+</head>
+
+<body>
+
+<h1>Eclipse 4.29 Plug-in Migration Guide</h1>
+<p>This guide covers migrating Eclipse 4.28 plug-ins to Eclipse 4.29.</p>
+<p>One of the goals of Eclipse 4.29 was to move Eclipse forward while remaining compatible
+  with previous versions to the greatest extent possible. That is, plug-ins written
+  against the Eclipse 4.28 APIs should continue to work in 4.29 in spite of any API changes.</p>
+<p>The key kinds of compatibility are API contract compatibility and binary compatibility.
+  API contract compatibility means that valid use of 4.28 APIs remains valid for
+  4.29, so there is no need to revisit working code. Binary compatibility means
+  that the API method signatures, etc. did not change in ways that would cause
+  existing compiled (&quot;binary&quot;) code to no longer link and run with the
+  new 4.29 libraries.</p>
+<p>While every effort was made to avoid breakage, there are a few areas of incompatibility or new
+  APIs that should be adopted by clients.
+  This document describes those areas and provides instructions for migrating 4.28 plug-ins to
+  4.29.</p>
+<ul>
+  <li><a href="4.29/faq.html">Eclipse 4.29 Plug-in Migration FAQ</a></li>
+  <li><a href="4.29/incompatibilities.html">Incompatibilities between Eclipse 4.28 and 4.29</a></li>
+  <li><a href="4.29/recommended.html">Adopting 4.29 mechanisms and API</a></li>
+</ul>
+
+</body>
+</html>


### PR DESCRIPTION
Add missing migration files that have been merged into R4_29 maintenance branch in #1290 also to master branch.

See https://github.com/eclipse-platform/eclipse.platform/issues/668