### PR TITLE
Update assertj-core to 2.26.0

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -49,7 +49,7 @@
 
       <!-- This is the "normal" Orbit repository.
            This is the repo that is expected to be updated on milestones and releases based on Orbit deliveries. -->
-      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202405211109"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202405271007"/>
     </location>
 
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
@@ -342,7 +342,7 @@
 			  <dependency>
 				  <groupId>org.assertj</groupId>
 				  <artifactId>assertj-core</artifactId>
-				  <version>3.25.3</version>
+				  <version>3.26.0</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>

--- a/eclipse.platform.releng/features/org.eclipse.test-feature/forceQualifierUpdate.txt
+++ b/eclipse.platform.releng/features/org.eclipse.test-feature/forceQualifierUpdate.txt
@@ -55,3 +55,4 @@ Update bytebuddy to 1.14.15
 Update mockito to 5.12.0
 Update bytebuddy to 1.14.16
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044
+Update assertj-core to 3.26.0


### PR DESCRIPTION
Using latest orbit milestone repo; no new content.