### PR TITLE
Update ecj version to latest in stable I-build

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -86,7 +86,7 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cbi-jdt-repo.url>https://repo.eclipse.org/content/repositories/eclipse-staging/</cbi-jdt-repo.url>
-    <cbi-ecj-version>3.38.0.v20240314-1517</cbi-ecj-version>
+    <cbi-ecj-version>3.38.0.v20240322-1728</cbi-ecj-version>
 
     <!--
       repo for released versions of CBI. Note, we intentionally use as specific a repo as possible.


### PR DESCRIPTION
Trying to fix thousands of "baseline and build for *.class have different contents"