### PR TITLE
Use proper maven-dependency-plugin configuration

### DIFF
--- a/eclipse.platform.common/pom.xml
+++ b/eclipse.platform.common/pom.xml
@@ -78,6 +78,23 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>copy</id>
+              <phase>process-resources</phase>
+              <goals>
+                <goal>copy-dependencies</goal>
+              </goals>
+              <configuration>
+                <overWriteReleases>true</overWriteReleases>
+                <overWriteSnapshots>true</overWriteSnapshots>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
 			<groupId>org.eclipse.tycho.extras</groupId>
 			<artifactId>tycho-document-bundle-plugin</artifactId>
 			<version>${tycho.version}</version>


### PR DESCRIPTION
Camelcase options.
Fixes warnings in the build:
00:22:41  [WARNING] Parameter 'overwriteReleases' is unknown for plugin 'maven-dependency-plugin:3.6.1:copy (copy)'
00:22:41  [WARNING] Parameter 'overwriteSnapshots' is unknown for plugin 'maven-dependency-plugin:3.6.1:copy (copy)'
00:22:41  [WARNING] Parameter 'overwriteReleases' is unknown for plugin 'maven-dependency-plugin:3.6.1:copy-dependencies (copy)' 00:22:41  [WARNING] Parameter 'overwriteSnapshots' is unknown for plugin 'maven-dependency-plugin:3.6.1:copy-dependencies (copy)'