### PR TITLE
Simply gpg signing

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/pom.xml
@@ -43,26 +43,11 @@
 					<artifactId>tycho-gpg-plugin</artifactId>
 					<version>${tycho.version}</version>
 					<configuration>
+						<signer>bc</signer>
 						<keyname>b6d3ab9bcc641282</keyname>
-						<skipIfJarsigned>true</skipIfJarsigned>
-						<forceSignature>
-							<bundle>bcpg</bundle>
-							<bundle>bcprov</bundle>
-							<bundle>com.sun.el.javax.el.source</bundle>
-							<bundle>com.sun.el.javax.el</bundle>
-							<bundle>javax.el-api.source</bundle>
-							<bundle>javax.el-api</bundle>
-							<bundle>org.apache.commons.codec.source</bundle>
-							<bundle>org.apache.commons.codec</bundle>
-							<bundle>org.apache.commons.jxpath.source</bundle>
-							<bundle>org.apache.commons.jxpath</bundle>
-							<bundle>org.apache.jasper.glassfish.source</bundle>
-							<bundle>org.apache.jasper.glassfish</bundle>
-							<bundle>org.glassfish.web.javax.servlet.jsp.source</bundle>
-							<bundle>org.glassfish.web.javax.servlet.jsp</bundle>
-							<bundle>org.jdom.source</bundle>
-							<bundle>org.jdom</bundle>
-						</forceSignature>
+						<skipIfJarsigned>false</skipIfJarsigned>
+						<skipIfJarsignedAndAnchored>true</skipIfJarsignedAndAnchored>
+						<pgpKeyBehavior>skip</pgpKeyBehavior>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
Use the bc signer because it's much faster.
Use <skipIfJarsignedAndAnchored> to avoid a <forceSignature> list; this will PGP sign any jar that's not considered to be signed and anchored, so it handles the jce-signed jars as well as any jars with old no-longer-supported weak jar signatures.