### PR TITLE
Add old javax.annotation as an additional javadoc dependency

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -721,6 +721,11 @@
 					    <artifactId>javax.inject</artifactId>
 					    <version>1</version>
 					</additionalDependency>
+					<additionalDependency>
+					    <groupId>javax.annotation</groupId>
+					    <artifactId>javax.annotation-api</artifactId>
+					    <version>1.3.2</version>
+					</additionalDependency>
                 </additionalDependencies>
             </configuration>
         </plugin>


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform/issues/1017

FYI @HeikoKlare 