### PR TITLE
Fix javadoc generation after search.core being split

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
@@ -57,6 +57,7 @@
 ;${eclipse.platform.ui.bundles}/org.eclipse.core.filebuffers/src
 ;${eclipse.platform.ui.bundles}/org.eclipse.jface.text/projection
 ;${eclipse.platform.ui.bundles}/org.eclipse.jface.text/src
+;${eclipse.platform.ui.bundles}/org.eclipse.search.core/search
 ;${eclipse.platform.ui.bundles}/org.eclipse.search/new search
 ;${eclipse.platform.ui.bundles}/org.eclipse.search/search
 ;${eclipse.platform.ui.bundles}/org.eclipse.text/projection


### PR DESCRIPTION
Continuation of
https://github.com/eclipse-platform/eclipse.platform.ui/pull/1105