### PR TITLE
Set 'ECLIPSE_I_BUILD_TEST' env-variable in I-build test executions

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse-junit-tests/src/main/scripts/library.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse-junit-tests/src/main/scripts/library.xml
@@ -277,6 +277,9 @@
             <sysproperty
                 key="PLUGIN_PATH"
                 value="${plugin-path}" />
+            <env
+                key="ECLIPSE_I_BUILD_TEST"
+                value="true"/>
         </java>
         <antcall target="collect-results" />
     </target>


### PR DESCRIPTION
This allows tests to check if they run in an Eclipse I-build test.

Part of https://github.com/eclipse-platform/eclipse.platform/issues/1098