### PR TITLE
Move more product configuration from p2.inf to product-file

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.p2.inf
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.p2.inf
@@ -1,44 +1,5 @@
 instructions.configure=\
-addRepository(type:0,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:0,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
   mkdir(path:${installFolder}/dropins);
-requires.1.namespace=org.eclipse.equinox.p2.iu
-requires.1.name=toolingorg.eclipse.platform.configuration.macosx
-requires.1.filter=(osgi.os=macosx)
-requires.1.range=[1.0.0,1.0.0]
-requires.1.greedy=true
-
-requires.2.namespace=org.eclipse.equinox.p2.iu
-requires.2.name=toolingorg.eclipse.platform.configuration
-requires.2.filter=(!(osgi.os=macosx))
-requires.2.range=[1.0.0,1.0.0]
-requires.2.greedy=true
-
-units.1.id=toolingorg.eclipse.platform.configuration.macosx
-units.1.version=1.0.0
-units.1.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.1.provides.1.name=toolingorg.eclipse.platform.configuration.macosx
-units.1.provides.1.version=1.0.0
-units.1.filter=(osgi.os=macosx)
-units.1.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.1.touchpoint.version=1.0.0
-units.1.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/Documents/workspace);
-#ln(linkTarget:Eclipse.app/Contents/MacOS/eclipse,targetDir:${installFolder},linkName:eclipse,force:true);
-units.1.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
-#org.eclipse.equinox.p2.touchpoint.natives.remove(path:${installFolder}/eclipse);
-
-units.2.id=toolingorg.eclipse.platform.configuration
-units.2.version=1.0.0
-units.2.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.2.provides.1.name=toolingorg.eclipse.platform.configuration
-units.2.provides.1.version=1.0.0
-units.2.filter=(!(osgi.os=macosx))
-units.2.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.2.touchpoint.version=1.0.0
-units.2.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/workspace);
-units.2.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
 
 # Restrict range so we are not an automatic update for 3.x.
 update.id = org.eclipse.platform.ide
@@ -47,9 +8,6 @@ update.severity = 0
 update.description = An update for 4.x generation Eclipse Platform.
 
 # Set the product property type
-properties.0.name = org.eclipse.equinox.p2.type.product
-properties.0.value = true
-
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 4.30 Release of the Eclipse Platform.
 

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.product
@@ -194,6 +194,13 @@ United States, other countries, or both.
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />
+      <property name="osgi.instance.area.default" value="@user.home/workspace" />
+      <property name="osgi.instance.area.default" value="@user.home/Documents/workspace" os="macosx" />
    </configurations>
+
+   <repositories>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.30" name="The Eclipse Project Updates" enabled="true" />
+      <repository location="https://download.eclipse.org/releases/2023-12" name="2023-12" enabled="true" />
+   </repositories>
 
 </product>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.p2.inf
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.p2.inf
@@ -1,42 +1,5 @@
 instructions.configure=\
-addRepository(type:0,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:0,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
   mkdir(path:${installFolder}/dropins);
-requires.1.namespace=org.eclipse.equinox.p2.iu
-requires.1.name=toolingorg.eclipse.sdk.configuration.macosx
-requires.1.filter=(osgi.os=macosx)
-requires.1.range=[1.0.0,1.0.0]
-requires.1.greedy=true
-
-requires.2.namespace=org.eclipse.equinox.p2.iu
-requires.2.name=toolingorg.eclipse.sdk.configuration
-requires.2.filter=(!(osgi.os=macosx))
-requires.2.range=[1.0.0,1.0.0]
-requires.2.greedy=true
-
-units.1.id=toolingorg.eclipse.sdk.configuration.macosx
-units.1.version=1.0.0
-units.1.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.1.provides.1.name=toolingorg.eclipse.sdk.configuration.macosx
-units.1.provides.1.version=1.0.0
-units.1.filter=(osgi.os=macosx)
-units.1.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.1.touchpoint.version=1.0.0
-units.1.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/Documents/workspace);
-units.1.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
-
-units.2.id=toolingorg.eclipse.sdk.configuration
-units.2.version=1.0.0
-units.2.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.2.provides.1.name=toolingorg.eclipse.sdk.configuration
-units.2.provides.1.version=1.0.0
-units.2.filter=(!(osgi.os=macosx))
-units.2.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.2.touchpoint.version=1.0.0
-units.2.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/workspace);
-units.2.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
 
 # Restrict range so we are not an automatic update for 3.x.
 update.id= org.eclipse.sdk.ide
@@ -45,9 +8,6 @@ update.severity = 0
 update.description = An update for 4.x generation Eclipse SDK.
 
 # Set the product property type
-properties.0.name = org.eclipse.equinox.p2.type.product
-properties.0.value = true
-
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 4.30 Release of the Eclipse SDK.
 

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.product
@@ -7,7 +7,7 @@
    </configIni>
 
    <launcherArgs>
-      <programArgs>--launcher.defaultAction openFile  --launcher.appendVmargs
+      <programArgs>--launcher.defaultAction openFile --launcher.appendVmargs
       </programArgs>
       <vmArgs>-Dosgi.requiredJavaVersion=17 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true --add-modules=ALL-SYSTEM -Dorg.slf4j.simpleLogger.defaultLogLevel=off -Djava.security.manager=allow
       </vmArgs>
@@ -199,6 +199,13 @@ United States, other countries, or both.
       <property name="osgi.bundles.defaultStartLevel" value="4" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="org.eclipse.update.reconcile" value="false" />
+      <property name="osgi.instance.area.default" value="@user.home/workspace" />
+      <property name="osgi.instance.area.default" value="@user.home/Documents/workspace" os="macosx" />
    </configurations>
+
+   <repositories>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.30" name="The Eclipse Project Updates" enabled="true" />
+      <repository location="https://download.eclipse.org/releases/2023-12" name="2023-12" enabled="true" />
+   </repositories>
 
 </product>


### PR DESCRIPTION
And remove the unnecessary specification of the property `org.eclipse.equinox.p2.type.product=true`, which Tycho/P2 already set by
default.
Additionally unify max-memory launcher-arguments of Platform/SDK products


P2 and Tycho 4.0.4 already support names for Product Update repositories with
- https://github.com/eclipse-equinox/p2/pull/353
- https://github.com/eclipse-tycho/tycho/pull/2929

but I think it is good to not submit this before PDE has Editor support for that as well as described in https://github.com/eclipse-equinox/p2/issues/345.

A similar simplification can then also be applied to all EPP packages.