### PR TITLE
Update Apache Aries SPIFly to version 1.3.7

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -143,7 +143,7 @@
 			  <dependency>
 				  <groupId>org.apache.aries.spifly</groupId>
 				  <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
-				  <version>1.3.6</version>
+				  <version>1.3.7</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>


### PR DESCRIPTION
Apache Aries 1.3.7 contains fixes that simplify its usage and add support for Java-21:
- https://github.com/apache/aries/pull/233
- https://github.com/apache/aries/pull/243

I'm currently updating m2e to that version, which I plan to contribute to SimRel for the december release:
- https://github.com/eclipse-m2e/m2e-core/pull/1594

Since it will be in the SimRel anyways I suggest to update it here in the SDK now as well.
