### PR TITLE
Add jakarta.servlet-api, javax.servlet.jsp-api, javax.el-api to target

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -209,6 +209,24 @@
 	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="Jetty and servlet API" missingManifest="error" type="Maven">
 		  <dependencies>
 			  <dependency>
+				  <groupId>jakarta.el</groupId>
+				  <artifactId>jakarta.el-api</artifactId>
+				  <version>3.0.3</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>jakarta.servlet</groupId>
+				  <artifactId>jakarta.servlet-api</artifactId>
+				  <version>4.0.4</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>javax.servlet.jsp</groupId>
+				  <artifactId>javax.servlet.jsp-api</artifactId>
+				  <version>2.3.3</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
 				  <groupId>org.eclipse.jetty.toolchain</groupId>
 				  <artifactId>jetty-servlet-api</artifactId>
 				  <version>4.0.6</version>


### PR DESCRIPTION
Some smaller products have narrower dependencies that are satisfied by these, even if the SDK itself doesn't need/use them.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1361