### PR TITLE
Remove Jetty 10 from target platform

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
@@ -203,7 +203,7 @@
                   </requirement>
                   <requirement>
                     <type>eclipse-plugin</type>
-                    <id>org.eclipse.jetty.servlet</id>
+                    <id>org.eclipse.jetty.ee8.servlet</id>
                     <versionRange>0.0.0</versionRange>
                   </requirement>
                   <requirement>

--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -232,18 +232,6 @@
 			  </dependency>
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>
-				  <artifactId>apache-jsp</artifactId>
-				  <version>10.0.16</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>org.eclipse.jetty</groupId>
-				  <artifactId>jetty-http</artifactId>
-				  <version>10.0.16</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>org.eclipse.jetty</groupId>
 				  <artifactId>jetty-http</artifactId>
 				  <version>12.0.1</version>
 				  <type>jar</type>
@@ -251,19 +239,7 @@
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>
 				  <artifactId>jetty-io</artifactId>
-				  <version>10.0.16</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>org.eclipse.jetty</groupId>
-				  <artifactId>jetty-io</artifactId>
 				  <version>12.0.1</version>
-				  <type>jar</type>
-			  </dependency>
-			   <dependency>
-				  <groupId>org.eclipse.jetty</groupId>
-				  <artifactId>jetty-security</artifactId>
-				  <version>10.0.16</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
@@ -275,19 +251,7 @@
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>
 				  <artifactId>jetty-server</artifactId>
-				  <version>10.0.16</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>org.eclipse.jetty</groupId>
-				  <artifactId>jetty-server</artifactId>
 				  <version>12.0.1</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>org.eclipse.jetty</groupId>
-				  <artifactId>jetty-servlet</artifactId>
-				  <version>10.0.16</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
@@ -299,19 +263,7 @@
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>
 				  <artifactId>jetty-util-ajax</artifactId>
-				  <version>10.0.16</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>org.eclipse.jetty</groupId>
-				  <artifactId>jetty-util-ajax</artifactId>
 				  <version>12.0.1</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>org.eclipse.jetty</groupId>
-				  <artifactId>jetty-util</artifactId>
-				  <version>10.0.16</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>

--- a/eclipse.platform.releng/features/org.eclipse.help-feature/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.help-feature/feature.xml
@@ -134,13 +134,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.eclipse.jetty.servlet"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.jetty.util"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
Should be the last part to land for
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1384