### PR TITLE
Update coactions to use Node 20

### DIFF
--- a/.github/workflows/codeQLworkflow.yml
+++ b/.github/workflows/codeQLworkflow.yml
@@ -76,7 +76,7 @@ jobs:
       with:
         maven-version: ${{ inputs.mavenVersion }}
     - name: Build with Maven
-      uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
+      uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
       with:
        run: >- 
         mvn --batch-mode -V -U

--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -76,7 +76,7 @@ jobs:
         target: .github/matcher
     - run: echo "::add-matcher::.github/matcher/${{ steps.api-tools-matcher.outputs.filename }}"
     - name: Build with Maven
-      uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
+      uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
       with:
        run: >- 
         mvn --batch-mode -V -U


### PR DESCRIPTION
GH Actions transitioned to Node 20 in September 2023 and all projects should transition too (see:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)

This gets rid of the warnings in the runs of GH Actions.