### PR TITLE
Fix finding search.core classes for javadoc

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/jdtOptions.txt
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/jdtOptions.txt
@@ -71,6 +71,7 @@
 ;${eclipse.platform.team.bundles}/org.eclipse.team.ui/${dot.classes}
 ;${eclipse.platform.ui.bundles}/org.eclipse.core.filebuffers/${dot.classes}
 ;${eclipse.platform.ui.bundles}/org.eclipse.jface.text/${dot.classes}
+;${eclipse.platform.ui.bundles}/org.eclipse.search.core/${dot.classes}
 ;${eclipse.platform.ui.bundles}/org.eclipse.search/${dot.classes}
 ;${eclipse.platform.ui.bundles}/org.eclipse.text/${dot.classes}
 ;${eclipse.platform.ui.bundles}/org.eclipse.ui.editors/${dot.classes}


### PR DESCRIPTION
Continuation of
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/commit/725cacd808359189e38bda85b416ed80d03bda22