### PR TITLE
Remove org.eclipse.core.resources.win32.x86_64 fragment from feature

### DIFF
--- a/eclipse.platform.releng/features/org.eclipse.platform-feature/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.platform-feature/feature.xml
@@ -228,12 +228,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.core.resources.win32.x86_64"
-         os="win32"
-         arch="x86_64"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.core.filesystem.win32.x86_64"
          os="win32"
          arch="x86_64"

--- a/eclipse.platform.releng/features/org.eclipse.platform-feature/pom.xml
+++ b/eclipse.platform.releng/features/org.eclipse.platform-feature/pom.xml
@@ -42,7 +42,6 @@
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-source-plugin</artifactId>
-        <version>${tycho.version}</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -60,7 +59,6 @@
                 <plugin id="org.eclipse.core.filesystem.macosx"/>
                 <plugin id="org.eclipse.core.filesystem.win32.x86_64"/>
                 <plugin id="org.eclipse.core.filesystem.linux.ppc64le"/>
-                <plugin id="org.eclipse.core.resources.win32.x86_64"/>
               </excludes>
             </configuration>
           </execution>
@@ -69,7 +67,6 @@
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
-        <version>${tycho.version}</version>
         <executions>
           <execution>
             <id>attach-p2-metadata</id>


### PR DESCRIPTION
The o.e.core.resources.win32.x86_64 fragment is removed because the Windows native file-system refresh monitor is migrated to use JNA instead of native code (JNI).

See https://github.com/eclipse-platform/eclipse.platform/pull/1394