### PR TITLE
Force qualifier to resign bundles signed with an expired certificate

### DIFF
--- a/eclipse.platform.releng/features/org.eclipse.test-feature/forceQualifierUpdate.txt
+++ b/eclipse.platform.releng/features/org.eclipse.test-feature/forceQualifierUpdate.txt
@@ -54,3 +54,4 @@ Update objenesis to 3.4
 Update bytebuddy to 1.14.15
 Update mockito to 5.12.0
 Update bytebuddy to 1.14.16
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044