### PR TITLE
Don't specify JVM memory limits in eclipse.ini

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.product
@@ -9,7 +9,7 @@
    <launcherArgs>
       <programArgs>--launcher.defaultAction openFile --launcher.appendVmargs
       </programArgs>
-      <vmArgs>-Dosgi.requiredJavaVersion=17 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true -Xms40m -Xmx512m --add-modules=ALL-SYSTEM -Dorg.slf4j.simpleLogger.defaultLogLevel=off -Djava.security.manager=allow
+      <vmArgs>-Dosgi.requiredJavaVersion=17 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true --add-modules=ALL-SYSTEM -Dorg.slf4j.simpleLogger.defaultLogLevel=off -Djava.security.manager=allow
       </vmArgs>
       <vmArgsMac>-Xdock:icon=../Resources/Eclipse.icns -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.product
@@ -9,7 +9,7 @@
    <launcherArgs>
       <programArgs>--launcher.defaultAction openFile  --launcher.appendVmargs
       </programArgs>
-      <vmArgs>-Dosgi.requiredJavaVersion=17 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true -Xms256m -Xmx2048m --add-modules=ALL-SYSTEM -Dorg.slf4j.simpleLogger.defaultLogLevel=off -Djava.security.manager=allow
+      <vmArgs>-Dosgi.requiredJavaVersion=17 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true --add-modules=ALL-SYSTEM -Dorg.slf4j.simpleLogger.defaultLogLevel=off -Djava.security.manager=allow
       </vmArgs>
       <vmArgsMac>-Xdock:icon=../Resources/Eclipse.icns -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1463

Re-opening this PR, as we see OOM's also without this change.

I plan to push it once https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3896 is fixed, to not mix possible regressions coming from this PR with "other" OOM issues we see right now.