### PR TITLE
Remove unused tycho-eclipserun-plugin configuration

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -400,22 +400,6 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.eclipse.tycho.extras</groupId>
-          <artifactId>tycho-eclipserun-plugin</artifactId>
-          <!-- this is actually present in any 0.14+ version -->
-          <version>${tycho.version}</version>
-          <configuration>
-            <executionEnvironment>JavaSE-17</executionEnvironment>
-            <repositories>
-              <repository>
-                <id>eclipse</id>
-                <layout>p2</layout>
-                <url>${eclipserun-repo}</url>
-              </repository>
-            </repositories>
-          </configuration>
-        </plugin>
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
           <version>3.1.0</version>


### PR DESCRIPTION
It is probably a left-over from the old setup to run the API-analysis, which is now not necessary anymore.
@laeubi, @akurtakov I guess it is also not used implicitly anymore, is it?