### PR TITLE
Adapt java-doc build to replacement of embedded service.http sources

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
@@ -163,6 +163,7 @@
 ;${dependency.dir}/org.osgi.service.prefs_*.jar
 ;${dependency.dir}/org.osgi.service.event_*.jar
 ;${dependency.dir}/org.osgi.service.cm_*.jar
+;${dependency.dir}/org.osgi.service.http.whiteboard_*.jar
 ;${dependency.dir}/org.osgi.service.component.annotations_*.jar
 ;${dependency.dir}/jetty-http_*.jar
 ;${dependency.dir}/jetty-io_*.jar
@@ -184,7 +185,7 @@
 ;${eclipse.platform.ui.bundles}/org.eclipse.e4.emf.xpath/${dot.classes}
 ;${rt.equinox.framework.bundles}/org.eclipse.osgi/${dot.classes}
 ;${rt.equinox.framework.bundles}/org.eclipse.osgi/osgi/osgi.annotation.jar
-;${rt.equinox.framework.bundles}/org.eclipse.osgi.services/${dot.classes}
+;${rt.equinox.framework.bundles}/org.eclipse.equinox.http.service.api/${dot.classes}
 ;${rt.equinox.p2.bundles}/org.eclipse.equinox.p2.director/${dot.classes}
 ;${rt.equinox.p2.bundles}/org.eclipse.equinox.p2.garbagecollector/${dot.classes}
 ;${rt.equinox.p2.bundles}/org.eclipse.equinox.p2.metadata.repository/${dot.classes}


### PR DESCRIPTION
Adapt to https://github.com/eclipse-equinox/equinox/pull/403 as requested in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1677#issuecomment-1862138451.

Based on what has changed in https://github.com/eclipse-equinox/equinox/pull/403 and what currently fails I assume these are the right changes.
@akurtakov or @laeubi can you confirm this?