### PR TITLE
PDE bundles are not needed for building Platform/JDT docs

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/pom.xml
@@ -47,16 +47,6 @@
                   </requirement>
                   <requirement>
                     <type>eclipse-plugin</type>
-                    <id>org.eclipse.pde.build</id>
-                    <versionRange>0.0.0</versionRange>
-                  </requirement>
-                  <requirement>
-                    <type>eclipse-plugin</type>
-                    <id>org.eclipse.pde.core</id>
-                    <versionRange>0.0.0</versionRange>
-                  </requirement>
-                  <requirement>
-                    <type>eclipse-plugin</type>
                     <id>org.eclipse.core.externaltools</id>
                     <versionRange>0.0.0</versionRange>
                   </requirement>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
@@ -58,16 +58,6 @@
                 <extraRequirements>
                   <requirement>
                     <type>eclipse-plugin</type>
-                    <id>org.eclipse.pde.build</id>
-                    <versionRange>0.0.0</versionRange>
-                  </requirement>
-                  <requirement>
-                    <type>eclipse-plugin</type>
-                    <id>org.eclipse.pde.core</id>
-                    <versionRange>0.0.0</versionRange>
-                  </requirement>
-                  <requirement>
-                    <type>eclipse-plugin</type>
                     <id>com.ibm.icu</id>
                     <versionRange>0.0.0</versionRange>
                   </requirement>


### PR DESCRIPTION
Work towards fixing
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1707