### PR TITLE
Don't skip api analysis if artifact was replaced to always get messages

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -954,6 +954,7 @@
                                  </repository>
                              </baselines>
                              <skip>${skipAPIAnalysis}</skip>
+                             <skipIfReplaced>false</skipIfReplaced>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
As people are ["steady confused"](https://github.com/eclipse-platform/eclipse.platform.ui/pull/1557#issuecomment-1910559050) we better should have slower builds than confusing even experienced committers so they constantly complain about "randomness". Also requested [here](https://github.com/eclipse-platform/eclipse.platform.ui/pull/1557#issuecomment-1910099859).