### PR TITLE
Remove obsolete core.net.win32.x86_64 fragment from o.e.platform feature

### DIFF
--- a/eclipse.platform.releng/features/org.eclipse.platform-feature/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.platform-feature/feature.xml
@@ -80,12 +80,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.core.net.win32.x86_64"
-         os="win32"
-         arch="x86_64"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.core.resources"
          version="0.0.0"/>
 


### PR DESCRIPTION
The fragment 'org.eclipse.core.net.win32.x86_64', that is empty since it was replaced by the architecture independent variant 'org.eclipse.core.net.win32' some time ago is deleted in https://github.com/eclipse-platform/eclipse.platform/pull/1349