### PR TITLE
ECJ version update for M3

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -86,7 +86,7 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cbi-jdt-repo.url>https://repo.eclipse.org/content/repositories/eclipse-staging/</cbi-jdt-repo.url>
-    <cbi-ecj-version>3.37.0.v20240207-0725</cbi-ecj-version>
+    <cbi-ecj-version>3.37.0.v20240215-1558</cbi-ecj-version>
 
     <!--
       repo for released versions of CBI. Note, we intentionally use as specific a repo as possible.


### PR DESCRIPTION
Run https://ci.eclipse.org/jdt/job/copyAndDeployJDTCompiler/ before merge.

@iloveeclipse @mpalat 