### PR TITLE
Switch GHA maven build to Mac 13

### DIFF
--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -41,7 +41,7 @@ jobs:
         config: 
           - { name: Linux,   os: ubuntu-latest  }
           - { name: Windows, os: windows-latest }
-          - { name: MacOS,   os: macos-latest   }
+          - { name: MacOS,   os: macos-13   }
     name: Verify ${{ matrix.config.name }}
     steps:
     - name: Checkout


### PR DESCRIPTION
mac-latest was used and this was mac-12 but due to https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/ is now mac-14.
Switching to mac-13 to still be newer than what it used to be but still latest as there is no temurin java 8 for it leading to https://github.com/eclipse-platform/eclipse.platform.ui/actions/runs/8801294125/job/24154512271?pr=1842 :
```
Trying to resolve the latest version from remote
  Error: Could not find satisfied version for SemVer '8'.
  Available versions: 22.0.1+8, 22.0.0+36, 21.0.3+9.0.LTS,
21.0.2+13.0.LTS, 21.0.1+12.0.LTS, 21.0.0+35.0.LTS, 20.0.2+9, 20.0.1+9,
20.0.0+36, 19.0.2+7, 19.0.1+10, 19.0.0+36, 18.0.2+101, 18.0.2+9,
18.0.1+10, 18.0.0+36, 17.0.11+9, 17.0.10+7, 17.0.9+9, 17.0.8+101,
17.0.8+7, 17.0.7+7, 17.0.6+10, 17.0.5+8, 17.0.4+101, 17.0.4+8, 17.0.3+7,
17.0.2+8, 17.0.1+12, 17.0.0+35, 11.0.23+9, 11.0.22+7.1, 11.0.22+7,
11.0.21+9, 11.0.20+101, 11.0.20+8, 11.0.19+7, 11.0.18+10, 11.0.17+8,
11.0.16+101, 11.0.16+8, 11.0.15+10
```