### PR TITLE
make path names unix friendly

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
@@ -544,7 +544,7 @@
                                 ;${eclipse.platform.ui.bundles}/org.eclipse.jface.text/projection
                                 ;${eclipse.platform.ui.bundles}/org.eclipse.jface.text/src
                                 ;${eclipse.platform.ui.bundles}/org.eclipse.search.core/search
-                                ;${eclipse.platform.ui.bundles}/org.eclipse.search/new search
+                                ;${eclipse.platform.ui.bundles}/org.eclipse.search/newsearch
                                 ;${eclipse.platform.ui.bundles}/org.eclipse.search/search
                                 ;${eclipse.platform.ui.bundles}/org.eclipse.text/projection
                                 ;${eclipse.platform.ui.bundles}/org.eclipse.text/src


### PR DESCRIPTION
remove white space from path names

Refs: https://github.com/eclipse-platform/eclipse.platform.ui/pull/1536