### PR TITLE
Do not check pde/jdt schema logs in build tests

### DIFF
--- a/eclipse.platform.releng/bundles/org.eclipse.releng.tests/test.xml
+++ b/eclipse.platform.releng/bundles/org.eclipse.releng.tests/test.xml
@@ -232,7 +232,7 @@
       
       <property
         name="vmargs"
-        value="-DdownloadHost=${downloadHost} -DbuildId=${buildId} -DRELENGTEST.JAVADOC.URLS=${JAVADOC_OUTPUT_LOCATION}/platform.doc.isv.javadoc.txt,${JAVADOC_OUTPUT_LOCATION}/jdt.doc.isv.javadoc.txt,${JAVADOC_OUTPUT_LOCATION}/pde.doc.user.javadoc.txt,${JAVADOC_OUTPUT_LOCATION}/platform.doc.isv.schema.txt,${JAVADOC_OUTPUT_LOCATION}/jdt.doc.isv.schema.txt,${JAVADOC_OUTPUT_LOCATION}/pde.doc.user.schema.txt"  />
+        value="-DdownloadHost=${downloadHost} -DbuildId=${buildId} -DRELENGTEST.JAVADOC.URLS=${JAVADOC_OUTPUT_LOCATION}/platform.doc.isv.javadoc.txt,${JAVADOC_OUTPUT_LOCATION}/jdt.doc.isv.javadoc.txt,${JAVADOC_OUTPUT_LOCATION}/pde.doc.user.javadoc.txt,${JAVADOC_OUTPUT_LOCATION}/platform.doc.isv.schema.txt"  />
     </ant>
   </target>
 


### PR DESCRIPTION
In case of issues build is supposed to fail now.