### PR TITLE
Move common build arguments to maven.config and remove unnecessary

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-DaggregatorBuild=true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,10 +55,9 @@ pipeline {
 					mvn clean verify -e -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 						-Pbree-libs \
 						${MVN_ARGS} \
-						-Dmaven.test.skip=true -DskipTests=true -DaggregatorBuild=true \
+						-Dmaven.test.skip=true -DskipTests=true \
 						-DapiBaselineTargetDirectory=${WORKSPACE} \
 						-Dgpg.passphrase="${KEYRING_PASSPHRASE}" \
-						-Dproject.build.sourceEncoding=UTF-8 \
 						-Dcbi-ecj-version=99.99
 					'''
 				}

--- a/cje-production/P-build/mb220_buildSdkPatch.sh
+++ b/cje-production/P-build/mb220_buildSdkPatch.sh
@@ -42,7 +42,6 @@ mvn -f eclipse.platform.releng.tychoeclipsebuilder/${PATCH_OR_BRANCH_LABEL}/pom.
   -Djgit.dirtyWorkingTree=error \
   -Dmaven.repo.local=$LOCAL_REPO \
   -Djava.io.tmpdir=$CJE_ROOT/$TMP_DIR \
-  -DaggregatorBuild=true \
   -DbuildTimestamp=$TIMESTAMP \
   -DbuildType=$BUILD_TYPE \
   -DbuildId=$BUILD_ID \

--- a/cje-production/mbscripts/mb220_buildSdkPatch.sh
+++ b/cje-production/mbscripts/mb220_buildSdkPatch.sh
@@ -39,7 +39,6 @@ mvn clean verify -DskipTests=true ${MVN_ARGS} \
   -Djgit.dirtyWorkingTree=error \
   -Dmaven.repo.local=$LOCAL_REPO \
   -Djava.io.tmpdir=$CJE_ROOT/$TMP_DIR \
-  -DaggregatorBuild=true \
   -DbuildTimestamp=$TIMESTAMP \
   -DbuildType=$BUILD_TYPE \
   -DbuildId=$BUILD_ID \

--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -670,7 +670,7 @@
       <id>build-individual-bundles</id>
       <activation>
         <property>
-          <!-- Enable if aggregatorBuild property is not set -->
+          <!-- Enable if aggregatorBuild system-property is not set -->
           <name>!aggregatorBuild</name>
         </property>
       </activation>

--- a/pom.xml
+++ b/pom.xml
@@ -20,10 +20,6 @@
   <artifactId>platform-aggregator</artifactId>
   <version>4.30.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <properties>
-    <!--Property used in parent pom which if defined disables activation of build-individual-bundles profile -->
-    <aggregatorBuild>true</aggregatorBuild>
-  </properties>
   <pluginRepositories>
 	<pluginRepository>
 		<id>tycho-snapshots</id>


### PR DESCRIPTION
The property 'project.build.sourceEncoding' is already defined in the eclipse-platform-parent/pom.xml used as parent for all modules, thus it is not necessary to explicitly add it in the Jenkinsfile.

Moving the definition of the 'aggregatorBuild' property to the maven.config simplifies local builds because then the property does not have to be declared.