### PR TITLE
Revert "Touch to fix comparator errors"

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -232,6 +232,18 @@
 			  </dependency>
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>
+				  <artifactId>apache-jsp</artifactId>
+				  <version>10.0.16</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>org.eclipse.jetty</groupId>
+				  <artifactId>jetty-http</artifactId>
+				  <version>10.0.16</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>org.eclipse.jetty</groupId>
 				  <artifactId>jetty-http</artifactId>
 				  <version>12.0.1</version>
 				  <type>jar</type>
@@ -239,7 +251,19 @@
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>
 				  <artifactId>jetty-io</artifactId>
+				  <version>10.0.16</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>org.eclipse.jetty</groupId>
+				  <artifactId>jetty-io</artifactId>
 				  <version>12.0.1</version>
+				  <type>jar</type>
+			  </dependency>
+			   <dependency>
+				  <groupId>org.eclipse.jetty</groupId>
+				  <artifactId>jetty-security</artifactId>
+				  <version>10.0.16</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
@@ -251,7 +275,19 @@
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>
 				  <artifactId>jetty-server</artifactId>
+				  <version>10.0.16</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>org.eclipse.jetty</groupId>
+				  <artifactId>jetty-server</artifactId>
 				  <version>12.0.1</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>org.eclipse.jetty</groupId>
+				  <artifactId>jetty-servlet</artifactId>
+				  <version>10.0.16</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
@@ -263,7 +299,19 @@
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>
 				  <artifactId>jetty-util-ajax</artifactId>
+				  <version>10.0.16</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>org.eclipse.jetty</groupId>
+				  <artifactId>jetty-util-ajax</artifactId>
 				  <version>12.0.1</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>org.eclipse.jetty</groupId>
+				  <artifactId>jetty-util</artifactId>
+				  <version>10.0.16</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>


### PR DESCRIPTION
Reverts eclipse-platform/eclipse.platform.releng.aggregator#1414 as this is completely different patch from what was ment.