### PR TITLE
Add deprecation notice for javax support by the E4 injector

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/removals.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/removals.html
@@ -61,10 +61,8 @@ For further details or to provide feedback on this change, see <a href="https://
 </p>
 
 
-
-
-
 <!-- ############################################## -->
+
 <h2>API removals after June 2018</h2>
 
 <h3 id="fullscreen">1. org.eclipse.ui.cocoa.fullscreenWindow</h3>
@@ -86,8 +84,8 @@ For further details or to provide feedback on this change, see
 </p>
 
 
-
 <!-- ############################################## -->
+
 <h2>API removals after June 2020</h2>
 
 <h3 id="mpartdescriptor">1. Remove Dirtable flag from MPartDescriptor</h3>
@@ -114,6 +112,8 @@ For further details or to provide feedback on this change, see <a href="https://
 </p>
 
 
+<!-- ############################################## -->
+
 <h2>API removals after March 2021</h2>
 
 <h3 id="commandsutil">1. org.eclipse.core.commands.util package</h3>
@@ -133,8 +133,8 @@ For further details or to provide feedback on this change, see <a href="https://
 </p>
 
 
-
 <!-- ############################################## -->
+
 <h2>API removals after June 2021</h2>
 
 <h3 id="commands">1. Delete deprecated contents of org.eclipse.ui.commands package</h3>
@@ -173,7 +173,9 @@ The following deprecated contents of org.eclipse.ui.commands are not used anymor
 For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=431177" target="_blank">bug 431177</a>.
 </p>
 
+
 <!-- ############################################## -->
+
 <h2>API removals after May 2022</h2>
 
 <h3 id="sharedImages">1. Hover images from ISharedImages</h3>
@@ -197,6 +199,9 @@ Multiple images not used since Eclipse 3.0 in the platform will be deleted.
 For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=559593" target="_blank">bug 559593</a>.
 </p>
 
+
+<!-- ############################################## -->
+
 <h2>API removals after June 2022</h2>
 
 <h3 id="icu4j">1. ICU4J bundle from SDK</h3>
@@ -206,7 +211,9 @@ Support and/or usage of ICU4J is being gradually removed from internals. Whereve
 For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=562582" target="_blank">bug 562582</a>.
 </p>
 
+
 <!-- ############################################## -->
+
 <h2>API removals after September 2022</h2>
 
 <h3 id="observablefactories">1. Observable factory classes</h3>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/removals.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/removals.html
@@ -254,6 +254,24 @@ For further details or to provide feedback on this change, see <a href="https://
 <h1 id="removed">Removed API in previous releases</h1>
 
 
+<!-- ############################################## -->
+
+<h2>API removals after December 2025</h2>
+
+<h3 id="javax-annotations">1. Support for javax-annotation by the E4 Injector</h3>
+
+The support of the Eclipse E4 Platform Dependency Injector for annotations from the <code>javax.inject</code> and <code>javax.annotation</code> package is deprecated
+and scheduled to be disabled by default after the December 2025 release.
+The eventual removal of support for these <code>javax</code> annotations will happen at any time after the December 2025 release without any further prior notice,
+whenever maintaining it is no longer feasible or hinders other development.
+<p>
+Processing of <code>javax</code> annotations can be explicitly disabled for an application by specifying the VM property <code>-Declipse.e4.inject.javax.disabled=true</code>
+and explicitly enabled by specifying <code>-Declipse.e4.inject.javax.disabled=false</code>.
+For further details or to provide feedback on this change, see <a href="https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1056">eclipse.platform.releng.aggregator#1056</a>.
+</p>
+For further information and possible long term compatibility strategies see
+<a href="https://eclipse.dev/eclipse/news/4.30/platform.php#support-jakarta-annotations">Eclipse 4.30 - New and Noteworthy: Support for Jakarta Annotations by Eclipse E4</a>.
+
 <hr>
 <!-- ############################################## -->
 


### PR DESCRIPTION
Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1056

I also added a corresponding N&N entry: https://github.com/eclipse-platform/www.eclipse.org-eclipse/pull/79