### PR TITLE
Registering URL Schemes for Signed macOS Apps Is Not Possible

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-linkhandlersprefs.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/reference/ref-linkhandlersprefs.htm
@@ -70,6 +70,11 @@
     <li>For the "macOS" and "Linux" operating system: If an URL scheme is handled by another application (Eclipse-based
     or not), it <strong>cannot</strong> be enabled directly. Handling of this URL scheme must first be disabled in the
     other application, before it can be enabled in the current application.</li>
+    <li>For the "macOS" operating system: If the current application is a signed application it's not possible to 
+    register / unregister URL schemes. Registering / unregistering would modify the application's info.plist file.
+    This would break the applications signature and lead to the situation that "macOS Gatekeeper" would no longer allow 
+    running the application. URL schemes must be added to the info.plist file already at build-time of the application
+    becore it's signed. For unsigned applications this restriction does not apply.</li>
     <li>When multiple Eclipse-based applications are running at the same time, the operating system may set a window to
     the foreground, which cannot handle the link. In such cases, ensure that only the expected Eclipse-based
     application is running.</li>


### PR DESCRIPTION
Contributes to https://github.com/eclipse-platform/eclipse.platform.ui/issues/1901