### PR TITLE
Temporary use ECF snapshots

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -73,14 +73,18 @@
       <unit id="org.eclipse.ecf.core.feature.source.feature.group" version="1.6.1.v20230507-1923"/>
       <unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="1.1.501.v20230507-1921"/>
       <unit id="org.eclipse.ecf.core.ssl.feature.source.feature.group" version="1.1.501.v20230507-1921"/>
-      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.14.1800.v20230422-0242"/>
-      <unit id="org.eclipse.ecf.filetransfer.feature.source.feature.group" version="3.14.1800.v20230422-0242"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" version="1.1.701.v20230423-0417"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.source.feature.group" version="1.1.701.v20230423-0417"/>
+      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.14.1900.v20230715-1945"/>
+      <unit id="org.eclipse.ecf.filetransfer.feature.source.feature.group" version="3.14.1900.v20230715-1945"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclientjava.feature.feature.group" version="2.0.0.v20230715-1752"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclientjava.feature.source.feature.group" version="2.0.0.v20230715-1752"/>
       <unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.1.401.v20230422-0242"/>
       <unit id="org.eclipse.ecf.filetransfer.ssl.feature.source.feature.group" version="1.1.401.v20230422-0242"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclientjava.feature.feature.group" version="1.0.0.v20230528-2254"/>
-      <repository location="https://download.eclipse.org/rt/ecf/3.14.39/site.p2/3.14.39.v20230529-2152/"/>
+      <!-- ⚠️ Remove httpclient5 when there is no reference left ⚠️ -->
+      <!-- https://github.com/eclipse-equinox/p2/pull/206 -->
+      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" version="1.1.701.v20230423-0417"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.source.feature.group" version="1.1.701.v20230423-0417"/>
+      <!-- ⚠️ TODO Use a release repo for 3.14.40 before releaseing Platform ⚠️ -->
+      <repository location="https://download.eclipse.org/rt/ecf/snapshot/site.p2/3.14.40.v20230905-1933/"/>
     </location>
 
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">


### PR DESCRIPTION
So we can start consuming the new httpclientjava and getting rid of httpclient5.

The snapshot repo must be replaced by release one as soon as ECF provides a release, before Eclipse 4.30.M3.

See https://github.com/eclipse-equinox/p2/pull/206