### PR TITLE
backport: Update Batik to 1.16

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -25,14 +25,6 @@
       <unit id="javax.servlet.jsp" version="2.2.0.v201112011158"/>
       <unit id="javax.servlet.jsp.source" version="2.2.0.v201112011158"/>
       <unit id="javax.xml" version="1.3.4.v201005080400"/>
-      <unit id="org.apache.batik.css" version="1.11.0.v20190515-0436"/>
-      <unit id="org.apache.batik.util" version="1.11.0.v20190515-0436"/>
-      <unit id="org.apache.batik.i18n" version="1.11.0.v20190515-0436"/>
-      <unit id="org.apache.batik.constants" version="1.11.0.v20190515-0436"/>
-      <unit id="org.apache.batik.css.source" version="1.11.0.v20190515-0436"/>
-      <unit id="org.apache.batik.util.source" version="1.11.0.v20190515-0436"/>
-      <unit id="org.apache.batik.i18n.source" version="1.11.0.v20190515-0436"/>
-      <unit id="org.apache.batik.constants.source" version="1.11.0.v20190515-0436"/>
       <unit id="org.apache.xmlgraphics" version="2.3.0.v20190515-0436"/>
       <unit id="org.apache.xmlgraphics.source" version="2.3.0.v20190515-0436"/>
       <unit id="org.apache.commons.logging" version="1.2.0.v20180409-1502"/>
@@ -147,6 +139,18 @@
       <unit id="org.jsoup" version="1.7.2.v201411291515"/>
 
       <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/repository"/>
+    </location>
+
+    <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
+      <unit id="org.apache.batik.css" version="1.16.0.v20221027-0840"/>
+      <unit id="org.apache.batik.util" version="1.16.0.v20221027-0840"/>
+      <unit id="org.apache.batik.i18n" version="1.16.0.v20221027-0840"/>
+      <unit id="org.apache.batik.constants" version="1.16.0.v20221027-0840"/>
+      <unit id="org.apache.batik.css.source" version="1.16.0.v20221027-0840"/>
+      <unit id="org.apache.batik.util.source" version="1.16.0.v20221027-0840"/>
+      <unit id="org.apache.batik.i18n.source" version="1.16.0.v20221027-0840"/>
+      <unit id="org.apache.batik.constants.source" version="1.16.0.v20221027-0840"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20230531010532/repository"/>
     </location>
     
     <!-- Apache Ant-->


### PR DESCRIPTION
Fixes:
* CVE-2022-42890
* CVE-2022-41704

/cc @akurtakov
