### PR TITLE
Publish 4.31 to Maven central

### DIFF
--- a/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr
+++ b/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr
@@ -2,10 +2,10 @@
 <aggregator:Aggregation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="SDK4Mvn" packedStrategy="UNPACK_AS_SIBLING" type="R" mavenResult="true" versionFormat="MavenRelease" includeSources="true">
   <validationSets label="main">
     <contributions label="sdk">
-      <repositories enabled="false" location="/home/data/httpd/download.eclipse.org/eclipse/updates/4.31-I-builds"/>
+      <repositories enabled="false" location="/home/data/httpd/download.eclipse.org/eclipse/updates/4.31/R-4.31-202402290520"/>
     </contributions>
     <contributions label="sdk_http">
-      <repositories location="https://download.eclipse.org/eclipse/updates/4.31-I-builds"/>
+      <repositories location="https://download.eclipse.org/eclipse/updates/4.31/R-4.31-202402290520"/>
     </contributions>
   </validationSets>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="aarch64"/>

--- a/eclipse.platform.releng/publish-to-maven-central/properties.sh
+++ b/eclipse.platform.releng/publish-to-maven-central/properties.sh
@@ -14,8 +14,8 @@
 
 # ECLIPSE:
 DROPS4=/home/data/httpd/download.eclipse.org/eclipse/downloads/drops4
-SDK_BUILD_DIR=R-4.30-202312010110
-SDK_VERSION=4.30
+SDK_BUILD_DIR=R-4.31-202402290520
+SDK_VERSION=4.31
 FILE_ECLIPSE=${DROPS4}/${SDK_BUILD_DIR}/eclipse-SDK-${SDK_VERSION}-linux-gtk-x86_64.tar.gz
 
 # AGGREGATOR:


### PR DESCRIPTION
Update SDK4Mvn.aggr and properties.sh file for publishing 4.31 to maven central.

Refs: https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1882

cc/ @MohananRahul 