### PR TITLE
Remove org.osgi.service.http and felix.http.servlet-api from SDK TP

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -317,13 +317,6 @@
 				  <version>9.0.83.1</version>
 				  <type>jar</type>
 			  </dependency>
-			  <!-- This is to temporary resolve the issue with warning about unsatisfied contracts / packages of org.osgi.service.http and org.osgi.service.http.whiteboard -->
-			  <dependency>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>org.apache.felix.http.servlet-api</artifactId>
-				<version>1.2.0</version>
-				<type>jar</type>
-			  </dependency>
 		  </dependencies>
 	  </location>
 	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="Test dependencies" missingManifest="error" type="Maven">
@@ -448,12 +441,6 @@
 				  <groupId>org.osgi</groupId>
 				  <artifactId>org.osgi.service.http.whiteboard</artifactId>
 				  <version>1.1.1</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>org.osgi</groupId>
-				  <artifactId>org.osgi.service.http</artifactId>
-				  <version>1.2.2</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>


### PR DESCRIPTION
With https://github.com/eclipse-equinox/equinox/pull/403 the sources of org.osgi.service.http are provided in a re-packed bundle from Equinox, that also provides the OSGi capabilities which where temporarily provided by felix.http.servlet-api.

As planned, this also reverts https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1672 because it is not necessary anymore.