### PR TITLE
Migrate tests in org.eclipse.test.performance to JUnit 5

### DIFF
--- a/eclipse.platform.releng/bundles/org.eclipse.test.performance/META-INF/MANIFEST.MF
+++ b/eclipse.platform.releng/bundles/org.eclipse.test.performance/META-INF/MANIFEST.MF
@@ -15,7 +15,8 @@ Export-Package: org.eclipse.perfmsr.core,
  org.eclipse.test.internal.performance.eval,
  org.eclipse.test.internal.performance.tests,
  org.eclipse.test.performance
-Import-Package: org.junit.jupiter.api
+Import-Package: org.junit.jupiter.api,
+ org.junit.platform.suite.api
 Require-Bundle: org.eclipse.core.runtime,
  org.junit
 Bundle-ActivationPolicy: lazy

--- a/eclipse.platform.releng/bundles/org.eclipse.test.performance/src/org/eclipse/test/internal/performance/tests/AllTests.java
+++ b/eclipse.platform.releng/bundles/org.eclipse.test.performance/src/org/eclipse/test/internal/performance/tests/AllTests.java
@@ -14,18 +14,11 @@
 
 package org.eclipse.test.internal.performance.tests;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
+@Suite
+@SelectClasses({ PerformanceMeterFactoryTest.class, SimplePerformanceMeterTest.class, VariationsTests.class })
 public class AllTests {
-
-    public static Test suite() {
-        TestSuite suite = new TestSuite("Performance Test plugin tests"); //$NON-NLS-1$
-
-        // suite.addTestSuite(SimplePerformanceMeterTest.class);
-        suite.addTestSuite(VariationsTests.class);
-        suite.addTestSuite(PerformanceMeterFactoryTest.class);
-
-        return suite;
-    }
+    //
 }

--- a/eclipse.platform.releng/bundles/org.eclipse.test.performance/src/org/eclipse/test/internal/performance/tests/PerformanceMeterFactoryTest.java
+++ b/eclipse.platform.releng/bundles/org.eclipse.test.performance/src/org/eclipse/test/internal/performance/tests/PerformanceMeterFactoryTest.java
@@ -14,20 +14,22 @@
 
 package org.eclipse.test.internal.performance.tests;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.eclipse.test.internal.performance.OSPerformanceMeter;
 import org.eclipse.test.performance.Performance;
 import org.eclipse.test.performance.PerformanceMeter;
+import org.junit.jupiter.api.Test;
 
-import junit.framework.TestCase;
+public class PerformanceMeterFactoryTest {
 
-public class PerformanceMeterFactoryTest extends TestCase {
-
+    @Test
     public void testPerformanceMeterFactory() {
         System.setProperty(
                 "PerformanceMeterFactory", "org.eclipse.test.performance:org.eclipse.test.internal.performance.OSPerformanceMeterFactory"); //$NON-NLS-1$ //$NON-NLS-2$
 
         Performance performance = Performance.getDefault();
-        PerformanceMeter pm = performance.createPerformanceMeter(performance.getDefaultScenarioId(this));
+        PerformanceMeter pm = performance.createPerformanceMeter(performance.getDefaultScenarioId(this.getClass()));
 
         assertTrue(pm instanceof OSPerformanceMeter);
     }

--- a/eclipse.platform.releng/bundles/org.eclipse.test.performance/src/org/eclipse/test/internal/performance/tests/SimplePerformanceMeterTest.java
+++ b/eclipse.platform.releng/bundles/org.eclipse.test.performance/src/org/eclipse/test/internal/performance/tests/SimplePerformanceMeterTest.java
@@ -14,17 +14,19 @@
 
 package org.eclipse.test.internal.performance.tests;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.eclipse.test.internal.performance.OSPerformanceMeter;
 import org.eclipse.test.performance.Performance;
 import org.eclipse.test.performance.PerformanceMeter;
+import org.junit.jupiter.api.Test;
 
-import junit.framework.TestCase;
+public class SimplePerformanceMeterTest {
 
-public class SimplePerformanceMeterTest extends TestCase {
-
+    @Test
     public void testPerformanceMeterFactory() {
         Performance performance = Performance.getDefault();
-        PerformanceMeter meter = performance.createPerformanceMeter(performance.getDefaultScenarioId(this));
+        PerformanceMeter meter = performance.createPerformanceMeter(performance.getDefaultScenarioId(this.getClass()));
 
         assertTrue(meter instanceof OSPerformanceMeter);
 

--- a/eclipse.platform.releng/bundles/org.eclipse.test.performance/src/org/eclipse/test/internal/performance/tests/VariationsTests.java
+++ b/eclipse.platform.releng/bundles/org.eclipse.test.performance/src/org/eclipse/test/internal/performance/tests/VariationsTests.java
@@ -14,12 +14,14 @@
 
 package org.eclipse.test.internal.performance.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.eclipse.test.internal.performance.db.Variations;
+import org.junit.jupiter.api.Test;
 
-import junit.framework.TestCase;
+public class VariationsTests {
 
-public class VariationsTests extends TestCase {
-
+    @Test
     public void testVariations() {
         Variations v1 = new Variations();
         v1.put("k1", "foo"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -40,6 +42,7 @@ public class VariationsTests extends TestCase {
         assertEquals("%|k1=foo|%|k2=bar|%|k3=xyz|%", v3.toQueryPattern()); //$NON-NLS-1$
     }
 
+    @Test
     public void testParseVariations() {
         Variations v1 = new Variations();
         v1.put("k1", "foo"); //$NON-NLS-1$ //$NON-NLS-2$


### PR DESCRIPTION
The tests in `org.eclipse.tests.performance` are still written in JUnit 3, i.e., the test classes extend `TestCase`.

This change
* migrates tests and test suite to JUnit 5, and
* adds the missing `SimplePerformanceMeterTest` to the according test suite.

Note that these tests are not automatically executed at all, as they are neither part of a test plug-in nor does the plug-in seem to be configured to execute the tests via surefire or some ant script. But they run well when started from within the IDE. Making them executed in a CI build may be a follow-up task.