### PR TITLE
Update icu4j to 74.1

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -105,7 +105,7 @@
 			  <dependency>
 				  <groupId>com.ibm.icu</groupId>
 				  <artifactId>icu4j</artifactId>
-				  <version>73.2</version>
+				  <version>74.1</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>

--- a/eclipse.platform.releng/features/org.eclipse.rcp/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.rcp/feature.xml
@@ -69,11 +69,4 @@
          fragment="true"
          unpack="false"/>
 
-   <plugin
-         id="com.ibm.icu"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
 </feature>


### PR DESCRIPTION
Remove the inclusion of icu4j from the org.eclipse.rcp feature.