### PR TITLE
Add javax.inject/annotation providing bundles to eclipse.sdk repository

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
@@ -46,4 +46,6 @@
    <!-- Will be removed soon, once integrated in an appropriate feature -->
    <bundle id="org.eclipse.unittest.ui"/>
    <bundle id="org.eclipse.unittest.ui.source"/>
+   <bundle id="jakarta.annotation-api" version="1.3.5"/>
+   <bundle id="jakarta.inject.jakarta.inject-api" version="1.0.5"/>
 </site>


### PR DESCRIPTION
... to ensure it is provided and to maintain backwards compatibility until support for javax annotations is finally removed.

Since https://github.com/eclipse-platform/eclipse.platform/pull/792 (and two follow-ups) the `javax.inect/annotation` providing bundles are not required by the `eclipse-platform-sdk` anymore and therefore not part of the sdk-repo automatically.

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1056