### PR TITLE
Fix platform javadoc build

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
@@ -163,6 +163,7 @@
 ;${dependency.dir}/org.osgi.service.prefs_*.jar
 ;${dependency.dir}/org.osgi.service.event_*.jar
 ;${dependency.dir}/org.osgi.service.cm_*.jar
+;${dependency.dir}/org.osgi.service.component.annotations_*.jar
 ;${dependency.dir}/jetty-http_*.jar
 ;${dependency.dir}/jetty-io_*.jar
 ;${dependency.dir}/jetty-security_*.jar

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
@@ -248,6 +248,11 @@
                   </requirement>
                   <requirement>
                     <type>eclipse-plugin</type>
+                    <id>org.osgi.service.component.annotations</id>
+                    <versionRange>0.0.0</versionRange>
+                  </requirement>
+                  <requirement>
+                    <type>eclipse-plugin</type>
                     <id>org.osgi.annotation.versioning</id>
                     <versionRange>0.0.0</versionRange>
                   </requirement>


### PR DESCRIPTION
Broken in
https://download.eclipse.org/eclipse/downloads/drops4/I20231205-0520/compilelogs/platform.doc.isv.javadoc.txt