### PR TITLE
Add LSP supporting libraries

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -734,6 +734,12 @@
 			  </dependency>
 		  </dependencies>
 	  </location>
+  	  <location includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="false" type="InstallableUnit">
+		  <repository location="http://download.eclipse.org/lsp4e/releases/latest/"/>
+		  <unit id="org.eclipse.lsp4e" version="0.18.0.202310181943"/>
+		  <unit id="org.eclipse.lsp4j" version="0.21.1.v20230829-0012"/>
+		  <unit id="org.eclipse.lsp4j.jsonrpc" version="0.21.1.v20230829-0012"/>
+	  </location>
   </locations>
   <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 </target>


### PR DESCRIPTION
Will be required by
- https://github.com/eclipse-pde/eclipse.pde/pull/821

@mickaelistria @akurtakov would the be general concerns to add LS4e/j to the platform target? I think the sooner or later they end up in the EPPs anyways because of m2e or others using LSP...