### PR TITLE
Rename rt.equinox.binaries sub-module to equinox.binaries

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,8 +26,8 @@
 [submodule "eclipse.platform.ui"]
   path = eclipse.platform.ui
   url = https://github.com/eclipse-platform/eclipse.platform.ui.git
-[submodule "rt.equinox.binaries"]
-  path = rt.equinox.binaries
+[submodule "equinox.binaries"]
+  path = equinox.binaries
   url = https://github.com/eclipse-equinox/equinox.binaries.git
 [submodule "equinox"]
   path = equinox

--- a/cje-production/streams/repositories_java23.txt
+++ b/cje-production/streams/repositories_java23.txt
@@ -1,4 +1,4 @@
-rt.equinox.binaries: master
+equinox.binaries: master
 equinox: master
 rt.equinox.p2: master
 eclipse.jdt: master

--- a/cje-production/streams/repositories_master.txt
+++ b/cje-production/streams/repositories_master.txt
@@ -1,4 +1,4 @@
-rt.equinox.binaries: master
+equinox.binaries: master
 equinox: master
 rt.equinox.p2: master
 eclipse.jdt.core.binaries: master

--- a/eclipse-platform-sources/sources.xml
+++ b/eclipse-platform-sources/sources.xml
@@ -28,10 +28,10 @@
         <exclude>eclipse.platform.swt/binaries/**/*.dll</exclude>
         <exclude>eclipse.platform.swt/binaries/**/*.jnilib</exclude>
         <exclude>eclipse.platform.swt/binaries/**/*.so</exclude>
-        <exclude>rt.equinox.binaries/org.eclipse.equinox.executable/bin/**</exclude>
-        <exclude>rt.equinox.binaries/org.eclipse.equinox.executable/contributed/**</exclude>
-        <exclude>rt.equinox.binaries/**/*.dll</exclude>
-        <exclude>rt.equinox.binaries/**/*.so</exclude>
+        <exclude>equinox.binaries/org.eclipse.equinox.executable/bin/**</exclude>
+        <exclude>equinox.binaries/org.eclipse.equinox.executable/contributed/**</exclude>
+        <exclude>equinox.binaries/**/*.dll</exclude>
+        <exclude>equinox.binaries/**/*.so</exclude>
         <exclude>equinox/**/*.dll</exclude>
         <exclude>equinox/**/*.jnilib</exclude>
         <exclude>equinox/**/*.so</exclude>

--- a/oomph/Platform.setup
+++ b/oomph/Platform.setup
@@ -706,7 +706,7 @@
           <excludedPath>eclipse.platform.swt.binaries</excludedPath>
           <excludedPath>eclipse.platform.ui</excludedPath>
           <excludedPath>equinox</excludedPath>
-          <excludedPath>rt.equinox.binaries</excludedPath>
+          <excludedPath>equinox.binaries</excludedPath>
           <excludedPath>rt.equinox.p2</excludedPath>
         </sourceLocator>
       </targlet>


### PR DESCRIPTION
Adapt to the name changed assumption about the default name in equinox.
See https://github.com/eclipse-equinox/equinox/pull/641