### PR TITLE
Remove ancient org.w3c.* bundles from the target platform

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
@@ -170,7 +170,7 @@
 ;${dependency.dir}/jetty-util_*.jar
 ;${dependency.dir}/org.sat4j.core_*.jar
 ;${dependency.dir}/org.sat4j.pb_*.jar
-;${dependency.dir}/org.w3c.css.sac_*.jar
+;${dependency.dir}/org.eclipse.orbit.xml-apis-ext_*.jar
 ;${dependency.dir}/bcpg-jdk18on_*.jar
 ;${dependency.dir}/bcprov-jdk18on_*.jar
 ;${eclipse.equinox.supplement}/${dot.classes}

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
@@ -228,7 +228,7 @@
                   </requirement>
                   <requirement>
                     <type>eclipse-plugin</type>
-                    <id>org.w3c.css.sac</id>
+                    <id>org.eclipse.orbit.xml-apis-ext</id>
                     <versionRange>0.0.0</versionRange>
                   </requirement>
                   <requirement>

--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -56,18 +56,6 @@
       <unit id="org.apache.jasper.glassfish" version="2.2.2.v201501141630"/>
       <unit id="org.apache.jasper.glassfish.source" version="2.2.2.v201501141630"/>
 
-      <unit id="org.w3c.css.sac" version="1.3.1.v200903091627"/>
-      <unit id="org.w3c.css.sac.source" version="1.3.1.v200903091627"/>
-      <unit id="org.w3c.dom.events" version="3.0.0.draft20060413_v201105210656"/>
-      <unit id="org.w3c.dom.events.source" version="3.0.0.draft20060413_v201105210656"/>
-
-      <unit id="org.w3c.dom.smil" version="1.0.1.v200903091627"/>
-      <unit id="org.w3c.dom.smil.source" version="1.0.1.v200903091627"/>
-
-      <unit id="org.w3c.dom.svg" version="1.1.0.v201011041433"/>
-      <unit id="org.w3c.dom.svg.source" version="1.1.0.v201011041433"/>
-
-
       <!-- RedDeer deps-->
       <unit id="org.json" version="1.0.0.v201011060100"/>
 

--- a/eclipse.platform.releng.tychoeclipsebuilder/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/pom.xml
@@ -62,8 +62,6 @@
 							<bundle>org.glassfish.web.javax.servlet.jsp</bundle>
 							<bundle>org.jdom.source</bundle>
 							<bundle>org.jdom</bundle>
-							<bundle>org.w3c.dom.smil.source</bundle>
-							<bundle>org.w3c.dom.smil</bundle>
 						</forceSignature>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1349