### PR TITLE
Add old javax.inject as an additional javadoc dependency

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -698,8 +698,8 @@
                         <head>Provisional:</head>
                     </tag>
                 </tags>
-                <!-- These are provided by PDE/Tycho by default but javadoc do not know that ... -->
                 <additionalDependencies>
+	                <!-- These are provided by PDE/Tycho by default but javadoc do not know that ... -->
                     <additionalDependency>
                         <groupId>org.osgi</groupId>
                         <artifactId>org.osgi.annotation.bundle</artifactId>
@@ -715,6 +715,12 @@
                         <artifactId>org.osgi.service.component.annotations</artifactId>
                         <version>1.5.0</version>
                     </additionalDependency>
+                    <!-- These are required unless we have no backward-compat anymore but javadoc do not know that ... -->
+                    <additionalDependency>
+					    <groupId>javax.inject</groupId>
+					    <artifactId>javax.inject</artifactId>
+					    <version>1</version>
+					</additionalDependency>
                 </additionalDependencies>
             </configuration>
         </plugin>


### PR DESCRIPTION
Fix https://github.com/eclipse-platform/eclipse.platform/issues/1017

FYI @HeikoKlare 