### PR TITLE
Print exception when executing maven

### DIFF
--- a/cje-production/mbscripts/mb220_buildSdkPatch.sh
+++ b/cje-production/mbscripts/mb220_buildSdkPatch.sh
@@ -45,4 +45,5 @@ mvn clean verify -DskipTests=true ${MVN_ARGS} \
   -Declipse-p2-repo.url=NOT_FOR_PRODUCTION_USE \
   -Dgpg.passphrase=${KEYRING_PASSPHRASE} \
   -Dcbi-ecj-version=99.99 \
+  -e \
   ${JAVA_DOC_TOOL}


### PR DESCRIPTION
Maven by default do not print stack traces when a mojo fails ,this makes it quite hard to understand build problems that are caused by unexpected failures.

This adds the -e switch to maven to print full stack trace.