### PR TITLE
Fix redirection problems with the root Platform.setup

### DIFF
--- a/oomph/Platform.setup
+++ b/oomph/Platform.setup
@@ -182,6 +182,24 @@
       <description>Platform Base, Update, and Ant</description>
     </setupTask>
     <setupTask
+        xsi:type="setup:ResourceCreationTask"
+        excludedTriggers="BOOTSTRAP"
+        targetURL="${github.clone.platform.location|uri/ua/infocenter-web/.project2}"
+        encoding="UTF-8">
+      <content>
+        &lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?>
+        &lt;projectDescription>
+        	&lt;name>infocenter-web&lt;/name>
+        	&lt;comment>&lt;/comment>
+        	&lt;projects>
+        	&lt;/projects>
+        	&lt;natures>
+        	&lt;/natures>
+        &lt;/projectDescription>
+
+      </content>
+    </setupTask>
+    <setupTask
         xsi:type="setup.targlets:TargletTask">
       <targlet
           name="Platform"
@@ -767,7 +785,7 @@
       <setupTask
           xsi:type="setup:EclipseIniTask"
           option="-Doomph.redirection.platform.releng.aggregator"
-          value="=https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.releng.aggregator/master/oomph/->${github.clone.platform.releng.aggregator.location|uri}/oomph/"
+          value="=https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.releng.aggregator/master/oomph/Platform.setup->${github.clone.platform.releng.aggregator.location|uri}/oomph/Platform.setup"
           vm="true"/>
     </stream>
     <description>The Platform Releng Agrregator components, including the Platform's products</description>


### PR DESCRIPTION
Create a .project file for infocenter-web so that it's imported into the workspace; this file is ignored by .gitignore so this doesn't dirty the clone.