### PR TITLE
Update the target platform to EMF 2.39 M0

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -47,26 +47,25 @@
       <unit id="org.eclipse.orbit.xml-apis-ext" version="1.0.0.v20230923-0644"/>
       <unit id="org.eclipse.orbit.xml-apis-ext.source" version="1.0.0.v20230923-0644"/>
 
-      <!-- This is the "normal" Orbit repository.
-           This is the repo that is expected to be updated on milestones and releases based on Orbit deliveries. -->
+      <!-- This is the "normal" Orbit repository is expected to be updated on milestones and releases based on Orbit deliveries. -->
       <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.32.0"/>
     </location>
 
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
        <!-- Check version in "<EMF>/features" directory -->
-      <unit id="org.eclipse.emf.common.feature.group" version="2.31.0.v20240314-0928"/>
-      <unit id="org.eclipse.emf.common.source.feature.group" version="2.31.0.v20240314-0928"/>
-      <unit id="org.eclipse.emf.ecore.feature.group" version="2.37.0.v20240203-0859"/>
-      <unit id="org.eclipse.emf.ecore.source.feature.group" version="2.37.0.v20240203-0859"/>
+      <unit id="org.eclipse.emf.common.feature.group" version="2.32.0.v20240604-0832"/>
+      <unit id="org.eclipse.emf.common.source.feature.group" version="2.32.0.v20240604-0832"/>
+      <unit id="org.eclipse.emf.ecore.feature.group" version="2.38.0.v20240604-0832"/>
+      <unit id="org.eclipse.emf.ecore.source.feature.group" version="2.38.0.v20240604-0832"/>
        <!-- For org.eclipse.ui.tools, and PDE's spy dependencies as of Eclipse 4.22 -->
        <!-- Check version in "<EMF>/features" directory -->
-      <unit id="org.eclipse.emf.edit.feature.group" version="2.22.0.v20231208-1346"/>
-      <unit id="org.eclipse.emf.edit.source.feature.group" version="2.22.0.v20231208-1346"/>
-      <unit id="org.eclipse.emf.databinding.feature.group" version="1.11.0.v20231208-1346"/>
-      <unit id="org.eclipse.emf.databinding.source.feature.group" version="1.11.0.v20231208-1346"/>
-      <unit id="org.eclipse.emf.databinding.edit.feature.group" version="1.11.0.v20231208-1346"/>
-      <unit id="org.eclipse.emf.databinding.edit.source.feature.group" version="1.11.0.v20231208-1346"/>
-      <repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.38.0"/>
+      <unit id="org.eclipse.emf.edit.feature.group" version="2.23.0.v20240604-0832"/>
+      <unit id="org.eclipse.emf.edit.source.feature.group" version="2.23.0.v20240604-0832"/>
+      <unit id="org.eclipse.emf.databinding.feature.group" version="1.12.0.v20240604-0832"/>
+      <unit id="org.eclipse.emf.databinding.source.feature.group" version="1.12.0.v20240604-0832"/>
+      <unit id="org.eclipse.emf.databinding.edit.feature.group" version="1.12.0.v20240604-0832"/>
+      <unit id="org.eclipse.emf.databinding.edit.source.feature.group" version="1.12.0.v20240604-0832"/>
+      <repository location="https://download.eclipse.org/modeling/emf/emf/builds/milestone/S202406110653"/>
     </location>
 
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
@@ -605,6 +604,12 @@
 			  </dependency>
 			  <dependency>
 				  <groupId>org.bndtools</groupId>
+				  <artifactId>bndtools.jareditor</artifactId>
+				  <version>7.0.0</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>org.bndtools</groupId>
 				  <artifactId>org.bndtools.headless.build.manager</artifactId>
 				  <version>7.0.0</version>
 				  <type>jar</type>
@@ -639,11 +644,6 @@
 				  <version>7.0.0</version>
 				  <type>jar</type>
 			  </dependency>
-			<dependency>
-			    <groupId>org.bndtools</groupId>
-			    <artifactId>bndtools.jareditor</artifactId>
-			    <version>7.0.0</version>
-			</dependency>
 		  </dependencies>
 	  </location>
 	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="Apache Felix" missingManifest="error" type="Maven">


### PR DESCRIPTION
- This version of EMF raises the BREE of all bundles to JavaSE 1.8.
- The other formatting changes are to reduce the number of changes resulting from the use of Update button in the PDE editor.