### PR TITLE
Make use of BREE configurable and fix documentation link

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -138,6 +138,8 @@
     <tycho.addMavenDescriptor>false</tycho.addMavenDescriptor>
     <!-- allows submodules to enable the mapping of p2 artifacts to maven artifacts -->
     <tycho.mapP2Dependencies>false</tycho.mapP2Dependencies>
+    <!-- allows submodules to disable the usage of BREE for their builds -->
+    <tycho.useJDK>BREE</tycho.useJDK>
     
     <compare-version-with-baselines.skip>true</compare-version-with-baselines.skip>
     <previous-release.baseline>https://download.eclipse.org/eclipse/updates/4.30-I-builds/I20231123-1700/</previous-release.baseline>
@@ -854,11 +856,10 @@
               <version>${tycho.version}</version>
               <configuration>
                 <!--
-                  this tells Tycho to use JRE libraries that match bundle runtime execution environment
-                  https://wiki.eclipse.org/Tycho/Release_Notes/0.14
-                  TODO provide CBI-specific wiki that explains how to setup BREE libraries and toolchain.xml
+                  this tells Tycho to use JRE libraries that match bundle runtime execution environment see:
+                  https://tycho.eclipseprojects.io/doc/latest/tycho-compiler-plugin/compile-mojo.html#useJDK
                 -->
-                <useJDK>BREE</useJDK>
+                <useJDK>${tycho.useJDK}</useJDK>
               </configuration>
             </plugin>
           </plugins>


### PR DESCRIPTION
See
- https://github.com/eclipse-pde/eclipse.pde/pull/913
- https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/4011

With only a few plugins actually using a lower BREE < 9 we could also think about dropping this completely over time and instead rely on the `-release` option of modern JDKs