### PR TITLE
backport: Update bouncycastle to 1.76

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -225,12 +225,12 @@
 				<dependency>
 					<groupId>org.bouncycastle</groupId>
 					<artifactId>bcpg-jdk18on</artifactId>
-					<version>1.72.2</version>
+					<version>1.76</version>
 				</dependency>
 				<dependency>
 					<groupId>org.bouncycastle</groupId>
 					<artifactId>bcprov-jdk18on</artifactId>
-					<version>1.72</version>
+					<version>1.76</version>
 				</dependency>
 				<dependency>
 					<groupId>commons-io</groupId>


### PR DESCRIPTION
Refs: https://github.com/advisories/GHSA-hr8g-6v94-x4m9

/cc @akurtakov 