### PR TITLE
Version bumps for 4.32 stream

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/META-INF/MANIFEST.MF
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.doc.isv; singleton:=true
-Bundle-Version: 3.14.2300.qualifier
+Bundle-Version: 3.14.2400.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.2.0,4.0.0)"

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.doc.isv</artifactId>
-  <version>3.14.2300-SNAPSHOT</version>
+  <version>3.14.2400-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <profiles>


### PR DESCRIPTION
Version bumps for 4.32 stream

Tracked in
eclipse-platform/eclipse.platform.releng.aggregator#1862