### PR TITLE
[Build] Build on larger centos-latest-8gb agents and increase max heap

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,2 +1,2 @@
 -XX:+PrintFlagsFinal
--XX:MaxRAMPercentage=35
+-Xmx2G

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
 		timestamps()
 	}
 	agent {
-		label "centos-latest"
+		label "centos-latest-8gb"
 	}
 	tools {
 		maven 'apache-maven-latest'


### PR DESCRIPTION
Currently Jenkins builds for branches of this repository regularly fail because they run out of java heap space.
This increases the max heap space limit from effectively 1.4GB (35% of 4GB RAM) to 2GiB and changes the Jenkins pipeline to run on `centos-latest` agents with the doubled amount of 8GB RAM. Otherwise the jobs get killed because insufficient memory for all running processes.
@sravanlakkimsetti and @laeubi since you discussed these values in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1798, you might be interested. In general I have the impression that the memory demand to build the Eclipse SDK recently grew.