### PR TITLE
Add save participant test project to Ant-based build

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/testManifest.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/testManifest.xml
@@ -560,6 +560,9 @@
       name="org.eclipse.core.tests.resources"
       type="test" />
     <logFile
+      name="org.eclipse.core.tests.resources.saveparticipant"
+      type="test" />
+    <logFile
       name="org.eclipse.core.tests.runtime"
       type="test" />
     <logFile

--- a/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
@@ -54,6 +54,10 @@
    <plugin
          id="org.eclipse.core.tests.resources"
          version="0.0.0"/>
+         
+   <plugin
+         id="org.eclipse.core.tests.resources.saveparticipant"
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.core.tests.net"

--- a/production/testScripts/configuration/sdk.tests/testScripts/test.xml
+++ b/production/testScripts/configuration/sdk.tests/testScripts/test.xml
@@ -1897,6 +1897,12 @@
     depends="init">
     <runTests testPlugin="org.eclipse.core.tests.resources" />
   </target>
+	
+  <target
+    name="coreresourcessaveparticipant"
+    depends="init">
+    <runTests testPlugin="org.eclipse.core.tests.resources.saveparticipant" />
+  </target>
 
   <target
     name="coreruntime"
@@ -2624,6 +2630,7 @@
     <antcall target="swt" />
     <antcall target="corecontenttype" />
     <antcall target="coreexpressions" />
+    <antcall target="coreresourcessaveparticipant" />
     <antcall target="coretestsnet" />
     <antcall target="text" />
     <antcall target="jfacedatabinding" />


### PR DESCRIPTION
This adds the test bundle org.eclipse.core.tests.resource.saveparticipant to the Ant-based build.
* Adds the bundles to the SDK test feature
* Adds according targets to the main test.xml
* Adds the produced log files to the testManifest.xml

Belongs to https://github.com/eclipse-platform/eclipse.platform/pull/1384