### PR TITLE
Document new option of declaring a default editor in preferences

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-content-type.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-content-type.htm
@@ -43,6 +43,10 @@
   <p>Those user-defined editor associations are stored in the user data area.</p>
   <p>Editor associations defined manually can be removed thanks to the <b>Remove</b> button. Editor associations that
   were defined by a plug-in are locked and cannot be removed.</p>
+  <p>In case there are multiple editors suitable to open a content type, you can declare one of these editors as
+  default editor (the preferred editor). Just select the editor in the associated editors list and press the
+  <b>Default</b> button. If there is no default editor, the first suitable editor found is used to open the
+  content type.</p>
   <h2>Define default encoding for content type</h2>
   <p class="Para">You can also set the default encoding for a given content type. To do this, simply enter the encoding
   name in the provided field and click <strong>Update</strong>.</p>


### PR DESCRIPTION
Documents changes from https://github.com/eclipse-platform/eclipse.platform.ui/pull/1665