### PR TITLE
Build I20240506-1800 is unstable due to new launcher binaries

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/rcp.config/forceQualifierUpdate.txt
+++ b/eclipse.platform.releng.tychoeclipsebuilder/rcp.config/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-equinox/equinox/pull/401
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2011


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2011