### PR TITLE
Print stacktrace on failure of maven builds

### DIFF
--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -79,7 +79,7 @@ jobs:
       uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
       with:
        run: >- 
-        mvn --batch-mode -V -U
+        mvn --batch-mode -V -U -e
         -ntp
         -Dcompare-version-with-baselines.skip=false
         -Pbree-libs


### PR DESCRIPTION
Currently stack trace are suppressed on maven build problems, as those are often the only way to understand unexpected build failures this now enables them by default. The drawback is that the output is a bit harder to read, but as we already have parsers for compile and test logs that present this to the user in a more comfortable way it seems a good compromise.