### PR TITLE
Unify Titles For Preference Pages Documentation

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/help_preferences.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/help_preferences.htm
@@ -7,10 +7,10 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
-  <title>Help preferences</title>
+  <title>Help</title>
 </head>
 <body>
-  <h1>Help preferences</h1>
+  <h1>Help</h1>
   <p class="Para">On the <a class="command-link" href=
   'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.help.ui.browsersPreferencePage)")'>
   <img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg" alt="command link"> <strong>Help</strong></a> preferences

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/help_preferences_content.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/help_preferences_content.htm
@@ -7,10 +7,10 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
-  <title>Help Content preferences</title>
+  <title>Help Content</title>
 </head>
 <body>
-  <h1>Help Content preferences</h1>
+  <h1>Help Content</h1>
   <p class="Para">Help topics from remote servers can be included seamlessly into the local help system. Use the
   <a class="command-link" href=
   'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.help.ui.contentPreferencePage)")'>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-12.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-12.htm
@@ -7,10 +7,10 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <link rel="STYLESHEET" href="../book.css" type="text/css">
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
-  <title>Editors preference page</title>
+  <title>Editors</title>
 </head>
 <body bgcolor="#FFFFFF">
-  <h1 class="Head">Editors preference page</h1>
+  <h1 class="Head">Editors</h1>
   <p class="Para">You can change the following preferences on the <a class="command-link" href=
   'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.ui.preferencePages.Editors)")'>
   <img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg" alt="command link"><strong>General &gt;

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-16.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-16.htm
@@ -7,10 +7,10 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
-  <title>Appearance preference page</title>
+  <title>Appearance</title>
 </head>
 <body bgcolor="#FFFFFF">
-  <h1 class="Head">Appearance preference page</h1>
+  <h1 class="Head">Appearance</h1>
   <p class="Para">You can change the following preference on the <a class="command-link" href=
   'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.ui.preferencePages.Views)")'>
   <img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg" alt="command link"><strong>General &gt;

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-19.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-19.htm
@@ -7,10 +7,10 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
-  <title>Team</title>
+  <title>Version Control (Team)</title>
 </head>
 <body bgcolor="#FFFFFF">
-  <h1 class="Head">Team</h1>
+  <h1 class="Head">Version Control (Team)</h1>
   <p class="Para">The <a class="command-link" href=
   'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.team.ui.TeamPreferences)")'>
   <img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg" alt="command link"> <strong>Version Control

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-20-fileContent.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-20-fileContent.htm
@@ -7,10 +7,10 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
-  <title>Team File Content</title>
+  <title>File Content</title>
 </head>
 <body bgcolor="#FFFFFF">
-  <h1 class="Head">Team File Content</h1>
+  <h1 class="Head">File Content</h1>
   <p class="Intro">On the <a class="command-link" href=
   'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.team.ui.TextPreferences)")'>
   <img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg" alt="command link"> <strong>Team &gt; File

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-20.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-20.htm
@@ -10,7 +10,7 @@
   <title>Ignored Resources</title>
 </head>
 <body bgcolor="#FFFFFF">
-  <h1 class="Head">Team Ignored Resources</h1>
+  <h1>Ignored Resources</h1>
   <p class="Intro">On the <a class="command-link" href=
   'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.team.ui.IgnorePreferences)")'>
   <img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg" alt="command link"> <strong>Team &gt; Ignored

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-20team-models.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-20team-models.htm
@@ -7,10 +7,10 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
-  <title>Team Models</title>
+  <title>Models</title>
 </head>
 <body bgcolor="#FFFFFF">
-  <h1 class="Head">Team Models</h1>
+  <h1 class="Head">Models</h1>
   <p>The <a class="command-link" href=
   'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.team.ui.enabledModels)")'><img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg"
   alt="command link"> <strong>Team &gt; Models</strong></a>preference page allows you to select which model providers

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-22.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-22.htm
@@ -6,7 +6,7 @@
   "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta http-equiv="Content-Style-Type" content="text/css" />
