### PR TITLE
Specify the locale for the javadoc build

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -247,9 +247,6 @@
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <!-- https://bugs.eclipse.org/bugs/show_bug.cgi?id=453757
-            <resolveWithExecutionEnvironmentConstraints>false</resolveWithExecutionEnvironmentConstraints>
-          -->
           <target>
             <artifact>
               <groupId>org.eclipse</groupId>
@@ -618,6 +615,7 @@
                 <splitindex>true</splitindex>
                 <breakiterator>true</breakiterator>
                 <notimestamp>true</notimestamp>
+                <locale>en</locale>
                 <encoding>UTF-8</encoding>
                 <charset>UTF-8</charset>
                 <use>true</use>


### PR DESCRIPTION
Currently the locale is determined by the system what can result in slightly different results.

This configures the locale to be always 'en' (+removes an old comment)