### PR TITLE
[GH] Explicitly specify mvn-toolchain-id for setup JDKs to match BREEs

### DIFF
--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -56,6 +56,10 @@ jobs:
           8
           11
           17
+        mvn-toolchain-id: |
+          JavaSE-1.8
+          JavaSE-11
+          JavaSE-17
         distribution: 'temurin'
         cache: maven
     - name: Set up Maven


### PR DESCRIPTION
The toolchains.xml generated by the setup-java GitHub action has '8' as 'version' value for the Java-1.8 JDK and therefore the tycho-compiler-plugin does not match it when has 'useJDK=BREE' configured for a Plugin with BREE JavaSE-1.8.

Therefore explicitly set the 'id' of each jdk-toolchain to match the corresponding BREE identifier so that the tycho-compiler-plugin can find it via this secondary way.