### PR TITLE
Change http://www.eclipse.org to https://www.eclipse.org in tips URLs

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.tips.user/META-INF/MANIFEST.MF
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.tips.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JDT Tip of the Day Provider
 Bundle-SymbolicName: org.eclipse.jdt.tips.user;singleton:=true
-Bundle-Version: 0.3.0.qualifier
+Bundle-Version: 0.3.100.qualifier
 Bundle-Vendor: Eclipse.org
 Automatic-Module-Name: org.eclipse.jdt.tips.user
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.tips.user/content/provider.json
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.tips.user/content/provider.json
@@ -4,7 +4,7 @@
 		"description": "Java and JDT Tips",
 		"expression": "<with variable=\"activeWorkbenchWindow.activePerspective\"><equals value=\"org.eclipse.jdt.ui.JavaPerspective\"></equals></with>",
 		"variables": {
-			"baseUrl": "http://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/tips/org.eclipse.jdt.tips.user"
+			"baseUrl": "https://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/tips/org.eclipse.jdt.tips.user"
 		},
 		"tips": [{
 			"date": "2018-01-05",

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.tips.user/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.tips.user/pom.xml
@@ -21,6 +21,6 @@
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.tips.core</artifactId>
-  <version>0.3.0-SNAPSHOT</version>
+  <version>0.3.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.tips.user/src/org/eclipse/jdt/tips/user/internal/JDTTipProvider.java
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.tips.user/src/org/eclipse/jdt/tips/user/internal/JDTTipProvider.java
@@ -34,7 +34,7 @@ public class JDTTipProvider extends JsonTipProvider {
 		if (fUrl != null) {
 			setJsonUrl(fUrl);
 		} else {
-			fUrl = "http://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/tips/org.eclipse.jdt.tips.user/" + FILENAME; //$NON-NLS-1$
+			fUrl = "https://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/tips/org.eclipse.jdt.tips.user/" + FILENAME; //$NON-NLS-1$
 			setJsonUrl(fUrl);
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1825