### PR TITLE
Fix platform javadoc build with Jetty 12

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
@@ -168,7 +168,10 @@
 ;${dependency.dir}/jetty-security_*.jar
 ;${dependency.dir}/jetty-server_*.jar
 ;${dependency.dir}/jetty-servlet_*.jar
+;${dependency.dir}/jetty-session_*.jar
 ;${dependency.dir}/jetty-util_*.jar
+;${dependency.dir}/jetty-ee8-servlet_*.jar
+;${dependency.dir}/jetty-ee8-nested_*.jar
 ;${dependency.dir}/org.sat4j.core_*.jar
 ;${dependency.dir}/org.sat4j.pb_*.jar
 ;${dependency.dir}/org.eclipse.orbit.xml-apis-ext_*.jar


### PR DESCRIPTION
Tracked in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1384