### PR TITLE
Config tycho-compiler-plugin to use project settings

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -482,7 +482,7 @@
             <excludeResources>
               <exclude>**/package.html</exclude>
             </excludeResources>
-            <useProjectSettings>false</useProjectSettings>
+            <useProjectSettings>true</useProjectSettings>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform/pull/973 identified that IDE builds and maven builds produce different bytecode due to ignoring project settings which shouldn't be the case