### PR TITLE
Update to Jetty 12.0.2

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -309,12 +309,6 @@
 				  <type>jar</type>
 			  </dependency>
 		  </dependencies>
-		  <repositories>
-			  <repository>
-				  <id>Id1</id>
-				  <url>https://oss.sonatype.org/content/repositories/jetty-1827/</url>
-			  </repository>
-		  </repositories>
 	  </location>
 	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="Test dependencies" missingManifest="error" type="Maven">
 		  <dependencies>

--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -233,67 +233,67 @@
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>
 				  <artifactId>jetty-http</artifactId>
-				  <version>12.0.1</version>
+				  <version>12.0.2</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>
 				  <artifactId>jetty-io</artifactId>
-				  <version>12.0.1</version>
+				  <version>12.0.2</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>
 				  <artifactId>jetty-security</artifactId>
-				  <version>12.0.1</version>
+				  <version>12.0.2</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>
 				  <artifactId>jetty-server</artifactId>
-				  <version>12.0.1</version>
+				  <version>12.0.2</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>
 				  <artifactId>jetty-session</artifactId>
-				  <version>12.0.1</version>
+				  <version>12.0.2</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>
 				  <artifactId>jetty-util-ajax</artifactId>
-				  <version>12.0.1</version>
+				  <version>12.0.2</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
 				  <groupId>org.eclipse.jetty</groupId>
 				  <artifactId>jetty-util</artifactId>
-				  <version>12.0.1</version>
+				  <version>12.0.2</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
 				  <groupId>org.eclipse.jetty.ee8</groupId>
 				  <artifactId>jetty-ee8-apache-jsp</artifactId>
-				  <version>12.0.1</version>
+				  <version>12.0.2</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
 				  <groupId>org.eclipse.jetty.ee8</groupId>
 				  <artifactId>jetty-ee8-nested</artifactId>
-				  <version>12.0.1</version>
+				  <version>12.0.2</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
 				  <groupId>org.eclipse.jetty.ee8</groupId>
 				  <artifactId>jetty-ee8-security</artifactId>
-				  <version>12.0.1</version>
+				  <version>12.0.2</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
 				  <groupId>org.eclipse.jetty.ee8</groupId>
 				  <artifactId>jetty-ee8-servlet</artifactId>
-				  <version>12.0.1</version>
+				  <version>12.0.2</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
@@ -309,6 +309,12 @@
 				  <type>jar</type>
 			  </dependency>
 		  </dependencies>
+		  <repositories>
+			  <repository>
+				  <id>Id1</id>
+				  <url>https://oss.sonatype.org/content/repositories/jetty-1827/</url>
+			  </repository>
+		  </repositories>
 	  </location>
 	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="Test dependencies" missingManifest="error" type="Maven">
 		  <dependencies>

--- a/eclipse.platform.releng/features/org.eclipse.help-feature/forceQualifierUpdate.txt
+++ b/eclipse.platform.releng/features/org.eclipse.help-feature/forceQualifierUpdate.txt
@@ -8,3 +8,4 @@ Bug 457171 - adopt and adjust to new jasper.glassfish bundle from Orbit
 Bug 527904 - Update platform.ua to Lucene 7.1
 Change in included bundle authored before last change on feature but merged after, confusing qualifier computation
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1419
+Update to Jetty 12.0.2


### PR DESCRIPTION
Jetty 12.0.2, which provides the fixed metadata, is staged according to:
https://github.com/eclipse/jetty.project/issues/10649