### PR TITLE
Make Java 21 the primary JVM to execute the maven build

### DIFF
--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -56,10 +56,12 @@ jobs:
           8
           11
           17
+          21
         mvn-toolchain-id: |
           JavaSE-1.8
           JavaSE-11
           JavaSE-17
+          JavaSE-21
         distribution: 'temurin'
         cache: maven
     - name: Set up Maven

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
 	}
 	tools {
 		maven 'apache-maven-latest'
-		jdk 'temurin-jdk17-latest'
+		jdk 'temurin-jdk21-latest'
 	}
 	stages {
 		stage('initialize PGP') {


### PR DESCRIPTION
Java 21 is the next LTS and projects are allowed to use Java 21 in this release, therefore it should become the new primary Java version used to execute the build.

This also will allow us to catch any possible issues with Java 21 used as build VM.