### PR TITLE
Add org.eclipse.tips.tests to main test script

### DIFF
--- a/production/testScripts/configuration/sdk.tests/testScripts/test.xml
+++ b/production/testScripts/configuration/sdk.tests/testScripts/test.xml
@@ -1978,6 +1978,12 @@
     </move>
   </target>
 
+ <target
+    name="tips"
+    depends="init">
+    <runTests testPlugin="org.eclipse.tips.tests" />
+  </target>
+	
   <target
     name="ua"
     depends="init">
@@ -2619,6 +2625,7 @@
     <antcall target="urischeme" />
 
     <antcall target="equinoxhttpservlet" />
+    <antcall target="tips" />
     <antcall target="ua" />
     <antcall target="uiforms" />
     <antcall target="equinoxp2ui" />


### PR DESCRIPTION
Enables the tests in the `org.eclipse.tips.tests` project for which an Ant configuration has been provided via https://github.com/eclipse-platform/eclipse.platform/pull/1147.