### PR TITLE
Prevent two PRs for same update from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,10 @@
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
-  - package-ecosystem: maven
-    directory: eclipse-platform-parent
-    schedule:
-      interval: daily
-    commit-message:
-      prefix: fix
-      prefix-development: chore
-      include: scope
-    labels:
-      - dependencies
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
-
 
   - package-ecosystem: docker
     directory: /cje-production/dockerfiles/centos-gtk3-metacity/8-gtk3


### PR DESCRIPTION
Example is
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1629 and https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1627

The config on "/" is enough as eclipse-platform-parent is a module of the top pom.
This is leftover from the past as initially the repo was mostly pointing to other subrepos and only eclipse-platform-parent was considered for updates. When config for / was added the one for eclipse-platform-parent should have been removed.