### PR TITLE
[License-Workflow] explicitly specify least required permission

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   call-license-check:
+    permissions:
+      pull-requests: write
     uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
     with:
       projectId: eclipse.platform


### PR DESCRIPTION
Context: https://github.com/eclipse/dash-licenses/pull/286