### PR TITLE
Remove jackson from the target platform

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -565,28 +565,6 @@
 			  </dependency>
 		  </dependencies>
 	  </location>
-	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="Reddeer Deps" missingManifest="error" type="Maven">
-		  <dependencies>
-			  <dependency>
-				  <groupId>com.fasterxml.jackson.core</groupId>
-				  <artifactId>jackson-annotations</artifactId>
-				  <version>2.15.2</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>com.fasterxml.jackson.core</groupId>
-				  <artifactId>jackson-core</artifactId>
-				  <version>2.15.2</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>com.fasterxml.jackson.core</groupId>
-				  <artifactId>jackson-databind</artifactId>
-				  <version>2.15.2</version>
-				  <type>jar</type>
-			  </dependency>
-		  </dependencies>
-	  </location>
 	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="Apache Felix" missingManifest="error" type="Maven">
 		  <dependencies>
 			  <dependency>


### PR DESCRIPTION
This was needed only for RedDeer and that dependency is already removed.