-  <title>Annotations preference page</title>
+  <title>Annotations </title>
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css" />
   <style type="text/css">
@@ -17,7 +17,7 @@
   </style>
 </head>
 <body>
-  <h1 class="Head">Annotations preference page</h1>
+  <h1 class="Head">Annotations</h1>
   <div class="Para">
     <p>The following preferences can be changed on the <a class="command-link" href=
     'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.ui.editors.preferencePages.Annotations)")'>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-35.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-35.htm
@@ -6,7 +6,7 @@
   "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta http-equiv="Content-Style-Type" content="text/css" />
-  <title>Quick Diff Preference Page</title>
+  <title>Quick Diff</title>
   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css" />
   <style type="text/css">
   /*<![CDATA[*/
@@ -18,7 +18,7 @@
 </head>
 <body>
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
-  <h1 class="Head">Quick Diff Preference Page</h1>
+  <h1 class="Head">Quick Diff</h1>
   <div class="Para"></div>
   <div class="Para">
     <p>The following preferences can be changed on the <a class="command-link" href=

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-36.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-36.htm
@@ -6,7 +6,7 @@
   "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
   <meta http-equiv="Content-Style-Type" content="text/css" />
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <title>Spelling preference page</title>
+  <title>Spelling</title>
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css" />
   <style type="text/css">
@@ -18,7 +18,7 @@
   </style>
 </head>
 <body>
-  <h1 class="Head">Spelling Preference Page</h1>
+  <h1 class="Head">Spelling</h1>
   <div class="Para">
     <p>The following preferences can be changed on the <a class="command-link" href=
     'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.ui.editors.preferencePages.Spelling)")'>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-42.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-42.htm
@@ -7,10 +7,10 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
-  <title>Web Browser preferences</title>
+  <title>Web Browser</title>
 </head>
 <body>
-  <h1>Web Browser preferences</h1>
+  <h1>Web Browser</h1>
   <div class="Para">
     <p>The following preferences can be changed on the <a class="command-link" href=
     'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.ui.browser.preferencePage)")'>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-7.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-7.htm
@@ -6,12 +6,12 @@
   "Copyright (c) IBM Corporation and others 2000, 2013. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta http-equiv="Content-Style-Type" content="text/css" />
-  <title>Accessibility preferences</title>
+  <title>Accessibility</title>
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
   <link rel="STYLESHEET" href="../book.css" type="text/css" />
 </head>
 <body bgcolor="#FFFFFF">
-  <h1 class="Head">Accessibility preferences</h1>
+  <h1 class="Head">Accessibility</h1>
   <p>The following preferences can be changed on the <a class="command-link" href=
   'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.ui.editors.preferencePages.Accessibility)")'>
   <img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg" alt="command link" /><strong>General &gt; Editors &gt; Text

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-antcontentassist.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-antcontentassist.htm
@@ -7,10 +7,10 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-  <title>Ant Content Assist Preferences</title>
+  <title>Ant Content Assist</title>
 </head>
 <body>
-  <h1>Ant Content Assist Preferences</h1>
+  <h1>Ant Content Assist</h1>
   <p>The following preferences can be changed on the <a class="command-link" href=
   'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.ant.ui.AntCodeAssistPreferencePage)")'>
   <img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg" alt="command link"> <strong>Ant &gt; Editor &gt; Content

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-anteditor.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-anteditor.htm
@@ -6,10 +6,10 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta http-equiv="Content-Style-Type" content="text/css">
   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-  <title>Ant editor</title>
+  <title>Ant Editor</title>
 </head>
 <body>
-  <h1>Ant editor</h1>
+  <h1>Ant Editor</h1>
   <p>The Ant editor provides specialized features for editor Ant buildfiles. Associated with the editor is a Ant
   buildfile specific <b><a href="PLUGINS_ROOT/org.eclipse.jdt.doc.user/reference/views/ref-view-outline.htm">Outline
   view</a></b> which shows the structure of the Ant build file. It is updated as you edit the buildfile</p>The editor

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-anteditorprefs.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-anteditorprefs.htm
@@ -7,10 +7,10 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-  <title>Ant Editor Preferences</title>
+  <title>Ant Editor</title>
 </head>
 <body>
