### PR TITLE
Add the ecf http5 feature back to the target platform

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -80,6 +80,8 @@
       <unit id="org.eclipse.ecf.filetransfer.httpclientjava.feature.source.feature.group" version="2.0.200.v20231021-2127"/>
       <unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.1.402.v20231021-2127"/>
       <unit id="org.eclipse.ecf.filetransfer.ssl.feature.source.feature.group" version="1.1.402.v20231021-2127"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" version="1.1.702.v20231021-2127"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.source.feature.group" version="1.1.702.v20231021-2127"/>
       <!-- ⚠️ TODO Use a release repo for 3.14.40 before releaseing Platform ⚠️ -->
       <repository location="https://download.eclipse.org/rt/ecf/snapshot/site.p2/3.14.40.v20231021-2127"/>
     </location>


### PR DESCRIPTION
For fallback configuration we want to still ship both implementations in 2023-12 release.

@merks @akurtakov Requires PMC/PL approval, still using @mickaelistria 

See also
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1390
- https://github.com/eclipse-equinox/p2/issues/381#issuecomment-1807081486