### PR TITLE
Add core.contenttype.tests and update.configurator.tests to Ant build

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/testManifest.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/testManifest.xml
@@ -533,6 +533,9 @@
       name="org.eclipse.compare.tests"
       type="test" />
     <logFile
+      name="org.eclipse.core.contenttype.tests"
+      type="test" />
+    <logFile
       name="org.eclipse.core.expressions.tests"
       type="test" />
     <logFile
@@ -720,6 +723,9 @@
       type="test" />
     <logFile
       name="org.eclipse.ui.tests.pluginchecks"
+      type="test" />
+    <logFile
+      name="org.eclipse.update.configurator.tests"
       type="test" />
 
   </logFiles>

--- a/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
@@ -359,4 +359,12 @@
          id="org.eclipse.pde.junit.runtime.tests"
          version="0.0.0"/>
 
+   <plugin
+         id="org.eclipse.core.contenttype.tests"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.update.configurator.tests"
+         version="0.0.0"/>
+
 </feature>

--- a/production/testScripts/configuration/sdk.tests/testScripts/test.xml
+++ b/production/testScripts/configuration/sdk.tests/testScripts/test.xml
@@ -1911,6 +1911,12 @@
   </target>
 
   <target
+    name="corecontenttype"
+    depends="init">
+    <runTests testPlugin="org.eclipse.core.contenttype.tests" />
+  </target>
+
+  <target
     name="coreexpressions"
     depends="init">
     <runTests testPlugin="org.eclipse.core.expressions.tests" />
@@ -2359,6 +2365,12 @@
   </target>
 
   <target
+    name="updateconfigurator"
+    depends="init">
+    <runTests testPlugin="org.eclipse.update.configurator.tests" />
+  </target>
+
+  <target
     name="all"
     depends="init">
     <!--
@@ -2610,6 +2622,7 @@
     <antcall target="compare" />
     <antcall target="coreruntime" />
     <antcall target="swt" />
+    <antcall target="corecontenttype" />
     <antcall target="coreexpressions" />
     <antcall target="coretestsnet" />
     <antcall target="text" />
@@ -2646,6 +2659,7 @@
     <antcall target="ltkuirefactoringtests" />
     <antcall target="ltkcorerefactoringtests" />
 
+    <antcall target="updateconfigurator" />
   </target>
 
   <!-- this group is "platform tests" that are Long Running


### PR DESCRIPTION
This adds the test bundles org.eclipse.core.contenttype.tests and org.eclipse.update.configurator.tests to the Ant-based build.
* Adds the bundles to the SDK test feature
* Adds according targets to the main test.xml
* Adds the produced log files to the testManifest.xml

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/219