### PR TITLE
Revert "[I/Y/P-Builds] Restore mount of toolchains.xml in K8 pod definitions"

### DIFF
--- a/JenkinsJobs/Builds/I_build.groovy
+++ b/JenkinsJobs/Builds/I_build.groovy
@@ -69,18 +69,6 @@ spec:
       requests:
         memory: "6144Mi"
         cpu: "2000m"
-    volumeMounts:
-    - mountPath: "/home/jenkins/.m2/toolchains.xml"
-      name: "toolchains-xml"
-      readOnly: true
-      subPath: "toolchains.xml"
-  volumes:
-  - configMap:
-      items:
-      - key: "toolchains.xml"
-        path: "toolchains.xml"
-      name: "m2-dir"
-    name: "toolchains-xml"
 """
     }
   }

--- a/JenkinsJobs/YBuilds/P_build.groovy
+++ b/JenkinsJobs/YBuilds/P_build.groovy
@@ -46,18 +46,6 @@ spec:
       requests:
         memory: "6144Mi"
         cpu: "2000m"
-    volumeMounts:
-    - mountPath: "/home/jenkins/.m2/toolchains.xml"
-      name: "toolchains-xml"
-      readOnly: true
-      subPath: "toolchains.xml"
-  volumes:
-  - configMap:
-      items:
-      - key: "toolchains.xml"
-        path: "toolchains.xml"
-      name: "m2-dir"
-    name: "toolchains-xml"
 """
     }
   }

--- a/JenkinsJobs/YBuilds/Y_build.groovy
+++ b/JenkinsJobs/YBuilds/Y_build.groovy
@@ -66,18 +66,6 @@ spec:
       requests:
         memory: "6144Mi"
         cpu: "2000m"
-    volumeMounts:
-    - mountPath: "/home/jenkins/.m2/toolchains.xml"
-      name: "toolchains-xml"
-      readOnly: true
-      subPath: "toolchains.xml"
-  volumes:
-  - configMap:
-      items:
-      - key: "toolchains.xml"
-        path: "toolchains.xml"
-      name: "m2-dir"
-    name: "toolchains-xml"
 """
     }
   }


### PR DESCRIPTION
This reverts PR https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2157.

The yaml merge strategy for pod templates was changed to 'merge' for all volumes/volumeMounts in:
https://github.com/eclipse-cbi/jiro/pull/377

Now they are all inherited from the pod-template.