### PR TITLE
Do not disable the default metadata generation

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -885,9 +885,6 @@
                 <phase>verify</phase>
               </execution>
             </executions>
-            <configuration>
-              <defaultP2Metadata>false</defaultP2Metadata>
-            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Currently the eclipse-sign goal disables the default meta data generation of a project (as it needs to update the metadata afterwards) but this seem to fail under some circumstances with quite obscure errors.

This removes the disabling of the default-metadata what might be a tiny little slower but seem not to cause any issues in reward.

@akurtakov this seems what currently fails the master build.