### PR TITLE
Add notices about deprecation of org.eclipse.osgi.services bundle and PluginVersionIdentifier class

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/removals.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/removals.html
@@ -269,6 +269,19 @@ For further details or to provide feedback on this change, see <a href="https://
 For further information and possible long term compatibility strategies see
 <a href="https://eclipse.dev/eclipse/news/4.30/platform.php#support-jakarta-annotations">Eclipse 4.30 - New and Noteworthy: Support for Jakarta Annotations by Eclipse E4</a>.
 
+<!-- ############################################## -->
+
+<h2>API removals after March 2026</h2>
+
+<h3 id="osgi.service-bundle">1. Bundle org.eclipse.osgi.services</h3>
+
+The bundle <code>org.eclipse.osgi.services</code> is deprecated for removal.
+Its content has already been replaced by the official OSGi bundles published to Maven-Central and it only reexports these <code>org.osgi.service.*</code> bundles.
+<p>
+Consumers are encouraged to replace their requirements on the bundle <code>org.eclipse.osgi.services</code> by imports of the used <code>org.osgi.service.*</code> packages already now.
+This allows the OSGi runtime to choose any suitable provider of the package that is available. 
+</p>
+
 
 <!-- ############################################## -->
 <!-- ############################################## -->

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/removals.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/removals.html
@@ -282,6 +282,10 @@ Consumers are encouraged to replace their requirements on the bundle <code>org.e
 This allows the OSGi runtime to choose any suitable provider of the package that is available. 
 </p>
 
+<h3 id="PluginVersionIdentifier">2. PluginVersionIdentifier</h3>
+
+The class <code>org.eclipse.core.runtime.PluginVersionIdentifier</code> is deprecated for removal.
+As replacement <code>org.osgi.framework.Version</code> should be used.
 
 <!-- ############################################## -->
 <!-- ############################################## -->

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/removals.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/removals.html
@@ -251,9 +251,6 @@ The fields <code>org.eclipse.pde.core.IModelProviderEvent.TARGET_CHANGED</code> 
 For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=570549" target="_blank">bug 570549</a>.
 </p>
 		
-<h1 id="removed">Removed API in previous releases</h1>
-
-
 <!-- ############################################## -->
 
 <h2>API removals after December 2025</h2>
@@ -271,6 +268,12 @@ For further details or to provide feedback on this change, see <a href="https://
 </p>
 For further information and possible long term compatibility strategies see
 <a href="https://eclipse.dev/eclipse/news/4.30/platform.php#support-jakarta-annotations">Eclipse 4.30 - New and Noteworthy: Support for Jakarta Annotations by Eclipse E4</a>.
+
+
+<!-- ############################################## -->
+<!-- ############################################## -->
+<h1 id="removed">Removed API in previous releases</h1>
+
 
 <hr>
 <!-- ############################################## -->


### PR DESCRIPTION
This adds notices for the deprecation for removal for 
- The bundle `org.eclipse.osgi.services`:
https://github.com/eclipse-equinox/equinox/issues/18
- The class `PluginVersionIdentifier`:
https://github.com/eclipse-equinox/equinox/pull/427

Besides adding this to the porting guide it could also be mentioned in the N&Ns?