### PR TITLE
Don't publish org.eclipse.orbit.xml-apis-ext to Maven

### DIFF
--- a/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr
+++ b/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr
@@ -17,7 +17,7 @@
   <mavenMappings namePattern="(org\.eclipse\.jdt)\.core\.compiler\.batch" groupId="$1" artifactId="ecj" snapshot="false"/>
   <mavenMappings namePattern="(org\.eclipse\.jdt)(.*)" groupId="$1" artifactId="$1$2" snapshot="false"/>
   <mavenMappings namePattern="(org\.eclipse\.pde)(.*)" groupId="$1" artifactId="$1$2" snapshot="false"/>
-  <mavenMappings namePattern="(org\.eclipse)((?!(\.emf|\.jetty|\.ecf)).*)$" groupId="$1.platform" artifactId="$1$2" snapshot="false"/>
+  <mavenMappings namePattern="(org\.eclipse)((?!(\.emf|\.jetty|\.ecf|\.orbit)).*)$" groupId="$1.platform" artifactId="$1$2" snapshot="false"/>
   <mavenMappings namePattern="(com\.jcraft)\.(.*)" groupId="$1" artifactId="$2"/>
   <mavenMappings namePattern="javax\.annotation" groupId="jakarta.annotation" artifactId="jakarta.annotation-api"/>
   <mavenMappings namePattern="(javax.inject)" groupId="$1" artifactId="$1" versionPattern="([^.]+)\.0(?:\..*)?" versionTemplate="$1"/>
@@ -26,11 +26,11 @@
   <mavenMappings namePattern="org\.apache\.ant$" groupId="org.apache.ant" artifactId="ant"/>
   <mavenMappings namePattern="org.apache.batik.([^.]+)" groupId="org.apache.xmlgraphics" artifactId="batik-$1" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
   <mavenMappings namePattern="org.junit" groupId="junit" artifactId="junit" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
-  <mavenMappings namePattern="org.w3c.css.sac" groupId="org.eclipse.birt.runtime" artifactId="org.w3c.css.sac"/>
+  <mavenMappings namePattern="org.eclipse.orbit.xml-apis-ext" groupId="xml-apis" artifactId="xml-apis-ext" versionTemplate="1.3.04"/>
   <mavenMappings namePattern="(com\.sun\.el|org.apache.jasper.glassfish)" groupId="org.eclipse.jetty.orbit" artifactId="$1"/>
   <mavenMappings namePattern="com\.sun\.jna" groupId="net.java.dev.jna" artifactId="jna"/>
   <mavenMappings namePattern=".*" groupId="\$maven-groupId\$" artifactId="\$maven-artifactId\$" versionPattern=".*" versionTemplate="\$maven-version\$"/>
-  <mavenDependencyMapping iuNamePattern="(?!.*(org\.eclipse\.)).*|org\.eclipse\.emf.*|org\.eclipse\.ecf.*|org\.eclipse\.jetty.*" namespacePattern=".*" namePattern=".*" groupId="!" artifactId="!"/>
+  <mavenDependencyMapping iuNamePattern="(?!.*(org\.eclipse\.)).*|org\.eclipse\.emf.*|org\.eclipse\.ecf.*|org\.eclipse\.jetty.*|org\.eclipse\.orbit.*" namespacePattern=".*" namePattern=".*" groupId="!" artifactId="!"/>
   <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt).internal.(compiler\.(apt|tool))" groupId="$1" artifactId="$1.$2" versionRangePattern=".*" versionRangeTemplate="major.minor.micro-qualifier"/>
   <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt).internal.(compiler\.apt)\..*" groupId="$1" artifactId="$1.$2" versionRangePattern=".*" versionRangeTemplate="major.minor.micro-qualifier"/>
   <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt)(.internal|.core)?.compiler.*" groupId="$1" artifactId="$1.core" versionRangePattern=".*" versionRangeTemplate="major.minor.micro-qualifier"/>

--- a/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggran
+++ b/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggran
@@ -3,7 +3,7 @@
     xmi:version="2.0"
     xmlns:xmi="http://www.omg.org/XMI"
     xmlns:analyzer="https://www.eclipse.org/cbi/p2repo/2021/aggregator/analyzer"
-    exclusion="org.eclipse.test.performance.*|eclipse-junit-tests|tooling.*|.*\.feature\.group|.*\.feature\.jar|.*.\.tests?(.source)?|.*\.tests\..*|org.eclipse.equinox.executable.*|org.eclipse.*.unittest.junit(.source)?|org.eclipse.platform.ide.executable.*|org.eclipse.platform.sdk.executable.*|org.eclipse.unittest.ui|org.eclipse.rcp\..*|org.eclipse.platform.ide|org.eclipse.platform.sdk|org.eclipse.sdk.ide.*|.*_root|(?!.*(org\.eclipse\.)).*|org.eclipse.emf.*|org.eclipse.jetty.*|org.eclipse.ecf.*"
+    exclusion="org.eclipse.test.performance.*|eclipse-junit-tests|tooling.*|.*\.feature\.group|.*\.feature\.jar|.*.\.tests?(.source)?|.*\.tests\..*|org.eclipse.equinox.executable.*|org.eclipse.*.unittest.junit(.source)?|org.eclipse.platform.ide.executable.*|org.eclipse.platform.sdk.executable.*|org.eclipse.unittest.ui|org.eclipse.rcp\..*|org.eclipse.platform.ide|org.eclipse.platform.sdk|org.eclipse.sdk.ide.*|.*_root|(?!.*(org\.eclipse\.)).*|org.eclipse.emf.*|org.eclipse.jetty.*|org.eclipse.ecf.*|org.eclipse.orbit.*"
     aggregation="SDK4Mvn.aggr#/">
   <contribution
       contribution="SDK4Mvn.aggr#//@validationSets[label='main']/@contributions[label='sdk']"/>


### PR DESCRIPTION
It should be mapped to two following as batik generally does:

https://repo1.maven.org/maven2/xml-apis/xml-apis-ext/1.3.04/