### PR TITLE
Adapt to moved org.eclipse.search.textEngingSearch

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/buildDoc.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/buildDoc.xml
@@ -51,6 +51,7 @@
 		<pde.convertSchemaToHTML manifest="${eclipse.platform.team.bundles}/org.eclipse.jsch.core/plugin.xml" destination="${dest}" additionalsearchpaths="${searchPaths}" />
 		<pde.convertSchemaToHTML manifest="${eclipse.jdt.ui}/org.eclipse.ltk.core.refactoring/plugin.xml" destination="${dest}" additionalsearchpaths="${searchPaths}" />
 		<pde.convertSchemaToHTML manifest="${eclipse.jdt.ui}/org.eclipse.ltk.ui.refactoring/plugin.xml" destination="${dest}" additionalsearchpaths="${searchPaths}" />
+		<pde.convertSchemaToHTML manifest="${eclipse.platform.ui.bundles}/org.eclipse.search.core/plugin.xml" destination="${dest}" additionalsearchpaths="${searchPaths}" />
 		<pde.convertSchemaToHTML manifest="${eclipse.platform.ui.bundles}/org.eclipse.search/plugin.xml" destination="${dest}" additionalsearchpaths="${searchPaths}" />
 		<pde.convertSchemaToHTML manifest="${eclipse.platform.team.bundles}/org.eclipse.team.core/plugin.xml" destination="${dest}" additionalsearchpaths="${searchPaths}" />
 		<pde.convertSchemaToHTML manifest="${eclipse.platform.team.bundles}/org.eclipse.team.ui/plugin.xml" destination="${dest}" additionalsearchpaths="${searchPaths}" />

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/plugin.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/plugin.xml
@@ -100,6 +100,7 @@
            <plugin id="org.eclipse.ltk.core.refactoring"/>
            <plugin id="org.eclipse.ltk.ui.refactoring"/>
            <plugin id="org.eclipse.osgi"/>
+           <plugin id="org.eclipse.search.core"/>
            <plugin id="org.eclipse.search"/>
            <plugin id="org.eclipse.swt"/>
            <plugin id="org.eclipse.team.core"/>


### PR DESCRIPTION
Add references to new org.eclipse.search.core bundle

Follow-up of
https://github.com/eclipse-platform/eclipse.platform.ui/pull/1054