### PR TITLE
Fix BuildTests.testPluginFiles() to ignore org.eclipse.orbit

### DIFF
--- a/eclipse.platform.releng/bundles/org.eclipse.releng.tests/src/org/eclipse/releng/tests/BuildTests.java
+++ b/eclipse.platform.releng/bundles/org.eclipse.releng.tests/src/org/eclipse/releng/tests/BuildTests.java
@@ -164,9 +164,9 @@ public class BuildTests {
 		String installDir = Platform.getInstallLocation().getURL().getPath();
 		File pluginDir = new File(installDir, "plugins");
 		for (File aPlugin : pluginDir.listFiles()) {
-			if (!aPlugin.getName().contains("test") && aPlugin.getName().startsWith("org.eclipse")
-					&& !aPlugin.getName().contains("org.eclipse.jetty")
-					&& !aPlugin.getName().contains("org.eclipse.ecf")) {
+			String name = aPlugin.getName();
+			if (!name.contains("test") && name.startsWith("org.eclipse") && !name.contains("org.eclipse.jetty")
+					&& !name.contains("org.eclipse.ecf") && !name.startsWith("org.eclipse.orbit")) {
 				if (!testPluginFile(aPlugin)) {
 					result.add(aPlugin.getPath());
 				}


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1349