### PR TITLE
Touch to fix comparator errors

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -232,18 +232,6 @@
 			  </dependency>
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>
-				  <artifactId>apache-jsp</artifactId>
-				  <version>10.0.16</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>org.eclipse.jetty</groupId>
-				  <artifactId>jetty-http</artifactId>
-				  <version>10.0.16</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>org.eclipse.jetty</groupId>
 				  <artifactId>jetty-http</artifactId>
 				  <version>12.0.1</version>
 				  <type>jar</type>
@@ -251,19 +239,7 @@
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>
 				  <artifactId>jetty-io</artifactId>
-				  <version>10.0.16</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>org.eclipse.jetty</groupId>
-				  <artifactId>jetty-io</artifactId>
 				  <version>12.0.1</version>
-				  <type>jar</type>
-			  </dependency>
-			   <dependency>
-				  <groupId>org.eclipse.jetty</groupId>
-				  <artifactId>jetty-security</artifactId>
-				  <version>10.0.16</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
@@ -275,19 +251,7 @@
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>
 				  <artifactId>jetty-server</artifactId>
-				  <version>10.0.16</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>org.eclipse.jetty</groupId>
-				  <artifactId>jetty-server</artifactId>
 				  <version>12.0.1</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>org.eclipse.jetty</groupId>
-				  <artifactId>jetty-servlet</artifactId>
-				  <version>10.0.16</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
@@ -299,19 +263,7 @@
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>
 				  <artifactId>jetty-util-ajax</artifactId>
-				  <version>10.0.16</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>org.eclipse.jetty</groupId>
-				  <artifactId>jetty-util-ajax</artifactId>
 				  <version>12.0.1</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>org.eclipse.jetty</groupId>
-				  <artifactId>jetty-util</artifactId>
-				  <version>10.0.16</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>


### PR DESCRIPTION
Caused by new launcher binaries
https://github.com/eclipse-equinox/equinox.binaries/commit/e186a1b573faabb9ad5ec5d9a2b4762b8074cc05