### PR TITLE
Add screenshots of failed tests to Platform UI test artifacts

### DIFF
--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -92,3 +92,4 @@ jobs:
         if-no-files-found: warn
         path: |
           ${{ github.workspace }}/**/target/surefire-reports/*.xml
+          ${{ github.workspace }}/**/results/**/*.png


### PR DESCRIPTION
Platform UI has unstable tests that are hard to debug and platform specific. They save screenshots but build system does not archive anything but Junit reports in XML format. As screenshots are essential for failure analysis and test stabilization this change adds them to test artifacts.

See https://github.com/eclipse-platform/eclipse.platform.ui/pull/1253#issuecomment-1783909424 for an example of test failure investigation.