### PR TITLE
Update target platform to Orbit pre-m1

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -9,14 +9,16 @@
 
       <unit id="org.apache.ant" version="1.10.14.v20230922-1200"/>
       <unit id="org.apache.ant.source" version="1.10.14.v20230922-1200"/>
-      <unit id="org.apache.batik.css" version="1.17.0.v20230917-1000"/>
-      <unit id="org.apache.batik.util" version="1.17.0.v20230917-1000"/>
-      <unit id="org.apache.batik.i18n" version="1.17.0.v20230917-1000"/>
-      <unit id="org.apache.batik.constants" version="1.17.0.v20230917-1000"/>
-      <unit id="org.apache.batik.css.source" version="1.17.0.v20230917-1000"/>
-      <unit id="org.apache.batik.util.source" version="1.17.0.v20230917-1000"/>
-      <unit id="org.apache.batik.i18n.source" version="1.17.0.v20230917-1000"/>
-      <unit id="org.apache.batik.constants.source" version="1.17.0.v20230917-1000"/>
+
+      <unit id="org.apache.batik.css" version="1.17.0.v20231009-1000"/>
+      <unit id="org.apache.batik.util" version="1.17.0.v20231009-1000"/>
+      <unit id="org.apache.batik.i18n" version="1.17.0.v20231009-1000"/>
+      <unit id="org.apache.batik.constants" version="1.17.0.v20231009-1000"/>
+      <unit id="org.apache.batik.css.source" version="1.17.0.v20231009-1000"/>
+      <unit id="org.apache.batik.util.source" version="1.17.0.v20231009-1000"/>
+      <unit id="org.apache.batik.i18n.source" version="1.17.0.v20231009-1000"/>
+      <unit id="org.apache.batik.constants.source" version="1.17.0.v20231009-1000"/>
+
       <unit id="org.apache.xmlgraphics" version="2.9.0.v20230916-1600"/>
       <unit id="org.apache.xmlgraphics.source" version="2.9.0.v20230916-1600"/>
 
@@ -24,12 +26,12 @@
       <unit id="org.junit" version="4.13.2.v20230809-1000"/>
       <unit id="org.junit.source" version="4.13.2.v20230809-1000"/>
 
-      <unit id="org.apache.lucene.core" version="9.7.0.v20230703-0758"/>
-      <unit id="org.apache.lucene.analysis-smartcn" version="9.7.0.v20230703-0758"/>
-      <unit id="org.apache.lucene.analysis-common" version="9.7.0.v20230703-0758"/>
-      <unit id="org.apache.lucene.core.source" version="9.7.0.v20230703-0758"/>
-      <unit id="org.apache.lucene.analysis-smartcn.source" version="9.7.0.v20230703-0758"/>
-      <unit id="org.apache.lucene.analysis-common.source" version="9.7.0.v20230703-0758"/>
+      <unit id="org.apache.lucene.core" version="9.8.0.v20230929-1030"/>
+      <unit id="org.apache.lucene.analysis-smartcn" version="9.8.0.v20230929-1030"/>
+      <unit id="org.apache.lucene.analysis-common" version="9.8.0.v20230929-1030"/>
+      <unit id="org.apache.lucene.core.source" version="9.8.0.v20230929-1030"/>
+      <unit id="org.apache.lucene.analysis-smartcn.source" version="9.8.0.v20230929-1030"/>
+      <unit id="org.apache.lucene.analysis-common.source" version="9.8.0.v20230929-1030"/>
 
       <unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
       <unit id="org.hamcrest.core.source" version="2.2.0.v20230809-1000"/>
@@ -47,7 +49,7 @@
 
       <!-- This is the "normal" Orbit repository.
            This is the repo that is expected to be updated on milestones and releases based on Orbit deliveries. -->
-      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202309230909"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202310110718"/>
     </location>
 
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">


### PR DESCRIPTION
This includes slightly updated versions of batik as well as new versions of lucene.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1392