### PR TITLE
[Build] Build don't resign signed jars and skip signing in master build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,14 +13,6 @@ pipeline {
 		jdk 'temurin-jdk21-latest'
 	}
 	stages {
-		stage('initialize PGP') {
-			steps {
-				withCredentials([file(credentialsId: 'secret-subkeys.asc', variable: 'KEYRING')]) {
-					sh 'gpg --batch --import "${KEYRING}"'
-					sh 'for fpr in $(gpg --list-keys --with-colons  | awk -F: \'/fpr:/ {print $10}\' | sort -u); do echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key ${fpr} trust; done'
-				}
-			}
-		}
 		stage('Use master') {
 			steps {
 				sh 'git submodule foreach "git fetch origin master; git checkout FETCH_HEAD"'
@@ -42,28 +34,17 @@ pipeline {
 		stage('Build') {
 		    when { not { branch pattern: "prepare_R.*", comparator: "REGEXP" } }
 			steps {
-				withCredentials([string(credentialsId: 'gpg-passphrase', variable: 'KEYRING_PASSPHRASE')]) {
-					sh '''
-					if [[ ${BRANCH_NAME} == master ]] || [[ ${BRANCH_NAME} =~ ^R[0-9]_[0-9]+_maintenance ]]; then
-						MVN_ARGS="-Peclipse-sign"
-					else
-						MVN_ARGS=
-						export KEYRING="deadbeef"
-						export KEYRING_PASSPHRASE="none"
-					fi
+				sh '''
 					mvn clean install -pl :eclipse-sdk-prereqs,:org.eclipse.jdt.core.compiler.batch -DlocalEcjVersion=99.99 -Dmaven.repo.local=$WORKSPACE/.m2/repository -U
 					mvn clean verify -e -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 						-Pbree-libs \
-						${MVN_ARGS} \
 						-DskipTests=true \
 						-Dcompare-version-with-baselines.skip=false \
 						-DapiBaselineTargetDirectory=${WORKSPACE} \
 						-Dgpg.passphrase="${KEYRING_PASSPHRASE}" \
 						-Dcbi-ecj-version=99.99 \
 						-U
-					'''
-				}
-
+				'''
 			}
 			post {
 				always {


### PR DESCRIPTION
Reduce the number of actual signing by not signing artifacts on master branch builds in this repository (the built artifacts are not published) and not re-signing artifacts in the I-build that are baseline replaced and therefore already signed.

Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2134

In order for `DO_NOT_RESIGN` to have an effect, signing should happen after a baseline-repacement done in `tycho-p2:p2-metadata`. Currently it is done before. Therefore this is a draft.

