### PR TITLE
Place jakarta-EE annotation bundles in one target location

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -131,18 +131,6 @@
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
-				  <groupId>jakarta.annotation</groupId>
-				  <artifactId>jakarta.annotation-api</artifactId>
-				  <version>1.3.5</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>jakarta.inject</groupId>
-				  <artifactId>jakarta.inject-api</artifactId>
-				  <version>1.0.5</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
 				  <groupId>net.java.dev.jna</groupId>
 				  <artifactId>jna-platform</artifactId>
 				  <version>5.13.0</version>
@@ -703,7 +691,19 @@
 			  <dependency>
 				  <groupId>jakarta.annotation</groupId>
 				  <artifactId>jakarta.annotation-api</artifactId>
+				  <version>1.3.5</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>jakarta.annotation</groupId>
+				  <artifactId>jakarta.annotation-api</artifactId>
 				  <version>2.1.1</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>jakarta.inject</groupId>
+				  <artifactId>jakarta.inject-api</artifactId>
+				  <version>1.0.5</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>


### PR DESCRIPTION
Follow-up on https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1370

@akurtakov I assume we can merge this now, even in M1 week since this should not have an external effect, can't we?