### PR TITLE
Add back readmetool example to platform.doc.isv

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
@@ -446,6 +446,7 @@
 			                <include>org.eclipse.ui.examples.fieldassist/doc-html/*.*</include>
 			                <include>org.eclipse.ui.examples.multipageeditor/doc-html/*.*</include>
 			                <include>org.eclipse.ui.examples.propertysheet/doc-html/*.*</include>
+			                <include>org.eclipse.ui.examples.readmetool/doc-html/*.*</include>
 			                <include>org.eclipse.ui.examples.undo/doc-html/*.*</include>
 			                <include>org.eclipse.ui.examples.javaeditor/doc-html/*.*</include>
 		            	</includes>


### PR DESCRIPTION
It was missed in the conversion to maven.