### PR TITLE
[I-Build-Tests] Declare parameters in job configuration

### DIFF
--- a/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3_java17.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3_java17.groovy
@@ -7,6 +7,9 @@ for (STREAM in STREAMS){
 
   pipelineJob('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-cen64-gtk3-java17'){
     description('Run Eclipse SDK Tests for the platform implied by this job\'s name')
+    parameters { // Define parameters in job configuration to make them available from the very first build onwards
+      stringParam('buildId', null, 'Build Id to test (such as I20240611-1800, N20120716-0800).')
+    }
 
     definition {
       cps {
@@ -17,9 +20,6 @@ pipeline {
     timeout(time: 600, unit: 'MINUTES')
     timestamps()
     buildDiscarder(logRotator(numToKeepStr:'5'))
-  }
-  parameters {
-    string(name: 'buildId', defaultValue: null, description: 'Build Id to test (such as I20120717-0800, N20120716-0800).')
   }
   agent {
     kubernetes {

--- a/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3_java21.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3_java21.groovy
@@ -7,6 +7,9 @@ for (STREAM in STREAMS){
 
   pipelineJob('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-cen64-gtk3-java21'){
     description('Run Eclipse SDK Tests for the platform implied by this job\'s name')
+    parameters { // Define parameters in job configuration to make them available from the very first build onwards
+      stringParam('buildId', null, 'Build Id to test (such as I20240611-1800, N20120716-0800).')
+    }
 
     definition {
       cps {
@@ -17,9 +20,6 @@ pipeline {
     timeout(time: 600, unit: 'MINUTES')
     timestamps()
     buildDiscarder(logRotator(numToKeepStr:'5'))
-  }
-  parameters {
-    string(name: 'buildId', defaultValue: null, description: 'Build Id to test (such as I20120717-0800, N20120716-0800).')
   }
   agent {
     kubernetes {

--- a/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3_java22.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3_java22.groovy
@@ -7,6 +7,9 @@ for (STREAM in STREAMS){
 
   pipelineJob('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-cen64-gtk3-java22'){
     description('Run Eclipse SDK Tests for the platform implied by this job\'s name')
+    parameters { // Define parameters in job configuration to make them available from the very first build onwards
+      stringParam('buildId', null, 'Build Id to test (such as I20240611-1800, N20120716-0800).')
+    }
 
     definition {
       cps {
@@ -17,9 +20,6 @@ pipeline {
     timeout(time: 600, unit: 'MINUTES')
     timestamps()
     buildDiscarder(logRotator(numToKeepStr:'5'))
-  }
-  parameters {
-    string(name: 'buildId', defaultValue: null, description: 'Build Id to test (such as I20120717-0800, N20120716-0800).')
   }
   agent {
     kubernetes {

--- a/JenkinsJobs/AutomatedTests/I_unit_mac64_java17.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_mac64_java17.groovy
@@ -7,6 +7,9 @@ for (STREAM in STREAMS){
 
   pipelineJob('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-mac64-java17'){
     description('Run Eclipse SDK Tests for the platform implied by this job\'s name')
+    parameters { // Define parameters in job configuration to make them available from the very first build onwards
+      stringParam('buildId', null, 'Build Id to test (such as I20240611-1800, N20120716-0800).')
+    }
 
     authenticationToken('windows2012tests')
  
@@ -19,9 +22,6 @@ pipeline {
     timeout(time: 600, unit: 'MINUTES')
     timestamps()
     buildDiscarder(logRotator(numToKeepStr:'5'))
-  }
-  parameters {
-    string(name: 'buildId', defaultValue: null, description: 'Build Id to test (such as I20120717-0800, N20120716-0800).')
   }
   agent {
     label 'nc1ht-macos11-arm64'

--- a/JenkinsJobs/AutomatedTests/I_unit_macM1_java17.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_macM1_java17.groovy
@@ -7,6 +7,9 @@ for (STREAM in STREAMS){
 
   pipelineJob('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-macM1-java17'){
     description('Run Eclipse SDK Tests for the platform implied by this job\'s name')
+    parameters { // Define parameters in job configuration to make them available from the very first build onwards
+      stringParam('buildId', null, 'Build Id to test (such as I20240611-1800, N20120716-0800).')
+    }
 
     authenticationToken('windows2012tests')
  
@@ -19,9 +22,6 @@ pipeline {
     timeout(time: 600, unit: 'MINUTES')
     timestamps()
     buildDiscarder(logRotator(numToKeepStr:'5'))
-  }
-  parameters {
-    string(name: 'buildId', defaultValue: null, description: 'Build Id to test (such as I20120717-0800, N20120716-0800).')
   }
   agent {
     label 'nc1ht-macos11-arm64'

--- a/JenkinsJobs/AutomatedTests/I_unit_win32_java17.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_win32_java17.groovy
@@ -7,6 +7,9 @@ for (STREAM in STREAMS){
 
   pipelineJob('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-win32-java17'){
     description('Run Eclipse SDK Tests for the platform implied by this job\'s name')
+    parameters { // Define parameters in job configuration to make them available from the very first build onwards
+      stringParam('buildId', null, 'Build Id to test (such as I20240611-1800, N20120716-0800).')
+    }
 
     authenticationToken('windows2012tests')
  
@@ -19,9 +22,6 @@ pipeline {
     timeout(time: 901, unit: 'MINUTES')
     timestamps()
     buildDiscarder(logRotator(numToKeepStr:'5'))
-  }
-  parameters {
-    string(name: 'buildId', defaultValue: null, description: 'Build Id to test (such as I20120717-0800, N20120716-0800).')
   }
   agent {
     label 'qa6xd-win11'


### PR DESCRIPTION
Declaring the parameters only within the pipeline definition has the disadvantage that they have to be discovered in the first run and are therefore only available in the second run onwards. This leads to total failures of all I-build tests on the first run each time the seed job to create the Eclipse RelEng jobs ran.

Permanently fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2101