### PR TITLE
Don't include timestamp in javadoc

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -617,6 +617,7 @@
                 <doclint>reference,html,syntax</doclint>
                 <splitindex>true</splitindex>
                 <breakiterator>true</breakiterator>
+                <notimestamp>true</notimestamp>
                 <encoding>UTF-8</encoding>
                 <charset>UTF-8</charset>
                 <use>true</use>


### PR DESCRIPTION
Currently there is a (hidden) timestamp generated in the javadoc what is not very useful for our use case where we want to replace artifacts by the baseline version what means we have changes on each build.

This disable the generation of timestamps for javadoc to get more reproducible builds.