### PR TITLE
Set a bunch of project encodings to UTF-8

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.tips.user/.settings/org.eclipse.core.resources.prefs
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.tips.user/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.tips/.settings/org.eclipse.core.resources.prefs
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.tips/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/eclipse.platform.releng/bundles/org.eclipse.test.performance/.settings/org.eclipse.core.resources.prefs
+++ b/eclipse.platform.releng/bundles/org.eclipse.test.performance/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/eclipse.platform.releng/publish-to-maven-central/.settings/org.eclipse.core.resources.prefs
+++ b/eclipse.platform.releng/publish-to-maven-central/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
It was done using a "Quick Fix" and the value set (UTF-8) is the same value that any other project in the workspace uses. The objective of this commit is to declutter the "Problems" view.