### PR TITLE
Remove jakarta.servlet-api, javax.servlet.jsp-api, javax.el-api

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
@@ -137,10 +137,7 @@
 ;${dependency.dir}/icu4j_*.jar
 ;${dependency.dir}/com.jcraft.jsch_*.jar
 ;${dependency.dir}/jakarta.annotation-api_*.jar
-;${dependency.dir}/javax.el-api_*.jar
 ;${dependency.dir}/jakarta.inject-api_*.jar
-;${dependency.dir}/javax.servlet.jsp-api_*.jar
-;${dependency.dir}/jakarta.servlet-api_*.jar
 ;${dependency.dir}/org.apache.ant_*/lib/ant.jar
 ;${dependency.dir}/org.apache.batik.css_*.jar
 ;${dependency.dir}/org.apache.commons.jxpath_*.jar

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
@@ -83,23 +83,8 @@
                   </requirement>
                   <requirement>
                     <type>eclipse-plugin</type>
-                    <id>javax.el-api</id>
-                    <versionRange>0.0.0</versionRange>
-                  </requirement>
-                  <requirement>
-                    <type>eclipse-plugin</type>
                     <id>jakarta.inject.jakarta.inject-api</id>
                     <versionRange>[1,2)</versionRange>
-                  </requirement>
-                  <requirement>
-                    <type>eclipse-plugin</type>
-                    <id>jakarta.servlet-api</id>
-                    <versionRange>0.0.0</versionRange>
-                  </requirement>
-                  <requirement>
-                    <type>eclipse-plugin</type>
-                    <id>javax.servlet.jsp-api</id>
-                    <versionRange>0.0.0</versionRange>
                   </requirement>
                   <requirement>
                     <type>eclipse-plugin</type>

--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -209,24 +209,6 @@
 	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="Jetty and servlet API" missingManifest="error" type="Maven">
 		  <dependencies>
 			  <dependency>
-				  <groupId>jakarta.el</groupId>
-				  <artifactId>jakarta.el-api</artifactId>
-				  <version>3.0.3</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>jakarta.servlet</groupId>
-				  <artifactId>jakarta.servlet-api</artifactId>
-				  <version>4.0.4</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>javax.servlet.jsp</groupId>
-				  <artifactId>javax.servlet.jsp-api</artifactId>
-				  <version>2.3.3</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
 				  <groupId>org.eclipse.jetty.toolchain</groupId>
 				  <artifactId>jetty-servlet-api</artifactId>
 				  <version>4.0.6</version>

--- a/eclipse.platform.releng/features/org.eclipse.help-feature/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.help-feature/feature.xml
@@ -22,34 +22,6 @@
    </license>
 
    <plugin
-         id="javax.el-api"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="jakarta.servlet-api"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="javax.servlet.jsp-api"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="com.sun.el.javax.el"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.equinox.http.jetty"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
These bundles are included by the org.eclipse.help feature but are not actually needed at runtime.

Also remove the include of com.sun.el.javax.el from the org.eclipse.help feature to eliminate its last 3rd party bundle include; the org.eclipse.equinox.jsp.jasper bundle's package requirement of the com.sun.el package is sufficient.

Remove these also from the places where the doc.isv mentions then.

And finally, remove them from the target platform itself.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1361