### PR TITLE
Document preferences to hide tab icons and show full texts in view areas

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-16.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-16.htm
@@ -54,6 +54,18 @@
       <td>Specifies whether the list of tabs should be sorted in the order in which they are most recently used.</td>
       <td>Enabled</td>
     </tr>
+    <tr valign="top">
+      <td><b>Always show full titles</b></td>
+      <td>Specify if the tabs in view areas should always show full titles. This setting is only available if 
+          <em>&quot;Enable Theming&quot;</em> is enabled.</td>
+      <td>Disabled</td>
+    </tr>    
+    <tr valign="top">
+      <td><b>Hide icons</b></td>
+      <td>Specify if the icons for tabs in view areas should be hidden. This setting is only available if 
+          <em>&quot;Enable Theming&quot;</em> is enabled.</td>
+      <td>Disabled</td>
+    </tr>    
   </table>
 </body>
 </html>


### PR DESCRIPTION
Document "Tab icons and titles in view areas" Section of The Appearance Preference Page #1778

As part of https://github.com/eclipse-platform/eclipse.platform.ui/pull/1071, two preferences were added in the Appearance section.

- hide tab icons in view areas, and 
- show full titles for tabs in view areas

<img width="500" alt="image" src="https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/assets/57699330/93615f7d-6018-4a89-a012-0aab0cd0dabf">

This PR aims at documenting these preferences for eclipse help.
