### PR TITLE
Restore creation of javaversionEscaped property in runTests2 ANT script

### DIFF
--- a/production/testScripts/runTests2.xml
+++ b/production/testScripts/runTests2.xml
@@ -1023,6 +1023,7 @@
     </exec>
     <echo message="full output from 'java -version' of ${jvm} is " />
     <echo message="${javaversion}" />
+    <escapeProperty property="javaversion" />
   </target>
   <target
     name="setJVMfromUserSpecified"
@@ -1042,6 +1043,7 @@
     </exec>
     <echo message="full output from 'java -version' of ${jvm} is " />
     <echo message="${javaversion}" />
+    <escapeProperty property="javaversion" />
   </target>
   <!-- function to centralize how we get (that is, set) the value of 'javaMajorVersion'.
     (expected to be integer, such as 5,6,7,8,9, or will be "0" if the version


### PR DESCRIPTION
This was removed in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2150 although the property `javaversionEscaped` is still in use.