### PR TITLE
Remove useless maven configurations

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse-junit-tests/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse-junit-tests/pom.xml
@@ -130,7 +130,6 @@
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <resolver>p2</resolver>
           <environments>
             <environment>
               <os>linux</os>

--- a/eclipse.platform.releng.tychoeclipsebuilder/equinox.starterkit.product/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/equinox.starterkit.product/pom.xml
@@ -30,7 +30,6 @@
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-packaging-plugin</artifactId>
-        <version>${tycho.version}</version>
         <configuration>
           <format>'${buildId}'</format>
         </configuration>
@@ -40,7 +39,6 @@
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <resolver>p2</resolver>
           <environments>
             <environment>
               <os>linux</os>


### PR DESCRIPTION
* tycho-version is already set in parent, no point in repeating it
* resolver=p2 is not supported configuration for ages