### PR TITLE
Add org.eclipse.tips.tests to SDK test feature

### DIFF
--- a/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
@@ -204,6 +204,10 @@
          version="0.0.0"/>
 
    <plugin
+         id="org.eclipse.tips.tests"
+         version="0.0.0"/>
+
+   <plugin
          id="org.eclipse.ua.tests"
          version="0.0.0"/>
 


### PR DESCRIPTION
The tests in `org.eclipse.tips.tests` recently enabled for the Ant-based build require the test plug-in to be added to the SDK test feature to be available during the build.

Complements https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1924