### PR TITLE
[Build] Don't resign already signed jars

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -837,6 +837,7 @@
               </execution>
             </executions>
             <configuration>
+              <resigningStrategy>DO_NOT_RESIGN</resigningStrategy>
               <excludeInnerJars>${defaultSigning-excludeInnerJars}</excludeInnerJars>
               <!--
                The default timeout is 0 seconds which means "wait forever": https://www.eclipse.org/cbi/sitedocs/eclipse-jarsigner-plugin/sign-mojo.html#timeoutMillis


### PR DESCRIPTION
Reduce the number of actual signing operations by not re-signing artifacts (in the I-build) are already signed, usually because they have been 'baseline-replaced'.

In order to ensure that signatures of baseline-replaced artifacts can be considered, the p2-baseline-replacement is moved before the `eclipse-jarsigner-plugin`.

Furthermore set 'defaultP2Metadata' to false to skip the default baseline replace.

Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2134

This is a follow-up on https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2140.
