### PR TITLE
Add org.apache.felix.http.servlet-api to resolve maven warnings

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -317,6 +317,13 @@
 				  <version>9.0.83.1</version>
 				  <type>jar</type>
 			  </dependency>
+			  <!-- This is to temporary resolve the issue with warning about unsatisfied contracts / packages of org.osgi.service.http and org.osgi.service.http.whiteboard -->
+			  <dependency>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>org.apache.felix.http.servlet-api</artifactId>
+				<version>1.2.0</version>
+				<type>jar</type>
+			  </dependency>
 		  </dependencies>
 	  </location>
 	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="Test dependencies" missingManifest="error" type="Maven">


### PR DESCRIPTION
This is to temporary resolve the issue with warning about unsatisfied contracts / packages of org.osgi.service.http and
org.osgi.service.http.whiteboard once we have resolved the discrepancy in org.eclipse.osgi.services this can be replaced / removed again.