### PR TITLE
[I-Build-Tests] Define Mac and Windows jobs as Jenkins-pipeline

### DIFF
--- a/JenkinsJobs/AutomatedTests/I_unit_mac64_java17.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_mac64_java17.groovy
@@ -5,80 +5,40 @@ for (STREAM in STREAMS){
   def MAJOR = STREAM.split('\\.')[0]
   def MINOR = STREAM.split('\\.')[1]
 
-  job('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-mac64-java17'){
+  pipelineJob('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-mac64-java17'){
     description('Run Eclipse SDK Tests for the platform implied by this job\'s name')
-
-    logRotator {
-      numToKeep(5)
-    }
-
-    parameters {
-      stringParam('buildId', null, 'Build Id to test (such as I20120717-0800, N20120716-0800). ')
-      stringParam('testSuite', 'all', null)
-    }
-
-
-    label('nc1ht-macos11-arm64')
-
-    jdk('openjdk-jdk11-latest')
 
     authenticationToken('windows2012tests')
  
-    wrappers { //adds pre/post actions
-      timestamps()
-      timeout {
-        absolute(600)
-      }
-    }
-  
-    steps {
-      shell('''
-#!/usr/bin/env bash
+    definition {
+      cps {
+        sandbox()
+        script('''
+pipeline {
+  options {
+    timeout(time: 600, unit: 'MINUTES')
+    timestamps()
+    buildDiscarder(logRotator(numToKeepStr:'5'))
+  }
+  parameters {
+    string(name: 'buildId', defaultValue: null, description: 'Build Id to test (such as I20120717-0800, N20120716-0800).')
+  }
+  agent {
+    label 'nc1ht-macos11-arm64'
+  }
 
-if [[ -z "${WORKSPACE}" ]]
-then
-  echo -e "\\n\\tERROR: WORKSPACE variable was not defined"
-  exit 1
-else
-  if [[ ! -d "${WORKSPACE}" ]]
-  then
-    echo -e "\\n\\tERROR: WORKSPACE was defined, but did not exist?"
-    echo -e "\\t\\tIt was defined as ${WORKSPACE}"
-    exit 1
-  else
-    echo -e "\\n\\tINFO: WORKSPACE was defined as ${WORKSPACE}"
-    echo -e "\\t\\tWill delete contents, for clean run"
-    MaxLoops=15
-    SleepTime=60
-    currentLoop=0
-    nFilesOrDirs=$( find "${WORKSPACE}" -mindepth 1 -maxdepth 1 | wc -l )
-    while [[ ${nFilesOrDirs} -gt 0 ]]
-    do
-      currentLoop=$(( ${currentLoop} + 1 ))
-      if [[ ${currentLoop} -gt ${MaxLoops} ]]
-      then
-        echo -e "\\n\\tERROR: Number of re-try loops, ${currentLoop}, exceeded maximum, ${MaxLoops}. "
-        echo -e " \\t\\tPossibly due to files still being used by another process?"
-        exit 0
-        break
-      fi
-      echo -e "\\tcurrentLoop: ${currentLoop}   nFilesOrDirs:  ${nFilesOrDirs}"
-      find "${WORKSPACE}" -mindepth 1 -maxdepth 1 -execdir rm -fr '{}' \\;
-      nFilesOrDirs=$( find "${WORKSPACE}" -mindepth 1 -maxdepth 1 | wc -l )
-      if [[ ${nFilesOrDirs} -gt 0 ]]
-      then
-        sleep ${SleepTime}
-      fi
-    done
-  fi
-fi
-echo -e "\\t... ending cleaning"
-
-exit 0
-      ''')
-      shell('''
-#!/bin/bash -x
-
+  stages {
+      stage('Run tests'){
+          environment {
+              // Declaring a jdk and ant the usual way in the 'tools' section, because of unknown reasons, breaks the usage of system commands like xvnc, pkill and sh
+              JAVA_HOME = '/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home'
+              ANT_HOME = '/opt/homebrew/Cellar/ant/1.10.11/libexec'
+              PATH = "${JAVA_HOME}/bin:${ANT_HOME}/bin:${PATH}"
+              eclipseArch = 'x86_64'
+          }
+          steps {
+              cleanWs() // workspace not cleaned by default
+              sh \'\'\'#!/bin/bash -x
 RAW_DATE_START="$(date +%s )"
 
 echo -e "\\n\\tRAW Date Start: ${RAW_DATE_START} \\n"
@@ -88,8 +48,8 @@ echo -e "\\n\\t uname -a: $(uname -a)\\n"
 
 # unset commonly defined system variables, which we either do not need, or want to set ourselves.
 # (this is to improve consistency running on one machine versus another)
-echo -e "Unsetting variables: JAVA_BINDIR JAVA_HOME JAVA_ROOT JDK_HOME JRE_HOME CLASSPATH ANT_HOME\\n"
-unset -v JAVA_BINDIR JAVA_HOME JAVA_ROOT JDK_HOME JRE_HOME CLASSPATH ANT_HOME
+echo "Unsetting variables: JAVA_BINDIR JAVA_ROOT JDK_HOME JRE_HOME CLASSPATH"
+unset -v JAVA_BINDIR JAVA_ROOT JDK_HOME JRE_HOME CLASSPATH
 
 # 0002 is often the default for shell users, but it is not when ran from
 # a cron job, so we set it explicitly, to be sure of value, so releng group has write access to anything
@@ -107,10 +67,6 @@ curl -o buildProperties.sh https://download.eclipse.org/eclipse/downloads/drops4
 cat getEBuilder.xml
 source buildProperties.sh
 
-export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
-export ANT_HOME=/opt/homebrew/Cellar/ant/1.10.11/libexec
-export PATH=${JAVA_HOME}/bin:${ANT_HOME}/bin:${PATH}
-
 echo JAVA_HOME: $JAVA_HOME
 echo ANT_HOME: $ANT_HOME
 echo PATH: $PATH
@@ -119,11 +75,10 @@ env  1>envVars.txt 2>&1
 ant -diagnostics  1>antDiagnostics.txt 2>&1
 java -XshowSettings -version  1>javaSettings.txt 2>&1
 
-export eclipseArch=x86_64
 ant -f getEBuilder.xml -Djava.io.tmpdir=${WORKSPACE}/tmp -DbuildId=$buildId -DeclipseStream=$STREAM -DEBUILDER_HASH=${EBUILDER_HASH} \\
   -DdownloadURL=https://download.eclipse.org/eclipse/downloads/drops4/${buildId} \\
   -Dosgi.os=macosx -Dosgi.ws=cocoa -Dosgi.arch=${eclipseArch} \\
-  -DtestSuite=${testSuite}
+  -DtestSuite=all
 
 RAW_DATE_END="$(date +%s )"
 
@@ -132,29 +87,19 @@ echo -e "\\n\\tRAW Date End: ${RAW_DATE_END} \\n"
 TOTAL_TIME=$((${RAW_DATE_END} - ${RAW_DATE_START}))
 
 echo -e "\\n\\tTotal elapsed time: ${TOTAL_TIME} \\n"
-      ''')
-    }
-
-    publishers {
-      archiveJunit('**/eclipse-testing/results/xml/*.xml') {
-        retainLongStdout()
-        healthScaleFactor((1.0).doubleValue())
-      }
-      archiveArtifacts {
-        pattern('**/eclipse-testing/results/**, **/eclipse-testing/directorLogs/**, *.properties, *.txt')
-      }
-      extendedEmail {
-        recipientList("sravankumarl@in.ibm.com")
-      }
-      downstreamParameterized {
-        trigger('Releng/ep-collectResults') {
-          condition('UNSTABLE_OR_BETTER')
-          parameters {
-            predefinedProp('triggeringJob', '$JOB_BASE_NAME')
-            predefinedProp('buildURL', '$BUILD_URL')
-            predefinedProp('buildID', '$buildId')
+              \'\'\'
+              archiveArtifacts '**/eclipse-testing/results/**, **/eclipse-testing/directorLogs/**, *.properties, *.txt'
+              junit keepLongStdio: true, testResults: '**/eclipse-testing/results/xml/*.xml'
+              build job: 'Releng/ep-collectResults', wait: false, parameters: [
+                string(name: 'triggeringJob', value: "${JOB_BASE_NAME}"),
+                string(name: 'buildURL', value: "${BUILD_URL}"),
+                string(name: 'buildID', value: "${params.buildId}")
+              ]
           }
-        }
+      }
+  }
+}
+        ''')
       }
     }
   }

--- a/JenkinsJobs/AutomatedTests/I_unit_macM1_java17.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_macM1_java17.groovy
@@ -5,79 +5,40 @@ for (STREAM in STREAMS){
   def MAJOR = STREAM.split('\\.')[0]
   def MINOR = STREAM.split('\\.')[1]
 
-  job('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-macM1-java17'){
+  pipelineJob('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-macM1-java17'){
     description('Run Eclipse SDK Tests for the platform implied by this job\'s name')
-
-    logRotator {
-      numToKeep(5)
-    }
-
-    parameters {
-      stringParam('buildId', null, 'Build Id to test (such as I20120717-0800, N20120716-0800). ')
-      stringParam('testSuite', 'all', null)
-    }
-
-    label('nc1ht-macos11-arm64')
-
-    jdk('openjdk-jdk11-latest')
 
     authenticationToken('windows2012tests')
  
-    wrappers { //adds pre/post actions
-      timestamps()
-      timeout {
-        absolute(600)
-      }
-    }
-  
-    steps {
-      shell('''
-#!/usr/bin/env bash
+    definition {
+      cps {
+        sandbox()
+        script('''
+pipeline {
+  options {
+    timeout(time: 600, unit: 'MINUTES')
+    timestamps()
+    buildDiscarder(logRotator(numToKeepStr:'5'))
+  }
+  parameters {
+    string(name: 'buildId', defaultValue: null, description: 'Build Id to test (such as I20120717-0800, N20120716-0800).')
+  }
+  agent {
+    label 'nc1ht-macos11-arm64'
+  }
 
-if [[ -z "${WORKSPACE}" ]]
-then
-  echo -e "\\n\\tERROR: WORKSPACE variable was not defined"
-  exit 1
-else
-  if [[ ! -d "${WORKSPACE}" ]]
-  then
-    echo -e "\\n\\tERROR: WORKSPACE was defined, but did not exist?"
-    echo -e "\\t\\tIt was defined as ${WORKSPACE}"
-    exit 1
-  else
-    echo -e "\\n\\tINFO: WORKSPACE was defined as ${WORKSPACE}"
-    echo -e "\\t\\tWill delete contents, for clean run"
-    MaxLoops=15
-    SleepTime=60
-    currentLoop=0
-    nFilesOrDirs=$( find "${WORKSPACE}" -mindepth 1 -maxdepth 1 | wc -l )
-    while [[ ${nFilesOrDirs} -gt 0 ]]
-    do
-      currentLoop=$(( ${currentLoop} + 1 ))
-      if [[ ${currentLoop} -gt ${MaxLoops} ]]
-      then
-        echo -e "\\n\\tERROR: Number of re-try loops, ${currentLoop}, exceeded maximum, ${MaxLoops}. "
-        echo -e " \\t\\tPossibly due to files still being used by another process?"
-        exit 0
-        break
-      fi
-      echo -e "\\tcurrentLoop: ${currentLoop}   nFilesOrDirs:  ${nFilesOrDirs}"
-      find "${WORKSPACE}" -mindepth 1 -maxdepth 1 -execdir rm -fr '{}' \\;
-      nFilesOrDirs=$( find "${WORKSPACE}" -mindepth 1 -maxdepth 1 | wc -l )
-      if [[ ${nFilesOrDirs} -gt 0 ]]
-      then
-        sleep ${SleepTime}
-      fi
-    done
-  fi
-fi
-echo -e "\\t... ending cleaning"
-
-exit 0
-      ''')
-      shell('''
-#!/bin/bash -x
-
+  stages {
+      stage('Run tests'){
+          environment {
+              // Declaring a jdk and ant the usual way in the 'tools' section, because of unknown reasons, breaks the usage of system commands like xvnc, pkill and sh
+              JAVA_HOME = '/usr/local/openjdk-17/Contents/Home'
+              ANT_HOME = '/opt/homebrew/Cellar/ant/1.10.11/libexec'
+              PATH = "${JAVA_HOME}/bin:${ANT_HOME}/bin:${PATH}"
+              eclipseArch = 'aarch64'
+          }
+          steps {
+              cleanWs() // workspace not cleaned by default
+              sh \'\'\'#!/bin/bash -x
 RAW_DATE_START="$(date +%s )"
 
 echo -e "\\n\\tRAW Date Start: ${RAW_DATE_START} \\n"
@@ -87,8 +48,8 @@ echo -e "\\n\\t uname -a: $(uname -a)\\n"
 
 # unset commonly defined system variables, which we either do not need, or want to set ourselves.
 # (this is to improve consistency running on one machine versus another)
-echo -e "Unsetting variables: JAVA_BINDIR JAVA_HOME JAVA_ROOT JDK_HOME JRE_HOME CLASSPATH ANT_HOME\\n"
-unset -v JAVA_BINDIR JAVA_HOME JAVA_ROOT JDK_HOME JRE_HOME CLASSPATH ANT_HOME
+echo "Unsetting variables: JAVA_BINDIR JAVA_ROOT JDK_HOME JRE_HOME CLASSPATH"
+unset -v JAVA_BINDIR JAVA_ROOT JDK_HOME JRE_HOME CLASSPATH
 
 # 0002 is often the default for shell users, but it is not when ran from
 # a cron job, so we set it explicitly, to be sure of value, so releng group has write access to anything
@@ -106,15 +67,9 @@ curl -o buildProperties.sh https://download.eclipse.org/eclipse/downloads/drops4
 cat getEBuilder.xml
 source buildProperties.sh
 
-export JAVA_HOME=/usr/local/openjdk-17/Contents/Home
-export ANT_HOME=/opt/homebrew/Cellar/ant/1.10.11/libexec
-export PATH=${JAVA_HOME}/bin:${ANT_HOME}/bin:${PATH}
-
 echo JAVA_HOME: $JAVA_HOME
 echo ANT_HOME: $ANT_HOME
 echo PATH: $PATH
-
-export eclipseArch=aarch64
 
 env  1>envVars.txt 2>&1
 ant -diagnostics  1>antDiagnostics.txt 2>&1
@@ -123,7 +78,7 @@ java -XshowSettings -version  1>javaSettings.txt 2>&1
 ant -f getEBuilder.xml -Djava.io.tmpdir=${WORKSPACE}/tmp -DbuildId=$buildId -DeclipseStream=$STREAM -DEBUILDER_HASH=${EBUILDER_HASH} \\
   -DdownloadURL=https://download.eclipse.org/eclipse/downloads/drops4/${buildId} \\
   -Dosgi.os=macosx -Dosgi.ws=cocoa -Dosgi.arch=${eclipseArch} \\
-  -DtestSuite=${testSuite}
+  -DtestSuite=all
 
 RAW_DATE_END="$(date +%s )"
 
@@ -132,29 +87,19 @@ echo -e "\\n\\tRAW Date End: ${RAW_DATE_END} \\n"
 TOTAL_TIME=$((${RAW_DATE_END} - ${RAW_DATE_START}))
 
 echo -e "\\n\\tTotal elapsed time: ${TOTAL_TIME} \\n"
-      ''')
-    }
-
-    publishers {
-      archiveJunit('**/eclipse-testing/results/xml/*.xml') {
-        retainLongStdout()
-        healthScaleFactor((1.0).doubleValue())
-      }
-      archiveArtifacts {
-        pattern('**/eclipse-testing/results/**, **/eclipse-testing/directorLogs/**, *.properties, *.txt')
-      }
-      extendedEmail {
-        recipientList("sravankumarl@in.ibm.com")
-      }
-      downstreamParameterized {
-        trigger('Releng/ep-collectResults') {
-          condition('UNSTABLE_OR_BETTER')
-          parameters {
-            predefinedProp('triggeringJob', '$JOB_BASE_NAME')
-            predefinedProp('buildURL', '$BUILD_URL')
-            predefinedProp('buildID', '$buildId')
+              \'\'\'
+              archiveArtifacts '**/eclipse-testing/results/**, **/eclipse-testing/directorLogs/**, *.properties, *.txt'
+              junit keepLongStdio: true, testResults: '**/eclipse-testing/results/xml/*.xml'
+              build job: 'Releng/ep-collectResults', wait: false, parameters: [
+                string(name: 'triggeringJob', value: "${JOB_BASE_NAME}"),
+                string(name: 'buildURL', value: "${BUILD_URL}"),
+                string(name: 'buildID', value: "${params.buildId}")
+              ]
           }
-        }
+      }
+  }
+}
+        ''')
       }
     }
   }

--- a/JenkinsJobs/AutomatedTests/I_unit_win32_java17.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_win32_java17.groovy
@@ -5,96 +5,38 @@ for (STREAM in STREAMS){
   def MAJOR = STREAM.split('\\.')[0]
   def MINOR = STREAM.split('\\.')[1]
 
-  job('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-win32-java17'){
+  pipelineJob('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-win32-java17'){
     description('Run Eclipse SDK Tests for the platform implied by this job\'s name')
-
-    logRotator {
-      numToKeep(5)
-    }
-
-    parameters {
-      stringParam('buildId', null, 'Build Id to test (such as I20120717-0800, N20120716-0800). ')
-    }
-
-    label('qa6xd-win11')
 
     authenticationToken('windows2012tests')
  
-    wrappers { //adds pre/post actions
-      timestamps()
-      timeout {
-        absolute(901)
-      }
-    }
-  
-    steps {
-      batchFile('''
-@echo off
-SETLOCAL ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
-echo start cleaning ...
-IF NOT DEFINED WORKSPACE (
-    echo ERROR: WORKSPACE variable was not defined.
-    exit /B 1
-    ) ELSE (
-      IF NOT EXIST "%WORKSPACE%" (
-        echo ERROR: WORKSPACE was defined, but it did not exist.
-        echo     It was defined as %WORKSPACE%
-        exit /B 1
-        ) ELSE (
-          echo WORSPACE defined as %WORKSPACE%
-          echo Will delete contents, for clean run.
-          rem Note that rmdir and rm do not return ERRORLEVEL.
-          rem Which is why we "do while" until count of files is zero.
-          rem (or, until max loops is reached).
-          set /a maxLoops=15
-          echo maxLoops: !maxLoops!
-          set /a sleepTime=60000
-          echo sleepTime: !sleepTime!
-          set /a currentLoop=0
+    definition {
+      cps {
+        sandbox()
+        script('''
+pipeline {
+  options {
+    timeout(time: 901, unit: 'MINUTES')
+    timestamps()
+    buildDiscarder(logRotator(numToKeepStr:'5'))
+  }
+  parameters {
+    string(name: 'buildId', defaultValue: null, description: 'Build Id to test (such as I20120717-0800, N20120716-0800).')
+  }
+  agent {
+    label 'qa6xd-win11'
+  }
 
-          set /a nFilesOrDirs=0
-          for /D %%f in ("%WORKSPACE%\\*") do set /a nFilesOrDirs+=1
-          for    %%f in ("%WORKSPACE%\\*") do set /a nFilesOrDirs+=1
-          echo currentLoop: !currentLoop!   nFilesOrDirs:  !nFilesOrDirs!
-
-          :LOOP
-          IF !nFilesOrDirs! GTR 0 (
-            rem this first for loop is for all subdirectories of workspace
-            FOR /D %%p IN ("%WORKSPACE%\\*") DO (
-              echo removing dir: %%p
-              rmdir "%%p" /s /q
-              )
-            rem this for loop is for for all files remaining, directly under workspace
-            FOR %%p IN ("%WORKSPACE%\\*") DO (
-              echo deleting file: %%p
-              del "%%p"  /q
-              )
-            set /a currentLoop+=1
-            IF !currentLoop! GTR !maxLoops! GOTO MAXLOOPS
-            set /a nFilesOrDirs=0
-            for /D %%f in ("%WORKSPACE%\\*") do set /a nFilesOrDirs+=1
-            for    %%f in ("%WORKSPACE%\\*") do set /a nFilesOrDirs+=1
-            echo currentLoop: !currentLoop!   nFilesOrDirs:  !nFilesOrDirs!
-            if !nFilesOrDirs! GTR 0 (
-              rem Pause a bit before retrying, since if we could not delete, likely due to some process still running.
-              rem 'timeout' causes "redirection not allowed" error. See bug 482598. 
-              rem C:\\Windows\\System32\\timeout.exe /t !sleepTime!
-              ping 127.0.0.1 -n1 -w !sleepTime! >NUL 
-              GOTO LOOP
-              )
-            )
-         )
-     )
-echo ... normal end of cleaning section (i.e. max loops NOT reached)
-exit 0
-
-
-:MAXLOOPS
-echo Reached max loops waiting for files to be free to delete
-rem note use of "hard exit" (no /B) as an attempt to get Hudson to fail.
-exit 0
-      ''')
-      batchFile('''
+  stages {
+      stage('Run tests'){
+          environment {
+              // Declaring a jdk and ant the usual way in the 'tools' section, because of unknown reasons, breaks the usage of system commands like xvnc, pkill and sh
+              JAVA_HOME = 'C:\\\\PROGRA~1\\\\ECLIPS~1\\\\jdk-17.0.5.8-hotspot\\\\'
+              PATH = "%JAVA_HOME%\\\\bin;C:\\\\ProgramData\\\\Boxstarter;C:\\\\Program Files\\\\IcedTeaWeb\\\\WebStart\\\\bin;C:\\\\Users\\\\jenkins_vnc\\\\AppData\\\\Local\\\\Microsoft\\\\WindowsApps;${env.PATH}"
+          }
+          steps {
+              cleanWs() // workspace not cleaned by default
+              bat \'\'\'
 rem May want to try and restrict path, as we do on cron jobs, so we
 rem have more consistent conditions.
 rem export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:~/bin
@@ -115,35 +57,27 @@ For /F "tokens=1* delims==" %%A IN (buildProperties.properties) DO (
 echo on
 set STREAM
 set EBUILDER_HASH
-set JAVA_HOME=C:\\PROGRA~1\\ECLIPS~1\\jdk-17.0.5.8-hotspot\\
 set JAVA_HOME
-set Path="C:\\PROGRA~1\\ECLIPS~1\\jdk-17.0.5.8-hotspot\\bin";C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\ProgramData\\chocolatey\\bin;C:\\tools\\cygwin\\bin;C:\\Program Files\\IcedTeaWeb\\WebStart\\bin;C:\\WINDOWS\\System32\\OpenSSH\\;C:\\Users\\jenkins_vnc\\AppData\\Local\\Microsoft\\WindowsApps;%PATH%
 
-ant -f getEBuilder.xml -Djava.io.tmpdir=%WORKSPACE%\\tmp -Djvm="C:\\PROGRA~1\\ECLIPS~1\\jdk-17.0.5.8-hotspot\\bin\\java.exe" -DbuildId=%buildId%  -DeclipseStream=%STREAM% -DEBUILDER_HASH=%EBUILDER_HASH%  -DdownloadURL="https://download.eclipse.org/eclipse/downloads/drops4/%buildId%" -Dargs=all -Dosgi.os=win32 -Dosgi.ws=win32 -Dosgi.arch=x86_64 -DtestSuite=all
+ant -f getEBuilder.xml -Djava.io.tmpdir=%WORKSPACE%/tmp -DbuildId=%buildId%  -DeclipseStream=%STREAM% -DEBUILDER_HASH=%EBUILDER_HASH% ^
+  -DdownloadURL="https://download.eclipse.org/eclipse/downloads/drops4/%buildId%" ^
+  -Dargs=all -Dosgi.os=win32 -Dosgi.ws=win32 -Dosgi.arch=x86_64 ^
+  -DtestSuite=all ^
+   -Djvm="%JAVA_HOME%\\\\bin\\\\java.exe"
 
-      ''')
-    }
-
-    publishers {
-      archiveJunit('**/eclipse-testing/results/xml/*.xml') {
-        retainLongStdout()
-        healthScaleFactor((1.0).doubleValue())
-      }
-      archiveArtifacts {
-        pattern('**/eclipse-testing/results/**, **/eclipse-testing/directorLogs/**, *.properties, *.txt')
-      }
-      extendedEmail {
-        recipientList("sravankumarl@in.ibm.com")
-      }
-      downstreamParameterized {
-        trigger('Releng/ep-collectResults') {
-          condition('ALWAYS')
-          parameters {
-            predefinedProp('triggeringJob', '$JOB_BASE_NAME')
-            predefinedProp('buildURL', '$BUILD_URL')
-            predefinedProp('buildID', '$buildId')
+              \'\'\'
+              archiveArtifacts '**/eclipse-testing/results/**, **/eclipse-testing/directorLogs/**, *.properties, *.txt'
+              junit keepLongStdio: true, testResults: '**/eclipse-testing/results/xml/*.xml'
+              build job: 'Releng/ep-collectResults', wait: false, parameters: [
+                string(name: 'triggeringJob', value: "${JOB_BASE_NAME}"),
+                string(name: 'buildURL', value: "${BUILD_URL}"),
+                string(name: 'buildID', value: "${params.buildId}")
+              ]
           }
-        }
+      }
+  }
+}
+        ''')
       }
     }
   }


### PR DESCRIPTION
This allows to unify the job definition with the test-jobs for Linux and also allows to simplify some parts of the job a lot.

It also removes the `testSuite` parameter only available in mac tests, since anybody that wants to run another suite than all can just `Replay` the build in the Jenkins web-interface and adjust the suite as desired.

Especially the Windows pipeline needs some more local testing, e.g. with regards to spanning a command over multiple lines, but nevertheless I still would like to gather some early feedback.