### PR TITLE
Use workspace co-located to the installation by default for SDK-products

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.product
@@ -194,8 +194,7 @@ United States, other countries, or both.
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />
-      <property name="osgi.instance.area.default" value="@user.home/workspace" />
-      <property name="osgi.instance.area.default" value="@user.home/Documents/workspace" os="macosx" />
+      <property name="osgi.instance.area" value="@noDefault" />
    </configurations>
 
    <repositories>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.product
@@ -199,8 +199,7 @@ United States, other countries, or both.
       <property name="osgi.bundles.defaultStartLevel" value="4" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="org.eclipse.update.reconcile" value="false" />
-      <property name="osgi.instance.area.default" value="@user.home/workspace" />
-      <property name="osgi.instance.area.default" value="@user.home/Documents/workspace" os="macosx" />
+      <property name="osgi.instance.area" value="@noDefault" />
    </configurations>
 
    <repositories>


### PR DESCRIPTION
As suggested in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1459#discussion_r1368244436, this is a suggestion to use as default for the workspace a directory colocated to the installation instead of `${user.home}/workspace`.

What do you others think?

We use that configuration for our products and it works well on Windows and Linux but since we don't provide Mac build I cannot tell how that setting works there.