### PR TITLE
Remove o.e.core.net fragments being merged from platform-feature

### DIFF
--- a/eclipse.platform.releng/features/org.eclipse.platform-feature/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.platform-feature/feature.xml
@@ -70,16 +70,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.core.net.linux"
-         os="linux"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.core.net.win32"
-         os="win32"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.core.resources"
          version="0.0.0"/>
 


### PR DESCRIPTION
The platform specific fragments 'org.eclipse.core.net.linux' and 'org.eclipse.core.net.win32' are merged into their host bundle 'org.eclipse.core.net' via https://github.com/eclipse-platform/eclipse.platform/pull/1440.