-  <h1 class="Head">Ant Editor Preferences</h1>
+  <h1 class="Head">Ant Editor</h1>
   <p>The following preferences can be changed on the <a class="command-link" href=
   'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.ant.ui.AntEditorPreferencePage)")'>
   <img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg" alt="command link"> <strong>Ant &gt; Editor</strong></a>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-antformatter.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-antformatter.htm
@@ -7,10 +7,10 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-  <title>Ant Formatter Preferences</title>
+  <title>Ant Formatter</title>
 </head>
 <body>
-  <h1>Ant Formatter Preferences</h1>
+  <h1>Ant Formatter</h1>
   <p>The following preferences can be changed on the <a class="command-link" href=
   'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.ant.ui.AntCodeFormatterPreferencePage)")'>
   <img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg" alt="command link"> <strong>Ant &gt; Editor &gt;

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-antprefs.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-antprefs.htm
@@ -7,10 +7,10 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <link rel="STYLESHEET" href="../book.css" type="text/css">
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
-  <title>General Ant Preferences</title>
+  <title>Ant</title>
 </head>
 <body>
-  <h1>General Ant Preferences</h1>
+  <h1>Ant</h1>
   <p>You can change the following preferences on the <a class="command-link" href=
   'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.ant.ui.AntPreferencePage)")'>
   <img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg" alt="command link"><strong>Ant</strong></a> preference

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-antruntimeprefs.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-antruntimeprefs.htm
@@ -7,10 +7,10 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-  <title>Ant Runtime Preferences</title>
+  <title>Ant Runtime</title>
 </head>
 <body>
-  <h1>Ant Runtime Preferences</h1>
+  <h1>Ant Runtime</h1>
   <p>The following preferences can be changed on the <a class="command-link" href=
   'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.ant.ui.AntRuntimePreferencePage)")'>
   <img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg" alt="command link"> <strong>Ant &gt; Runtime</strong></a>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-anttemplates.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-anttemplates.htm
@@ -7,10 +7,10 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-  <title>Ant Templates Preference</title>
+  <title>Ant Templates</title>
 </head>
 <body>
-  <h1>Ant Templates Preferences</h1>
+  <h1>Ant Templates</h1>
   <p>The following preferences can be changed on the <a class="command-link" href=
   'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.ant.ui.TemplatesPreferencePage)")'>
   <img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg" alt="command link"><strong>Ant &gt; Editor &gt;

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-capabilitiespref.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-capabilitiespref.htm
@@ -10,7 +10,7 @@
   <title>Capabilities</title>
 </head>
 <body bgcolor="#FFFFFF">
-  <h2>Capabilities</h2>
+  <h1>Capabilities</h1>
   <p class="Para">The <a class="command-link" href=
   'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.sdk.capabilities)")'><img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg"
   alt="command link"> <strong>General &gt; Capabilities</strong></a> preference page allows you to enable or disable

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-content-type.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-content-type.htm
@@ -7,10 +7,10 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
   <link rel="STYLESHEET" href="../book.css" type="text/css">
-  <title>Content Types preference page</title>
+  <title>Content Types</title>
 </head>
 <body bgcolor="#FFFFFF">
-  <h1 class="Head">Content Types preference page</h1>
+  <h1 class="Head">Content Types</h1>
   <p class="Para">The <a class="command-link" href=
   'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.ui.preferencePages.ContentTypes)")'>
   <img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg" alt="command link"><strong>General &gt; Content

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-globalizationprefs.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-globalizationprefs.htm
@@ -7,10 +7,10 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <link rel="STYLESHEET" href="../book.css" type="text/css">
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
-  <title>Globalization Preferences</title>
+  <title>Globalization</title>
 </head>
 <body>
