### PR TITLE
[I-Build-Tests] Fix breakage of fundamental commands by tools-sections

### DIFF
--- a/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3_java17.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3_java17.groovy
@@ -85,9 +85,11 @@ spec:
 
   stages {
       stage('Run tests'){
-          tools {
-              jdk 'openjdk-jdk17-latest'
-              ant 'apache-ant-latest'
+          environment {
+              // Declaring a jdk and ant the usual way in the 'tools' section, because of unknown reasons, breaks the usage of fundamental commands like xvnc, pkill and sh
+              JAVA_HOME = tool(type:'jdk', name:'openjdk-jdk17-latest')
+              ANT_HOME = tool(type:'ant', name:'apache-ant-latest')
+              PATH = "$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
           }
           steps {
               container ('custom'){

--- a/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3_java21.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3_java21.groovy
@@ -85,9 +85,11 @@ spec:
 
   stages {
       stage('Run tests'){
-          tools {
-              jdk 'openjdk-jdk21-latest'
-              ant 'apache-ant-latest'
+          environment {
+              // Declaring a jdk and ant the usual way in the 'tools' section, because of unknown reasons, breaks the usage of fundamental commands like xvnc, pkill and sh
+              JAVA_HOME = tool(type:'jdk', name:'openjdk-jdk21-latest')
+              ANT_HOME = tool(type:'ant', name:'apache-ant-latest')
+              PATH = "$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
           }
           steps {
               container ('custom'){

--- a/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3_java22.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3_java22.groovy
@@ -85,9 +85,11 @@ spec:
 
   stages {
       stage('Run tests'){
-          tools {
-              jdk 'openjdk-jdk22-latest'
-              ant 'apache-ant-latest'
+          environment {
+              // Declaring a jdk and ant the usual way in the 'tools' section, because of unknown reasons, breaks the usage of fundamental commands like xvnc, pkill and sh
+              JAVA_HOME = tool(type:'jdk', name:'openjdk-jdk22-latest')
+              ANT_HOME = tool(type:'ant', name:'apache-ant-latest')
+              PATH = "$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
           }
           steps {
               container ('custom'){


### PR DESCRIPTION
Declaring a jdk and ant the usual way in the 'tools' section, because of unknown reasons, breaks the usage of fundamental commands like `xvnc`, `pkill` and `sh`.

See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1997#issuecomment-2080385005