### PR TITLE
Install available sources with the SDK product

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/pom.xml
@@ -382,6 +382,7 @@ UNmHBQdtflW5G1L5fQggWG7V
             </goals>
             <configuration>
               <profile>SDKProfile</profile>
+              <installSources>true</installSources>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
Currently only some sources are included in the SDK product these are those that explicitly specified in source features. As removing more and more third party dependencies from features, they will also vanish from source features and therefore missing in the SDK product. Beside that, managing source features itself is a tedious task.

This enables the `<installSources>` option for the SDK product that will install any available source with a bundle automatically.

![grafik](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/assets/1331477/3039d904-9d40-489a-8fe2-bdce506fd464)

FYI @merks @iloveeclipse 

Fix https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1767