-  <h1>Globalization Preferences</h1>
+  <h1>Globalization</h1>
   <p>On the <a class="command-link" href=
   'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.ui.preferencePages.Globalization)")'>
   <img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg" alt="command link"> <strong>General &gt;

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-securestorage-prefs.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-securestorage-prefs.htm
@@ -7,10 +7,10 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
-  <title>Secure storage preference page</title>
+  <title>Secure Storage</title>
 </head>
 <body bgcolor="#FFFFFF">
-  <h1 class="Head">Secure storage preference page</h1>
+  <h1 class="Head">Secure Storage</h1>
   <p>The <a class="command-link" href=
   'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.equinox.security.ui.storage)")'>
   <img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg" alt="command link"> <strong>General &gt; Security &gt;

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-startup-workspaces.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-startup-workspaces.htm
@@ -7,10 +7,10 @@
   <meta http-equiv="Content-Style-Type" content="text/css">
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-  <title>Startup and Shutdown, Workspaces</title>
+  <title>Workspaces</title>
 </head>
 <body bgcolor="#FFFFFF">
-  <h1 class="Head">Startup and Shutdown, Workspaces</h1>
+  <h1 class="Head">Workspaces</h1>
   <p class="Para">The <a class="command-link" href=
   'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.ui.preferencePages.Startup.Workspaces)")'>
   <img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg" alt="command link"> <strong>General &gt; Startup and

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-texteditorprefs.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-texteditorprefs.htm
@@ -6,7 +6,7 @@
   "Copyright (c) IBM Corporation and others 2000, 2018. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta http-equiv="Content-Style-Type" content="text/css" />
-  <title>Text Editors preference page</title>
+  <title>Text Editors</title>
   <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css" />
   <style type="text/css">
@@ -18,7 +18,7 @@
   </style>
 </head>
 <body>
-  <h1 class="Head">Text Editors preference page</h1>
+  <h1 class="Head">Text Editors</h1>
   <p>The following preferences can be changed on the <a class="command-link" href=
   'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.ui.preferencePages.GeneralTextEditor)")'>
   <img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg" alt="command link" /> <strong>General &gt; Editors &gt;

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/topics_Reference.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/topics_Reference.xml
@@ -108,23 +108,23 @@
 			</enablement>
 		</topic>
 		<topic label="Startup and Shutdown" href="reference/ref-startup.htm"></topic>
-		<topic label="Team" href="reference/ref-19.htm">
+		<topic label="Version Control (Team)" href="reference/ref-19.htm">
 			<enablement>
 				<test property="org.eclipse.core.runtime.isBundleInstalled" args="org.eclipse.team.ui"/>
 			</enablement>
 		</topic>
-		<topic label="Team File Content" href="reference/ref-20-fileContent.htm">
+		<topic label="File Content" href="reference/ref-20-fileContent.htm">
 			<enablement>
 				<test property="org.eclipse.core.runtime.isBundleInstalled" args="org.eclipse.team.ui"/>
 			</enablement>
 		</topic>
-		<topic label="Team Ignored Resources" href="reference/ref-20.htm">
+		<topic label="Ignored Resources" href="reference/ref-20.htm">
 		    <topic label="Ignoring resources from version control" href="reference/ref-48a.htm" ></topic>
 			<enablement>
 				<test property="org.eclipse.core.runtime.isBundleInstalled" args="org.eclipse.team.ui"/>
 			</enablement>
 		</topic>
-		<topic label="Team Models" href="reference/ref-20team-models.htm">
+		<topic label="Models" href="reference/ref-20team-models.htm">
 			<enablement>
 				<test property="org.eclipse.core.runtime.isBundleInstalled" args="org.eclipse.team.ui"/>
 			</enablement>


### PR DESCRIPTION
The titles of the documenation of the preference pages should be uniform. This means:
- Use "Title Case" style and and not "Sentences case" style
- Don't append additional words "Preferences" or "Preference Page"
- Entry in the table of content (tree on the left side) should be the same as the title