### PR TITLE
Remove eclipse.platform.swt.binaries sub-module to reflect merge with eclipse.platform.swt

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,17 +15,14 @@
   path = eclipse.jdt.ui
   url = https://github.com/eclipse-jdt/eclipse.jdt.ui.git
 [submodule "eclipse.pde"]
-	path = eclipse.pde
-	url = https://github.com/eclipse-pde/eclipse.pde.git
+  path = eclipse.pde
+  url = https://github.com/eclipse-pde/eclipse.pde.git
 [submodule "eclipse.platform"]
   path = eclipse.platform
   url = https://github.com/eclipse-platform/eclipse.platform.git
 [submodule "eclipse.platform.swt"]
   path = eclipse.platform.swt
   url = https://github.com/eclipse-platform/eclipse.platform.swt.git
-[submodule "eclipse.platform.swt.binaries"]
-  path = eclipse.platform.swt.binaries
-  url = https://github.com/eclipse-platform/eclipse.platform.swt.binaries.git
 [submodule "eclipse.platform.ui"]
   path = eclipse.platform.ui
   url = https://github.com/eclipse-platform/eclipse.platform.ui.git

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
     <module>eclipse.platform.ui</module>
     <module>eclipse.platform.common</module>
     <module>eclipse.platform.swt</module>
-    <module>eclipse.platform.swt.binaries</module>
 
     <module>equinox</module>
     <module>rt.equinox.p2</module>


### PR DESCRIPTION
With https://github.com/eclipse-platform/eclipse.platform.swt/pull/956 the swt native binaries are stored in the `eclipse.platform.swt` repository using git-lfs. The `eclipse.platform.swt.binaries` repository is therefore obsolete.

Part of https://github.com/eclipse-platform/eclipse.platform.swt.binaries/issues/2
