### PR TITLE
Declare required jdk and maven as top-level pipeline tools in I-builds

### DIFF
--- a/JenkinsJobs/Builds/I_build.groovy
+++ b/JenkinsJobs/Builds/I_build.groovy
@@ -147,13 +147,15 @@ spec:
 """
     }
   }
+  tools {
+      jdk 'openjdk-jdk17-latest'
+      maven 'apache-maven-latest'
+  }
   environment {
       MAVEN_OPTS = "-Xmx6G"
       CJE_ROOT = "${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production"
-      PATH = "$PATH:/opt/tools/apache-maven/latest/bin"
       logDir = "$CJE_ROOT/buildlogs"
     }
-  
   stages {
       stage('Clean Workspace'){
           steps {
@@ -234,8 +236,7 @@ spec:
           steps {
               container('jnlp') {
 		      sshagent(['projects-storage.eclipse.org-bot-ssh']) {
-		          withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
-		              withAnt(installation: 'apache-ant-latest', jdk: 'openjdk-jdk17-latest') {
+		              withAnt(installation: 'apache-ant-latest') {
 		                sh \'\'\'
 		                    cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
 		                    ./mb020_createBaseBuilder.sh $CJE_ROOT/buildproperties.shsource 2>&1 | tee $logDir/mb020_createBaseBuilder.sh.log
@@ -246,7 +247,6 @@ spec:
 		                    fi
 		                \'\'\'
 		              }
-		          }
 		        }
 		      }
 		}
@@ -310,7 +310,6 @@ spec:
 	  stage('Create Source Bundles'){
           steps {
               container('jnlp') {
-                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
                     sh \'\'\'
                         cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
                         unset JAVA_TOOL_OPTIONS 
@@ -322,7 +321,6 @@ spec:
                             exit 1
                         fi
                     \'\'\'
-                  }
                 }
             }
 		}
@@ -333,7 +331,6 @@ spec:
           }
           steps {
               container('jnlp') {
-                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
                     sh \'\'\'
                         cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
                         unset JAVA_TOOL_OPTIONS 
@@ -345,7 +342,6 @@ spec:
                             exit 1
                         fi
                     \'\'\'
-                  }
                 }
             }
 		}
@@ -356,8 +352,7 @@ spec:
           }
           steps {
               container('jnlp') {
-                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
-                      withAnt(installation: 'apache-ant-latest', jdk: 'openjdk-jdk17-latest') {
+                      withAnt(installation: 'apache-ant-latest') {
                           sh \'\'\'
                             cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
                             bash -x ./mb300_gatherEclipseParts.sh $CJE_ROOT/buildproperties.shsource 2>&1 | tee $logDir/mb300_gatherEclipseParts.sh.log
@@ -368,7 +363,6 @@ spec:
                             fi
                           \'\'\'
                       }
-                  }
                 }
             }
 		}
@@ -379,8 +373,7 @@ spec:
           }
           steps {
               container('jnlp') {
-                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
-                      withAnt(installation: 'apache-ant-latest', jdk: 'openjdk-jdk17-latest') {
+                      withAnt(installation: 'apache-ant-latest') {
                           sh \'\'\'
                             cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
                             ./mb310_gatherEquinoxParts.sh $CJE_ROOT/buildproperties.shsource 2>&1 | tee $logDir/mb310_gatherEquinoxParts.sh.log
@@ -391,14 +384,12 @@ spec:
                             fi
                           \'\'\'
                       }
-                  }
                 }
             }
 		}
 	  stage('Generate Repo reports'){
           steps {
               container('jnlp') {
-                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
                       sh \'\'\'
                         cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
                         unset JAVA_TOOL_OPTIONS 
@@ -410,14 +401,12 @@ spec:
                             exit 1
                         fi
                       \'\'\'
-                  }
                 }
             }
 		}
 	  stage('Generate API tools reports'){
           steps {
               container('jnlp') {
-                  withEnv(["JAVA_HOME=${ tool 'openjdk-jdk17-latest' }"]) {
                       sh \'\'\'
                         cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
                         unset JAVA_TOOL_OPTIONS 
@@ -429,7 +418,6 @@ spec:
                             exit 1
                         fi
                       \'\'\'
-                  }
                 }
             }
 		}


### PR DESCRIPTION
Since https://github.com/eclipse-platform/eclipse.platform.swt/pull/973 the I-build (like the SWT build) requires a java-17 (or later) jdk on the `PATH` system environment-variable in order to launch a `jdk>=17` with the 'java' command from the CLI. Just setting the `JAVA_HOME` variable to a path pointing to a jdk-17 is not sufficient since the the java executable is usually located in `$JAVA_HOME/bin`. And while the maven launch script searches in `$JAVA_HOME/bin` for a java executable to run the build itself, a simple java command on the CLI isn't that smart. 
Previously running the `java` command would just run the default default java version on the Jenkins executor.

In general this simplifies the build-configuration because the JDK to use is only defined once and used everywhere.

Hopefully fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1724. I have no way to test this in advance but the explanation above is the only one I found why the Maven build itself runs fine (which requires Java-17 because of Tycho), but fails as soon as a `java` command is launched that requires java>=17.