### PR TITLE
Update BND-lib to 7.0.0

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -537,31 +537,31 @@
 			  <dependency>
 				  <groupId>biz.aQute.bnd</groupId>
 				  <artifactId>biz.aQute.bnd.annotation</artifactId>
-				  <version>6.4.1</version>
+				  <version>7.0.0</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
 				  <groupId>biz.aQute.bnd</groupId>
 				  <artifactId>biz.aQute.bnd.embedded-repo</artifactId>
-				  <version>6.4.1</version>
+				  <version>7.0.0</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
 				  <groupId>biz.aQute.bnd</groupId>
 				  <artifactId>biz.aQute.bnd.util</artifactId>
-				  <version>6.4.1</version>
+				  <version>7.0.0</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
 				  <groupId>biz.aQute.bnd</groupId>
 				  <artifactId>biz.aQute.bndlib</artifactId>
-				  <version>6.4.1</version>
+				  <version>7.0.0</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
 				  <groupId>biz.aQute.bnd</groupId>
 				  <artifactId>biz.aQute.repository</artifactId>
-				  <version>6.4.1</version>
+				  <version>7.0.0</version>
 				  <type>jar</type>
 			  </dependency>
 		  </dependencies>


### PR DESCRIPTION
The Import-Package version ranges already have been widened in https://github.com/eclipse-pde/eclipse.pde/pull/781 to work with the new version too.