### PR TITLE
Use Tycho 4.0.5 SNAPSHOT

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
 						export KEYRING="deadbeef"
 						export KEYRING_PASSPHRASE="none"
 					fi
-					mvn clean install -pl :eclipse-sdk-prereqs,:org.eclipse.jdt.core.compiler.batch -DlocalEcjVersion=99.99 -Dmaven.repo.local=$WORKSPACE/.m2/repository
+					mvn clean install -pl :eclipse-sdk-prereqs,:org.eclipse.jdt.core.compiler.batch -DlocalEcjVersion=99.99 -Dmaven.repo.local=$WORKSPACE/.m2/repository -U
 					mvn clean verify -e -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 						-Pbree-libs \
 						${MVN_ARGS} \
@@ -59,7 +59,8 @@ pipeline {
 						-Dcompare-version-with-baselines.skip=false \
 						-DapiBaselineTargetDirectory=${WORKSPACE} \
 						-Dgpg.passphrase="${KEYRING_PASSPHRASE}" \
-						-Dcbi-ecj-version=99.99
+						-Dcbi-ecj-version=99.99 \
+						-U
 					'''
 				}
 

--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -67,7 +67,7 @@
     <releaseNumberSDK>4.31</releaseNumberSDK>
     <releaseNumberPlatform>4.31</releaseNumberPlatform>
 
-    <tycho.version>4.0.4</tycho.version>
+    <tycho.version>4.0.5-SNAPSHOT</tycho.version>
 
     <cbi-plugins.version>1.4.3</cbi-plugins.version>
     <surefire.version>3.2.2</surefire.version>


### PR DESCRIPTION
As tycho 4.0.5 contains some important Api Tools fixes we should use the snapshot until the release.

**This should be merged as soon as master is opened for next development cycle.**