### PR TITLE
Add Jetty EE8 bundles to target platform

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -321,6 +321,30 @@
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
+				  <groupId>org.eclipse.jetty.ee8</groupId>
+				  <artifactId>jetty-ee8-apache-jsp</artifactId>
+				  <version>12.0.1</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>org.eclipse.jetty.ee8</groupId>
+				  <artifactId>jetty-ee8-nested</artifactId>
+				  <version>12.0.1</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>org.eclipse.jetty.ee8</groupId>
+				  <artifactId>jetty-ee8-security</artifactId>
+				  <version>12.0.1</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>org.eclipse.jetty.ee8</groupId>
+				  <artifactId>jetty-ee8-servlet</artifactId>
+				  <version>12.0.1</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
 				  <groupId>org.glassfish</groupId>
 				  <artifactId>jakarta.el</artifactId>
 				  <version>3.0.4</version>


### PR DESCRIPTION
Another step towards
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1384