### PR TITLE
Add org.eclipse.tips.tests to testManifest.xml

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/testManifest.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/testManifest.xml
@@ -692,6 +692,9 @@
       name="org.eclipse.text.tests"
       type="test" />
     <logFile
+      name="org.eclipse.tips.tests"
+      type="test" />
+    <logFile
       name="org.eclipse.ua.tests"
       type="test" />
     <logFile


### PR DESCRIPTION
The test results for `org.eclipse.tips.tests` now show up in the CI test results, e.g. https://download.eclipse.org/eclipse/downloads/drops4/I20240325-1800/testResults.php
Still there is an error about a missing xml file entry on the CI test results page to be fixed by this PR.
![image](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/assets/755472/12ae7c76-3272-445b-ac9c-f40dde01d5f9)


The `TestResultsGenerator` used for collecting aggregator build tests results contains a sanity check that requires each test project to be added to a `testManifest.xml`. This adds the `org.eclipse.tips.tests` project recently enabled for the Ant-based build to that XML file.

Complements https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1924