### PR TITLE
Revert "Prevent two PRs for same update from dependabot"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,21 @@
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
+  - package-ecosystem: maven
+    directory: eclipse-platform-parent
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    labels:
+      - dependencies
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
+
 
   - package-ecosystem: docker
     directory: /cje-production/dockerfiles/centos-gtk3-metacity/8-gtk3


### PR DESCRIPTION
Reverts eclipse-platform/eclipse.platform.releng.aggregator#1643

This broke dependabot opening PRs for maven plugins in eclipse-platform-parent