### PR TITLE
Make tycho-surefire-plugin quiet

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,5 +1,2 @@
 -XX:+PrintFlagsFinal
-<<<<<<< Upstream, based on master
 -Xmx2g
-=======
->>>>>>> 100ffb6 Make the fail for javadoc configurable

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,2 +1,5 @@
 -XX:+PrintFlagsFinal
+<<<<<<< Upstream, based on master
 -Xmx2g
+=======
+>>>>>>> 100ffb6 Make the fail for javadoc configurable

--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -523,6 +523,7 @@
           <configuration>
             <enableAssertions>true</enableAssertions>
             <argLine>${surefire.testArgLine} ${surefire.platformSystemProperties} ${surefire.systemProperties} ${surefire.moduleProperties}</argLine>
+            <quiet>true</quiet>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Do not print an extra message if tests pass/fail even if test failures
are ignored.

Here it was complained that "maven" prints an additional error/warnings when test fails:
- https://github.com/eclipse-platform/eclipse.platform.ui/discussions/1644#discussioncomment-8380264

this now makes the mojo "quiet" so it does not give any message at all and hopes the user notices it otherwise that test failures occurred (e.g. by examine the Test results on Jenkins).