### PR TITLE
Redirect API messages to the ECJ log

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -159,6 +159,7 @@
     <!-- system specific JVM args; if needed provided by system properties to the build command -->
     <surefire.systemProperties></surefire.systemProperties>
     <java.version>17</java.version>
+    <printApiMessages>false</printApiMessages>
   </properties>
 
   <organization>
@@ -955,6 +956,9 @@
                              </baselines>
                              <skip>${skipAPIAnalysis}</skip>
                              <skipIfReplaced>false</skipIfReplaced>
+                             <logDirectory>${project.build.directory}/compilelogs</logDirectory>
+                             <enhanceLogs>true</enhanceLogs>
+                             <printProblems>${printApiMessages}</printProblems>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Currently API tools messages are shown only in the maven log where they are hard to find.

This disable the maven log output and redirects the messages to the compile logs so they can be displayed in Jenkins