### PR TITLE
Add jakarta.servlet-api, javax.servlet.jsp-api, javax.el-api to isv.

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
@@ -137,7 +137,10 @@
 ;${dependency.dir}/icu4j_*.jar
 ;${dependency.dir}/com.jcraft.jsch_*.jar
 ;${dependency.dir}/jakarta.annotation-api_*.jar
+;${dependency.dir}/javax.el-api_*.jar
 ;${dependency.dir}/jakarta.inject-api_*.jar
+;${dependency.dir}/javax.servlet.jsp-api_*.jar
+;${dependency.dir}/jakarta.servlet-api_*.jar
 ;${dependency.dir}/org.apache.ant_*/lib/ant.jar
 ;${dependency.dir}/org.apache.batik.css_*.jar
 ;${dependency.dir}/org.apache.commons.jxpath_*.jar

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
@@ -83,8 +83,23 @@
                   </requirement>
                   <requirement>
                     <type>eclipse-plugin</type>
+                    <id>javax.el-api</id>
+                    <versionRange>0.0.0</versionRange>
+                  </requirement>
+                  <requirement>
+                    <type>eclipse-plugin</type>
                     <id>jakarta.inject.jakarta.inject-api</id>
                     <versionRange>[1,2)</versionRange>
+                  </requirement>
+                  <requirement>
+                    <type>eclipse-plugin</type>
+                    <id>jakarta.servlet-api</id>
+                    <versionRange>0.0.0</versionRange>
+                  </requirement>
+                  <requirement>
+                    <type>eclipse-plugin</type>
+                    <id>javax.servlet.jsp-api</id>
+                    <versionRange>0.0.0</versionRange>
                   </requirement>
                   <requirement>
                     <type>eclipse-plugin</type>


### PR DESCRIPTION
The javadoc build seems to need them.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1361