### PR TITLE
[GH] Explicitly specify mvn-toolchain-id for setup JDKs to match BREEs in codeQLworkflow.yml

### DIFF
--- a/.github/workflows/codeQLworkflow.yml
+++ b/.github/workflows/codeQLworkflow.yml
@@ -65,6 +65,10 @@ jobs:
           8
           11
           17
+        mvn-toolchain-id: |
+          JavaSE-1.8
+          JavaSE-11
+          JavaSE-17
         distribution: 'temurin'
         cache: maven
     - name: Set up Maven


### PR DESCRIPTION
Follow-up on https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1399