### PR TITLE
Touch to fix comparator errors

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/rcp.config/forceQualifierUpdate.txt
+++ b/eclipse.platform.releng.tychoeclipsebuilder/rcp.config/forceQualifierUpdate.txt
@@ -20,3 +20,4 @@ Touch due to changes for "Mac App" layout
 Bug 461674 - [Mac] Look for eclipse.ini in new place
 Bug 461674 - [Mac] Look for eclipse.ini in new place
 Bug 461674 - [Mac] Look for eclipse.ini in new place
+Touch due to recompiled launcher binaries. 


### PR DESCRIPTION
Caused by new launcher binaries
eclipse-equinox/equinox.binaries@e186a1b