### PR TITLE
add build-helper-maven-plugin to pluginManagement section

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -595,6 +595,11 @@
 		    <artifactId>maven-toolchains-plugin</artifactId>
 		    <version>3.1.0</version>
 		</plugin>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>build-helper-maven-plugin</artifactId>
+					<version>3.4.0</version>
+				</plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
There are many warnings in the platform builds in the following form:

'build.plugins.plugin.version' for
org.codehaus.mojo:build-helper-maven-plugin is missing

this is injected automatically by tycho-build-extension but as the extension can't know the desired version it has to be configured in the configurator-pom (or parent like here),