### PR TITLE
Remove wrong tycho.scmUrls

### DIFF
--- a/eclipse.platform.common/pom.xml
+++ b/eclipse.platform.common/pom.xml
@@ -24,7 +24,7 @@
   <packaging>pom</packaging>
 
    <properties>
-     <tycho.scmUrl>scm:git:https://github.com/eclipse-platform/eclipse.platform.common.git</tycho.scmUrl>
+     <tycho.scmUrl>scm:git:https://github.com/eclipse-platform/eclipse.platform.releng.aggregator.git</tycho.scmUrl>
   </properties>
 
   <!--

--- a/eclipse.platform.releng/pom.xml
+++ b/eclipse.platform.releng/pom.xml
@@ -27,7 +27,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <tycho.scmUrl>scm:git:https://github.com/eclipse-platform/eclipse.platform.releng.git</tycho.scmUrl>
+    <tycho.scmUrl>scm:git:https://github.com/eclipse-platform/eclipse.platform.releng.aggregator.git</tycho.scmUrl>
   </properties>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
   <artifactId>platform-aggregator</artifactId>
   <version>4.30.0-SNAPSHOT</version>
   <packaging>pom</packaging>
+
   <pluginRepositories>
 	<pluginRepository>
 		<id>tycho-snapshots</id>


### PR DESCRIPTION
They have been wrong since the merge of repos and lead to wrong scm urls in bundles.