### PR TITLE
use 3GB Heap on Platform Workspace

### DIFF
--- a/oomph/PlatformSDKConfiguration.setup
+++ b/oomph/PlatformSDKConfiguration.setup
@@ -93,7 +93,7 @@
         &lt;stringAttribute key=&quot;org.eclipse.jdt.launching.JRE_CONTAINER&quot; value=&quot;org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17&quot;/>
         &lt;stringAttribute key=&quot;org.eclipse.jdt.launching.PROGRAM_ARGUMENTS&quot; value=&quot;-os $${target.os} -ws $${target.ws} -arch $${target.arch} -nl $${target.nl} -consoleLog&quot;/>
         &lt;stringAttribute key=&quot;org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER&quot; value=&quot;org.eclipse.pde.ui.workbenchClasspathProvider&quot;/>
-        &lt;stringAttribute key=&quot;org.eclipse.jdt.launching.VM_ARGUMENTS&quot; value=&quot;-Xms256m&amp;#13;&amp;#10;-Xmx3072m&quot;/>
+        &lt;stringAttribute key=&quot;org.eclipse.jdt.launching.VM_ARGUMENTS&quot; value=&quot;-Xms256m&amp;#13;&amp;#10;-Xmx4g&quot;/>
         &lt;stringAttribute key=&quot;pde.version&quot; value=&quot;3.3&quot;/>
         &lt;stringAttribute key=&quot;product&quot; value=&quot;org.eclipse.sdk.ide&quot;/>
         &lt;booleanAttribute key=&quot;restart&quot; value=&quot;true&quot;/>

--- a/oomph/PlatformSDKConfiguration.setup
+++ b/oomph/PlatformSDKConfiguration.setup
@@ -93,7 +93,7 @@
         &lt;stringAttribute key=&quot;org.eclipse.jdt.launching.JRE_CONTAINER&quot; value=&quot;org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17&quot;/>
         &lt;stringAttribute key=&quot;org.eclipse.jdt.launching.PROGRAM_ARGUMENTS&quot; value=&quot;-os $${target.os} -ws $${target.ws} -arch $${target.arch} -nl $${target.nl} -consoleLog&quot;/>
         &lt;stringAttribute key=&quot;org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER&quot; value=&quot;org.eclipse.pde.ui.workbenchClasspathProvider&quot;/>
-        &lt;stringAttribute key=&quot;org.eclipse.jdt.launching.VM_ARGUMENTS&quot; value=&quot;-Xms256m&amp;#13;&amp;#10;-Xmx2048m&quot;/>
+        &lt;stringAttribute key=&quot;org.eclipse.jdt.launching.VM_ARGUMENTS&quot; value=&quot;-Xms256m&amp;#13;&amp;#10;-Xmx3072m&quot;/>
         &lt;stringAttribute key=&quot;pde.version&quot; value=&quot;3.3&quot;/>
         &lt;stringAttribute key=&quot;product&quot; value=&quot;org.eclipse.sdk.ide&quot;/>
         &lt;booleanAttribute key=&quot;restart&quot; value=&quot;true&quot;/>


### PR DESCRIPTION
After few days of doing much work in platform workspace across several repositories i use to end up in OOME.
I never could find a single point of failure, memory is allocated by jdt, platform, jgit, pde, classloader ... it seems like it just sums up
![image](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/assets/51790620/8fe5a593-27b9-46f8-8fa5-472416adcd73)

If anybody wants that heapdump just tell me