### PR TITLE
[Setup] Add JGit LFS to Platform Aggregator setup

### DIFF
--- a/oomph/Platform.setup
+++ b/oomph/Platform.setup
@@ -60,16 +60,26 @@
           key="/instance/org.eclipse.pde.api.tools/MISSING_EE_DESCRIPTIONS"
           value="Warning"/>
     </setupTask>
+    <setupTask
+        xsi:type="setup:CompoundTask"
+        name="org.eclipse.egit.ui">
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.egit.ui/auto_lfs_config"
+          value="true"/>
+    </setupTask>
   </setupTask>
   <setupTask
       xsi:type="setup.p2:P2Task"
-      label="Platform">
+      label="Platform and Git LFS">
     <requirement
         name="org.eclipse.platform.feature.group"/>
     <requirement
         name="org.eclipse.jdt.feature.group"/>
     <requirement
         name="org.eclipse.pde.feature.group"/>
+    <requirement
+        name="org.eclipse.jgit.lfs"/>
   </setupTask>
   <setupTask
       xsi:type="setup:VariableTask"


### PR DESCRIPTION
The eclipse.platform.swt sub-module contains Git LFS content. Therefore in order to fully pull it with EGit/JGit the LFS plugin is necessary.

@merks or should we just add it to the parent Platform project? Then it would not be necessary to have it in the SWT setup and the Platform Aggregator setup.
Having it installed is usually not a problem if not used.

@laeubi FYI