### PR TITLE
Add help context for the find/replace overlay

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/contexts_Workbench.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/contexts_Workbench.xml
@@ -8,370 +8,386 @@
     </context>
     <context id="dock_on_perspective_action_context">
         <description>This docks the perspective bar in different locations.</description>
-        <topic label="Perspectives" href="concepts/concepts-4.htm"/>
-        <topic label="Perspective Bar" href="reference/ref-3.htm"/>
+        <topic label="Perspectives" href="concepts/concepts-4.htm" />
+        <topic label="Perspective Bar" href="reference/ref-3.htm" />
     </context>
     <context id="toggle_coolbar_action">
         <description>This toggles the visibility of the window toolbar and perspective bar.</description>
-        <topic label="Perspective Bar" href="reference/ref-3.htm"/>
-        <topic label="Window Menu - Customize Perspective" href="reference/ref-60.htm"/>
+        <topic label="Perspective Bar" href="reference/ref-3.htm" />
+        <topic label="Window Menu - Customize Perspective" href="reference/ref-60.htm" />
     </context>
     <context id="show_text_perspective_action_context">
         <description>This toggles whether text is shown for items on the perspective bar.</description>
-        <topic label="Perspectives" href="concepts/concepts-4.htm"/>
-        <topic label="Perspective Bar" href="reference/ref-3.htm"/>
+        <topic label="Perspectives" href="concepts/concepts-4.htm" />
+        <topic label="Perspective Bar" href="reference/ref-3.htm" />
     </context>
 
     <context id="add_bookmark_action_context">
-        <description><b>Bookmarks</b> place an &quot;anchor&quot; at a specific line in a workbench resource.</description>
-        <topic label="Adding a Bookmark" href="tasks/tasks-81.htm"/>
-        <topic label="Bookmarks" href="concepts/cbookmrk.htm"/>
+        <description><b>Bookmarks</b> place an &quot;anchor&quot; at a specific line in a workbench
+            resource.</description>
+        <topic label="Adding a Bookmark" href="tasks/tasks-81.htm" />
+        <topic label="Bookmarks" href="concepts/cbookmrk.htm" />
     </context>
     <context id="add_task_action_context">
-        <description><b>Tasks</b> place an &quot;anchor&quot; at a specific line in a workbench resource.</description>
-        <topic label="Adding a Task" href="tasks/tasks-77b.htm"/>
-        <topic label="Tasks View" href="concepts/ctskview.htm"/>
+        <description><b>Tasks</b> place an &quot;anchor&quot; at a specific line in a workbench
+            resource.</description>
+        <topic label="Adding a Task" href="tasks/tasks-77b.htm" />
+        <topic label="Tasks View" href="concepts/ctskview.htm" />
     </context>
     <context id="incremental_build_action_context">
-        <description>An <b>incremental build</b> compiles only the resources in the selected project that have been modified since the last build.</description>
-        <topic label="Project Explorer View - Rebuild All" href="reference/ref-27.htm"/>
-        <topic label="Builds" href="concepts/concepts-22.htm"/>
-        <topic label="Building Resources" href="tasks/tasks-73.htm"/>
+        <description>An <b>incremental build</b> compiles only the resources in the selected project
+            that have been modified since the last build.</description>
+        <topic label="Project Explorer View - Rebuild All" href="reference/ref-27.htm" />
+        <topic label="Builds" href="concepts/concepts-22.htm" />
+        <topic label="Building Resources" href="tasks/tasks-73.htm" />
     </context>
     <context id="full_build_action_context">
-        <description>A <b>full build</b> compiles the resources in the selected project from scratch. This kind of build is only performed when a manual build is done.</description>
-        <topic label="Project Explorer View - Rebuild All" href="reference/ref-27.htm"/>
-        <topic label="Builds" href="concepts/concepts-22.htm"/>
-        <topic label="Building Resources" href="tasks/tasks-73.htm"/>
+        <description>A <b>full build</b> compiles the resources in the selected project from
+            scratch. This kind of build is only performed when a manual build is done.</description>
+        <topic label="Project Explorer View - Rebuild All" href="reference/ref-27.htm" />
+        <topic label="Builds" href="concepts/concepts-22.htm" />
+        <topic label="Building Resources" href="tasks/tasks-73.htm" />
     </context>
     <context id="global_incremental_build_action_context">
-        <description>An incremental build compiles only the resources that have been modified since the last build.</description>
-        <topic label="Builds" href="concepts/concepts-22.htm"/>
-        <topic label="Building Resources" href="tasks/tasks-73.htm"/>
+        <description>An incremental build compiles only the resources that have been modified since
+            the last build.</description>
+        <topic label="Builds" href="concepts/concepts-22.htm" />
+        <topic label="Building Resources" href="tasks/tasks-73.htm" />
     </context>
     <context id="global_full_build_action_context">
-        <description>A <b>full build</b> compiles the entire workbench from scratch. This kind of build is only performed when a manual build is done.</description>
-        <topic label="Builds" href="concepts/concepts-22.htm"/>
-        <topic label="Building Resources" href="tasks/tasks-73.htm"/>
+        <description>A <b>full build</b> compiles the entire workbench from scratch. This kind of
+            build is only performed when a manual build is done.</description>
+        <topic label="Builds" href="concepts/concepts-22.htm" />
+        <topic label="Building Resources" href="tasks/tasks-73.htm" />
     </context>
     <context id="close_resource_action_context">
         <description>This closes the selected resource.</description>
-        <topic label="Closing Resources" href="tasks/tasks-47.htm"/>
-        <topic label="Project Explorer View - Close" href="reference/ref-27.htm"/>
+        <topic label="Closing Resources" href="tasks/tasks-47.htm" />
+        <topic label="Project Explorer View - Close" href="reference/ref-27.htm" />
     </context>
     <context id="open_resource_action_context">
         <description>This opens the selected resource.</description>
-        <topic label="Opening Resources" href="tasks/tasks-46.htm"/>
-        <topic label="Project Explorer View - Open" href="reference/ref-27.htm"/>
+        <topic label="Opening Resources" href="tasks/tasks-46.htm" />
+        <topic label="Project Explorer View - Open" href="reference/ref-27.htm" />
     </context>
     <context id="open_file_action_context">
-        <description>This causes the selected resource to open in the editor area or in the specified external editor.</description>
-        <topic label="Project Explorer View - Open With..." href="reference/ref-27.htm"/>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
+        <description>This causes the selected resource to open in the editor area or in the
+            specified external editor.</description>
+        <topic label="Project Explorer View - Open With..." href="reference/ref-27.htm" />
+        <topic label="Editors" href="concepts/concepts-6.htm" />
     </context>
     <context id="open_local_file_action_context">
-        <description>This opens a file system dialog that allows to open the selected files in the corresponding editor.</description>
+        <description>This opens a file system dialog that allows to open the selected files in the
+            corresponding editor.</description>
     </context>
     <context id="open_system_editor_action_context">
-        <description>This causes the selected resource to open in the default system editor for this file type.</description>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
-        <topic label="Editing a File Externally" href="tasks/tasks-52.htm"/>
+        <description>This causes the selected resource to open in the default system editor for this
+            file type.</description>
+        <topic label="Editors" href="concepts/concepts-6.htm" />
+        <topic label="Editing a File Externally" href="tasks/tasks-52.htm" />
     </context>
     <context id="refresh_action_context">
         <description>This refreshes the contents and display of the view.</description>
-        <topic label="Project Explorer View - Refresh" href="reference/ref-27.htm"/>
+        <topic label="Project Explorer View - Refresh" href="reference/ref-27.htm" />
     </context>
     <context id="move_resource_action_context">
         <description>This command allows you to move a resource from one location to another.</description>
-        <topic label="Moving Resources" href="tasks/tasks-63.htm"/>
-        <topic label="Project Explorer View - Move" href="reference/ref-27.htm"/>
+        <topic label="Moving Resources" href="tasks/tasks-63.htm" />
+        <topic label="Project Explorer View - Move" href="reference/ref-27.htm" />
     </context>
     <context id="copy_resource_action_context">
         <description>This command allows you to copy a resource from one location to another.</description>
-        <topic label="Project Explorer View - Copy" href="reference/ref-27.htm"/>
+        <topic label="Project Explorer View - Copy" href="reference/ref-27.htm" />
     </context>
     <context id="move_project_action_context">
         <description>This command allows you to move a project from one location to another.</description>
-        <topic label="Moving Resources" href="tasks/tasks-63.htm"/>
-        <topic label="Project Explorer View - Move" href="reference/ref-27.htm"/>
+        <topic label="Moving Resources" href="tasks/tasks-63.htm" />
+        <topic label="Project Explorer View - Move" href="reference/ref-27.htm" />
     </context>
     <context id="copy_project_action_context">
         <description>This command allows you to copy a project from one location to another.</description>
-        <topic label="Project Explorer View - Copy" href="reference/ref-27.htm"/>
+        <topic label="Project Explorer View - Copy" href="reference/ref-27.htm" />
     </context>
     <context id="rename_resource_action_context">
         <description>This command allows you to supply a new name for the selected resource.</description>
-        <topic label="Renaming Resources" href="tasks/tasks-66.htm"/>
-        <topic label="Project Explorer View - Rename" href="reference/ref-27.htm"/>
+        <topic label="Renaming Resources" href="tasks/tasks-66.htm" />
+        <topic label="Project Explorer View - Rename" href="reference/ref-27.htm" />
     </context>
     <context id="delete_resource_action_context">
         <description>This command allows you to delete the selected resource.</description>
-        <topic label="Deleting Resources" href="tasks/tasks-67.htm"/>
-        <topic label="Project Explorer View - Delete" href="reference/ref-27.htm"/>
+        <topic label="Deleting Resources" href="tasks/tasks-67.htm" />
+        <topic label="Project Explorer View - Delete" href="reference/ref-27.htm" />
     </context>
     <context id="delete_retarget_action_context">
         <description>This command deletes the selected resource or element.</description>
-        <topic label="Deleting Resources" href="tasks/tasks-67.htm"/>
-        <topic label="Project Explorer View - Delete" href="reference/ref-27.htm"/>
+        <topic label="Deleting Resources" href="tasks/tasks-67.htm" />
+        <topic label="Project Explorer View - Delete" href="reference/ref-27.htm" />
     </context>
     <context id="property_dialog_action_context">
         <description>This command displays the various properties of the selected resource.</description>
-        <topic label="Viewing Resource Properties" href="tasks/tasks-49.htm"/>
-        <topic label="Project Explorer View - Properties" href="reference/ref-27.htm"/>
+        <topic label="Viewing Resource Properties" href="tasks/tasks-49.htm" />
+        <topic label="Project Explorer View - Properties" href="reference/ref-27.htm" />
     </context>
     <context id="project_property_dialog_action_context">
-        <description>This command displays the various properties of the project for the selected resource.</description>
-        <topic label="Project Menu - Properties" href="reference/ref-59.htm"/>
-        <topic label="Viewing Resource Properties" href="tasks/tasks-49.htm"/>
+        <description>This command displays the various properties of the project for the selected
+            resource.</description>
+        <topic label="Project Menu - Properties" href="reference/ref-59.htm" />
+        <topic label="Viewing Resource Properties" href="tasks/tasks-49.htm" />
     </context>
     <context id="create_folder_action_context">
         <description>This command allows you to create a new folder container.</description>
-        <topic label="Resources" href="concepts/concepts-12.htm"/>
-        <topic label="Creating Resources - Folders" href="tasks/tasks-43.htm"/>
-        <topic label="New Folder Wizard" href="reference/ref-38.htm"/>
+        <topic label="Resources" href="concepts/concepts-12.htm" />
+        <topic label="Creating Resources - Folders" href="tasks/tasks-43.htm" />
+        <topic label="New Folder Wizard" href="reference/ref-38.htm" />
     </context>
     <context id="create_file_action_context">
         <description>This command allows you to create a new file.</description>
-        <topic label="Resources" href="concepts/concepts-12.htm"/>
-        <topic label="Creating Resources - Files" href="tasks/tasks-44.htm"/>
-        <topic label="New File Wizard" href="reference/ref-39.htm"/>
+        <topic label="Resources" href="concepts/concepts-12.htm" />
+        <topic label="Creating Resources - Files" href="tasks/tasks-44.htm" />
+        <topic label="New File Wizard" href="reference/ref-39.htm" />
     </context>
     <context id="new_action_context">
         <description>This command allows you to create a new item such as a resource.</description>
-        <topic label="Resources" href="concepts/concepts-12.htm"/>
-        <topic label="Workbench New Wizards" href="reference/ref-37.htm"/>
+        <topic label="Resources" href="concepts/concepts-12.htm" />
+        <topic label="Workbench New Wizards" href="reference/ref-37.htm" />
     </context>
     <context id="import_action_context">
         <description>This command allows you to import resources.</description>
-        <topic label="Importing" href="tasks/tasks-53.xhtml"/>
-        <topic label="Importing from a Directory" href="tasks/tasks-55.htm"/>
-        <topic label="Importing from a Zip File" href="tasks/tasks-55bg.htm"/>
-        <topic label="File Menu - Import" href="reference/ref-56.htm"/>
+        <topic label="Importing" href="tasks/tasks-53.xhtml" />
+        <topic label="Importing from a Directory" href="tasks/tasks-55.htm" />
+        <topic label="Importing from a Zip File" href="tasks/tasks-55bg.htm" />
+        <topic label="File Menu - Import" href="reference/ref-56.htm" />
     </context>
     <context id="export_action_context">
         <description>This command allows you to export resources.</description>
-        <topic label="Exporting" href="tasks/tasks-57.xhtml"/>
-        <topic label="Exporting to the File System" href="tasks/tasks-59.htm"/>
-        <topic label="Exporting to a Zip File" href="tasks/tasks-59ag.htm"/>
-        <topic label="File Menu - Export" href="reference/ref-56.htm"/>
+        <topic label="Exporting" href="tasks/tasks-57.xhtml" />
+        <topic label="Exporting to the File System" href="tasks/tasks-59.htm" />
+        <topic label="Exporting to a Zip File" href="tasks/tasks-59ag.htm" />
+        <topic label="File Menu - Export" href="reference/ref-56.htm" />
     </context>
     <context id="scrub_local_action_context">
         <description>The workbench is preparing for a build.</description>
-        <topic label="Builds" href="concepts/concepts-22.htm"/>
+        <topic label="Builds" href="concepts/concepts-22.htm" />
     </context>
     <context id="save_perspective_action_context">
-        <description>This menu option allows you to save the current perspective as a defined perspective.</description>
-        <topic label="Perspectives" href="concepts/concepts-4.htm"/>
-        <topic label="Saving Perspectives" href="tasks/tasks-9i.htm"/>
-        <topic label="Window Menu - Save Perspective As" href="reference/ref-60.htm"/>
+        <description>This menu option allows you to save the current perspective as a defined
+            perspective.</description>
+        <topic label="Perspectives" href="concepts/concepts-4.htm" />
+        <topic label="Saving Perspectives" href="tasks/tasks-9i.htm" />
+        <topic label="Window Menu - Save Perspective As" href="reference/ref-60.htm" />
     </context>
     <context id="save_as_action_context">
-        <description>This command allows you to save the resource being edited to another workbench location.</description>
-        <topic label="File Menu - Save As" href="reference/ref-56.htm"/>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
+        <description>This command allows you to save the resource being edited to another workbench
+            location.</description>
+        <topic label="File Menu - Save As" href="reference/ref-56.htm" />
+        <topic label="Editors" href="concepts/concepts-6.htm" />
     </context>
     <context id="save_all_action_context">
         <description>This command allows you to save all open resources in the editor area at once.</description>
-        <topic label="File Menu - Save All" href="reference/ref-56.htm"/>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
+        <topic label="File Menu - Save All" href="reference/ref-56.htm" />
+        <topic label="Editors" href="concepts/concepts-6.htm" />
     </context>
     <context id="save_action_context">
         <description>This command saves the resource that is currently active in the editor area.</description>
-        <topic label="File Menu - Save" href="reference/ref-56.htm"/>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
+        <topic label="File Menu - Save" href="reference/ref-56.htm" />
+        <topic label="Editors" href="concepts/concepts-6.htm" />
     </context>
     <context id="about_action_context">
         <description>This command displays product information.</description>
-      	<topic label="About your installation" href="tasks/tasks-134.htm" />
-        <topic label="Help Menu - About" href="reference/ref-61.htm"/>
-      	<topic label="Installation Details" href="tasks/tasks-130.htm" />
+        <topic label="About your installation" href="tasks/tasks-134.htm" />
+        <topic label="Help Menu - About" href="reference/ref-61.htm" />
+        <topic label="Installation Details" href="tasks/tasks-130.htm" />
     </context>
     <context id="close_all_action_context">
         <description>This command closes all editors that are currently open in the editor area.</description>
-        <topic label="File Menu - Close All" href="reference/ref-56.htm"/>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
+        <topic label="File Menu - Close All" href="reference/ref-56.htm" />
+        <topic label="Editors" href="concepts/concepts-6.htm" />
     </context>
     <context id="close_page_action_context">
         <description>This command closes the active perspective.</description>
-        <topic label="Perspectives - Concept" href="concepts/concepts-4.htm"/>
-        <topic label="Window Menu - Close Perspective" href="reference/ref-60.htm"/>
-        <topic label="Perspectives - Reference" href="reference/ref-6.htm"/>
+        <topic label="Perspectives - Concept" href="concepts/concepts-4.htm" />
+        <topic label="Window Menu - Close Perspective" href="reference/ref-60.htm" />
+        <topic label="Perspectives - Reference" href="reference/ref-6.htm" />
     </context>
     <context id="close_part_action_context">
         <description>This command closes the currently-active editor.</description>
-        <topic label="File Menu - Close" href="reference/ref-56.htm"/>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
+        <topic label="File Menu - Close" href="reference/ref-56.htm" />
+        <topic label="Editors" href="concepts/concepts-6.htm" />
     </context>
     <context id="hide_menu_or_toolbar_items">
         <description>This command allows you to show or hide menu items and toolbar buttons.</description>
-        <topic label="Configuring Perspectives" href="tasks/tasks-9n.htm"/>
-        <topic label="Window Menu - Customize Perspective" href="reference/ref-60.htm"/>
+        <topic label="Configuring Perspectives" href="tasks/tasks-9n.htm" />
+        <topic label="Window Menu - Customize Perspective" href="reference/ref-60.htm" />
     </context>
     <context id="edit_action_sets_action_context">
-        <description>This command allows you to customize the command groups available in the workbench menu bar and toolbar.</description>
-        <topic label="Configuring Perspectives" href="tasks/tasks-9m.htm"/>
-        <topic label="Window Menu - Customize Perspective" href="reference/ref-60.htm"/>
+        <description>This command allows you to customize the command groups available in the
+            workbench menu bar and toolbar.</description>
+        <topic label="Configuring Perspectives" href="tasks/tasks-9m.htm" />
+        <topic label="Window Menu - Customize Perspective" href="reference/ref-60.htm" />
     </context>
     <context id="customize_shortcuts">
-        <description>This command allows you to customize the shortcuts available in the New, Show Window and Show View menus.</description>
-        <topic label="Configuring Perspectives" href="tasks/tasks-9k.htm"/>
-        <topic label="Window Menu - Customize Perspective" href="reference/ref-60.htm"/>
+        <description>This command allows you to customize the shortcuts available in the New, Show
+            Window and Show View menus.</description>
+        <topic label="Configuring Perspectives" href="tasks/tasks-9k.htm" />
+        <topic label="Window Menu - Customize Perspective" href="reference/ref-60.htm" />
     </context>
     <context id="edit_perspectives_action_context">
-        <description>This command allows you to delete or reset defined perspectives or to define the default perspective.</description>
-        <topic label="Perspectives - Concept" href="concepts/concepts-4.htm"/>
-        <topic label="Changing Where Perspectives Open" href="tasks/tasks-24.htm"/>
-        <topic label="Perspectives - Reference" href="reference/ref-6.htm"/>
+        <description>This command allows you to delete or reset defined perspectives or to define
+            the default perspective.</description>
+        <topic label="Perspectives - Concept" href="concepts/concepts-4.htm" />
+        <topic label="Changing Where Perspectives Open" href="tasks/tasks-24.htm" />
+        <topic label="Perspectives - Reference" href="reference/ref-6.htm" />
     </context>
     <context id="close_all_pages_action_context">
         <description>This closes all the perspectives that are currently open.</description>
-        <topic label="Perspectives - Concept" href="concepts/concepts-4.htm"/>
-        <topic label="Window Menu - Close All Perspectives" href="reference/ref-60.htm"/>
+        <topic label="Perspectives - Concept" href="concepts/concepts-4.htm" />
+        <topic label="Window Menu - Close All Perspectives" href="reference/ref-60.htm" />
     </context>
     <context id="open_preferences_action_context">
         <description>This opens the preferences dialog.</description>
-        <topic label="General - Preferences" href="reference/ref-10.htm"/>
+        <topic label="General - Preferences" href="reference/ref-10.htm" />
     </context>
     <context id="open_new_window_action_context">
         <description>This opens a new window.</description>
-        <topic label="Opening perspectives" href="tasks/tasks-9f.htm"/>
-        <topic label="Changing Where Perspectives Open" href="tasks/tasks-24.htm"/>
-        <topic label="Workbench" href="concepts/concepts-2.htm"/>
-        <topic label="Perspectives" href="concepts/concepts-4.htm"/>
+        <topic label="Opening perspectives" href="tasks/tasks-9f.htm" />
+        <topic label="Changing Where Perspectives Open" href="tasks/tasks-24.htm" />
+        <topic label="Workbench" href="concepts/concepts-2.htm" />
+        <topic label="Perspectives" href="concepts/concepts-4.htm" />
     </context>
     <context id="quick_start_action_context">
         <description>This will open the welcome editor.</description>
-        <topic label="Help Menu - Welcome" href="reference/ref-61.htm"/>
+        <topic label="Help Menu - Welcome" href="reference/ref-61.htm" />
     </context>
     <context id="tips_and_tricks_action_context">
         <description>This will open the tips and tricks help page.</description>
-        <topic label="Help Menu - Tips and Tricks" href="reference/ref-61.htm"/>
+        <topic label="Help Menu - Tips and Tricks" href="reference/ref-61.htm" />
     </context>
     <context id="quit_action_context">
         <description>This will save the workspace and exit.</description>
-        <topic label="File Menu - Exit" href="reference/ref-56.htm"/>
+        <topic label="File Menu - Exit" href="reference/ref-56.htm" />
     </context>
     <context id="reset_perspective_action_context">
         <description>This will reset the perspective to its original (default) layout.</description>
-        <topic label="Perspectives" href="concepts/concepts-4.htm"/>
-        <topic label="Reset Perspectives" href="tasks/tasks-9j.htm"/>
-        <topic label="Window Menu - Reset Perspective" href="reference/ref-60.htm"/>
+        <topic label="Perspectives" href="concepts/concepts-4.htm" />
+        <topic label="Reset Perspectives" href="tasks/tasks-9j.htm" />
+        <topic label="Window Menu - Reset Perspective" href="reference/ref-60.htm" />
     </context>
     <context id="target_editors_visibility_action_context">
-        <description>This allows you to hide or show the editor area.  You can increase the area other views have to display themselves when you hide the editor area.</description>
-        <topic label="Window Menu - Show/Hide Editors" href="reference/ref-60.htm"/>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
+        <description>This allows you to hide or show the editor area. You can increase the area
+            other views have to display themselves when you hide the editor area.</description>
+        <topic label="Window Menu - Show/Hide Editors" href="reference/ref-60.htm" />
+        <topic label="Editors" href="concepts/concepts-6.htm" />
     </context>
     <context id="show_view_action_context">
         <description>This will show a view based on your selection.</description>
-        <topic label="Displaying Views" href="tasks/tasks-3.htm"/>
-        <topic label="Window Menu - Show View" href="reference/ref-60.htm"/>
+        <topic label="Displaying Views" href="tasks/tasks-3.htm" />
+        <topic label="Window Menu - Show View" href="reference/ref-60.htm" />
     </context>
     <context id="show_view_other_action_context">
         <description>Opens a dialog to select a view to show.</description>
-        <topic label="Displaying Views" href="tasks/tasks-3.htm"/>
-        <topic label="Window Menu - Show View" href="reference/ref-60.htm"/>
+        <topic label="Displaying Views" href="tasks/tasks-3.htm" />
+        <topic label="Window Menu - Show View" href="reference/ref-60.htm" />
     </context>
     <context id="open_perspective_action_context">
         <description>Opens the selected perspective.</description>
-        <topic label="Opening Perspectives" href="tasks/tasks-9f.htm"/>
-        <topic label="Window Menu - Open Perspective" href="reference/ref-60.htm"/>
+        <topic label="Opening Perspectives" href="tasks/tasks-9f.htm" />
+        <topic label="Window Menu - Open Perspective" href="reference/ref-60.htm" />
     </context>
     <context id="remove_bookmark_action_context">
         <description>Remove a bookmark.</description>
-        <topic label="Deleting a Bookmark" href="tasks/tasks-82.htm"/>
-        <topic label="Bookmarks" href="concepts/cbookmrk.htm"/>
+        <topic label="Deleting a Bookmark" href="tasks/tasks-82.htm" />
+        <topic label="Bookmarks" href="concepts/cbookmrk.htm" />
     </context>
     <context id="open_bookmark_action_context">
         <description>Open resource in which a bookmark resides.</description>
-        <topic label="Bookmarks" href="concepts/cbookmrk.htm"/>
+        <topic label="Bookmarks" href="concepts/cbookmrk.htm" />
     </context>
     <context id="select_all_bookmark_action_context">
         <description>Select all bookmarks.</description>
-        <topic label="Bookmarks" href="concepts/cbookmrk.htm"/>
+        <topic label="Bookmarks" href="concepts/cbookmrk.htm" />
     </context>
     <context id="filter_selection_action_context">
         <description>This command allows filtering of the types shown in the resource navigator.</description>
-        <topic label="Project Explorer View - Filters" href="reference/ref-27.htm"/>
+        <topic label="Project Explorer View - Filters" href="reference/ref-27.htm" />
     </context>
     <context id="goto_resource_action_context">
         <description>Go to the selected resource.</description>
-        <topic label="Project Explorer View - Go To" href="reference/ref-27.htm"/>
+        <topic label="Project Explorer View - Go To" href="reference/ref-27.htm" />
     </context>
     <context id="resource_navigator_move_action_context">
         <description>Move the selected resource to another location.</description>
-        <topic label="Moving Resources" href="tasks/tasks-63.htm"/>
-        <topic label="Project Explorer View - Move" href="reference/ref-27.htm"/>
+        <topic label="Moving Resources" href="tasks/tasks-63.htm" />
+        <topic label="Project Explorer View - Move" href="reference/ref-27.htm" />
     </context>
     <context id="resource_navigator_rename_action_context">
         <description>Rename the selected resource.</description>
-        <topic label="Renaming Resources" href="tasks/tasks-66.htm"/>
-        <topic label="Project Explorer View - Rename" href="reference/ref-27.htm"/>
+        <topic label="Renaming Resources" href="tasks/tasks-66.htm" />
+        <topic label="Project Explorer View - Rename" href="reference/ref-27.htm" />
     </context>
     <context id="show_in_navigator_action_context">
         <description>Show the selected resource in the Project Explorer view.</description>
-        <topic label="Resources" href="concepts/concepts-12.htm"/>
-        <topic label="Project Explorer View" href="reference/ref-27.htm"/>
+        <topic label="Resources" href="concepts/concepts-12.htm" />
+        <topic label="Project Explorer View" href="reference/ref-27.htm" />
     </context>
     <context id="properties_categories_action_context">
         <description>Show property values grouped according to category.</description>
-        <topic label="Properties View" href="concepts/cpropview.htm"/>
+        <topic label="Properties View" href="concepts/cpropview.htm" />
     </context>
     <context id="properties_defaults_action_context">
         <description>Sets the value of the selected property to its default value.</description>
-        <topic label="Properties View" href="concepts/cpropview.htm"/>
+        <topic label="Properties View" href="concepts/cpropview.htm" />
     </context>
     <context id="properties_filter_action_context">
         <description>Filter properties.</description>
-        <topic label="Properties View" href="concepts/cpropview.htm"/>
+        <topic label="Properties View" href="concepts/cpropview.htm" />
     </context>
     <context id="purge_completed_task_action_context">
         <description>Remove all completed tasks from the list.</description>
-        <topic label="Deleting Tasks" href="tasks/tasks-78.htm"/>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Deleting Tasks" href="tasks/tasks-78.htm" />
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="new_task_action_context">
         <description>Create a new task.</description>
-        <topic label="Adding an Unassociated Task" href="tasks/tasks-77.htm"/>
-        <topic label="Adding an Associated Task" href="tasks/tasks-77b.htm"/>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Adding an Unassociated Task" href="tasks/tasks-77.htm" />
+        <topic label="Adding an Associated Task" href="tasks/tasks-77b.htm" />
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="remove_task_action_context">
         <description>Remove a task from this list.</description>
-        <topic label="Deleting Tasks" href="tasks/tasks-78.htm"/>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Deleting Tasks" href="tasks/tasks-78.htm" />
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="goto_task_action_context">
         <description>Opens the resource associated with a task.</description>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="undo_action_context">
         <description>Undo the previous edit.</description>
-        <topic label="Edit Menu - Undo" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Undo" href="reference/ref-57.htm" />
     </context>
     <context id="redo_action_context">
         <description>Redo the previous edit.</description>
-        <topic label="Edit Menu - Redo" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Redo" href="reference/ref-57.htm" />
     </context>
     <context id="cut_action_context">
         <description>Cut the selected text to the clipboard.</description>
-        <topic label="Edit Menu - Cut" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Cut" href="reference/ref-57.htm" />
     </context>
     <context id="copy_action_context">
         <description>Copy the selection to the clipboard.</description>
-        <topic label="Edit Menu - Copy" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Copy" href="reference/ref-57.htm" />
     </context>
     <context id="paste_action_context">
         <description>Paste the contents of the clipboard at the current cursor position.</description>
-        <topic label="Edit Menu - Paste" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Paste" href="reference/ref-57.htm" />
     </context>
     <context id="delete_action_context">
         <description>Delete the selection.</description>
-        <topic label="Edit Menu - Delete" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Delete" href="reference/ref-57.htm" />
     </context>
     <context id="selectAll_action_context">
         <description>Select all contents of the file.</description>
-        <topic label="Edit Menu - Select All" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Select All" href="reference/ref-57.htm" />
     </context>
     <context id="ShiftLeft_action_context">
         <description>Shift selected text to the left, reducing the indentation.</description>
@@ -381,15 +397,15 @@
     </context>
     <context id="find_action_context">
         <description>This will bring up a dialog to specify text to search for in the editor.</description>
-        <topic label="Edit Menu - Find/Replace" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Find/Replace" href="reference/ref-57.htm" />
     </context>
     <context id="bookmark_action_context">
         <description>Add a bookmark on this resource.</description>
-        <topic label="Edit Menu - Add Bookmark" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Add Bookmark" href="reference/ref-57.htm" />
     </context>
     <context id="addTask_action_context">
         <description>Add a task associated with this resource.</description>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="revert_action_context">
         <description>Revert to saved contents.</description>
@@ -399,7 +415,7 @@
     </context>
     <context id="open_workspace_file_action_context">
         <description>Opens an editor on a specified resource.</description>
-        <topic label="Navigate Menu - Open Resource" href="reference/ref-58.htm"/>
+        <topic label="Navigate Menu - Open Resource" href="reference/ref-58.htm" />
     </context>
     <context id="print_action_context">
         <description>This command prints the resource that is currently active in the editor area.</description>
@@ -418,70 +434,75 @@
     </context>
     <context id="navigation_history_forward">
         <description>Moves forward in the navigation history.</description>
-        <topic label="Navigate Menu - Forward" href="reference/ref-58.htm"/>
+        <topic label="Navigate Menu - Forward" href="reference/ref-58.htm" />
     </context>
     <context id="navigation_history_backward">
         <description>Moves backward in the navigation history.</description>
-        <topic label="Navigate Menu - Back" href="reference/ref-58.htm"/>
+        <topic label="Navigate Menu - Back" href="reference/ref-58.htm" />
     </context>
     <!-- Dialogs -->
     <context id="about_dialog_context">
         <description>This dialog displays product information.</description>
-     	<topic label="About your installation" href="tasks/tasks-134.htm" />
-       	<topic label="Installation Details" href="tasks/tasks-130.htm" />
-        <topic label="Help Menu - About" href="reference/ref-61.htm"/>
+        <topic label="About your installation" href="tasks/tasks-134.htm" />
+        <topic label="Installation Details" href="tasks/tasks-130.htm" />
+        <topic label="Help Menu - About" href="reference/ref-61.htm" />
     </context>
     <context id="action_set_selection_dialog_context">
-        <description>This dialog allows you to customize the menu items and toolbar buttons which are visible in a perspective. You can change which wizards, views and perspectives are listed in submenus, change the availability of command groups, and tweak the visibility of menu items and toolbar buttons.</description>
-		<topic label="Showing and hiding menu items and toolbar buttons" href="tasks/tasks-9n.htm"/>
-		<topic label="Configuring perspective command groups" href="tasks/tasks-9m.htm"/>
-        <topic label="Configuring perspective shortcuts" href="tasks/tasks-9k.htm"/>
-        <topic label="Window Menu - Customize Perspective" href="reference/ref-60.htm"/>
+        <description>This dialog allows you to customize the menu items and toolbar buttons which
+            are visible in a perspective. You can change which wizards, views and perspectives are
+            listed in submenus, change the availability of command groups, and tweak the visibility
+            of menu items and toolbar buttons.</description>
+        <topic label="Showing and hiding menu items and toolbar buttons" href="tasks/tasks-9n.htm" />
+        <topic label="Configuring perspective command groups" href="tasks/tasks-9m.htm" />
+        <topic label="Configuring perspective shortcuts" href="tasks/tasks-9k.htm" />
+        <topic label="Window Menu - Customize Perspective" href="reference/ref-60.htm" />
     </context>
     <context id="editor_selection_dialog_context">
-        <description>In this dialog, you can associate various embedded and external editors with the various types of workbench resources.</description>
-        <topic label="Preferences - File Associations" href="reference/ref-13.htm"/>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
+        <description>In this dialog, you can associate various embedded and external editors with
+            the various types of workbench resources.</description>
+        <topic label="Preferences - File Associations" href="reference/ref-13.htm" />
+        <topic label="Editors" href="concepts/concepts-6.htm" />
     </context>
     <context id="file_extension_dialog_context">
         <description>In this dialog, indicate the extension for the file type you wish to identify.</description>
-        <topic label="Preferences - File Associations" href="reference/ref-13.htm"/>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
+        <topic label="Preferences - File Associations" href="reference/ref-13.htm" />
+        <topic label="Editors" href="concepts/concepts-6.htm" />
     </context>
     <context id="preference_dialog_context">
         <description>This dialog allows you to set your workbench preferences.</description>
-        <topic label="Preferences Dialog" href="reference/ref-72.htm"/>
+        <topic label="Preferences Dialog" href="reference/ref-72.htm" />
     </context>
     <context id="property_dialog_context">
-        <description>This dialog allows you to view or change the properties of the selected resource.</description>
-        <topic label="Project Explorer View - Properties Page" href="reference/ref-27.htm"/>
-        <topic label="Resource Properties" href="tasks/tasks-49.htm"/>
+        <description>This dialog allows you to view or change the properties of the selected
+            resource.</description>
+        <topic label="Project Explorer View - Properties Page" href="reference/ref-27.htm" />
+        <topic label="Resource Properties" href="tasks/tasks-49.htm" />
     </context>
     <context id="save_perspective_dialog_context">
         <description>This dialog allows you to save a perspective under a new name.</description>
-        <topic label="Perspectives" href="concepts/concepts-4.htm"/>
-        <topic label="Saving Perspectives" href="tasks/tasks-9i.htm"/>
+        <topic label="Perspectives" href="concepts/concepts-4.htm" />
+        <topic label="Saving Perspectives" href="tasks/tasks-9i.htm" />
     </context>
     <context id="select_perspective_dialog_context">
         <description>Dialog to select a perspective.</description>
-        <topic label="Perspectives - Concept" href="concepts/concepts-4.htm"/>
-        <topic label="Saving Perspectives" href="tasks/tasks-9i.htm"/>
-        <topic label="Window Menu" href="reference/ref-60.htm"/>
+        <topic label="Perspectives - Concept" href="concepts/concepts-4.htm" />
+        <topic label="Saving Perspectives" href="tasks/tasks-9i.htm" />
+        <topic label="Window Menu" href="reference/ref-60.htm" />
     </context>
     <context id="project_location_selection_dialog_context">
         <description>Dialog to select the location of a project.</description>
     </context>
     <context id="show_view_dialog_context">
         <description>Dialog to select a view to show.</description>
-        <topic label="Displaying Views" href="tasks/tasks-3.htm"/>
+        <topic label="Displaying Views" href="tasks/tasks-3.htm" />
     </context>
     <context id="save_as_dialog_context">
         <description>Dialog to specify the name and location of the a resource to save.</description>
     </context>
     <context id="type_filtering_dialog_context">
         <description>Use this dialog to filter file types.</description>
-        <topic label="Export Wizard" href="reference/ref-71.htm"/>
-        <topic label="Import Wizard" href="reference/ref-70.htm"/>
+        <topic label="Export Wizard" href="reference/ref-71.htm" />
+        <topic label="Import Wizard" href="reference/ref-70.htm" />
     </context>
     <context id="container_selection_dialog_context">
         <description>Dialog to select a folder.</description>
@@ -503,389 +524,426 @@
     </context>
     <context id="task_filters_dialog_context">
         <description>Dialog that allows you to show or hide tasks based on certain criteria.</description>
-        <topic label="Filtering Your Task List" href="tasks/tasks-79.htm"/>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Filtering Your Task List" href="tasks/tasks-79.htm" />
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="find_replace_dialog_context">
         <description>Dialog to find and replace specified text.</description>
-		<topic label="Find/Replace with regular expressions" href="reference/ref-regex-find-replace.htm" />
+        <topic label="Find/Replace with regular expressions"
+            href="reference/ref-regex-find-replace.htm" />
+    </context>
+    <context id="find_replace_overlay_context">
+        <description>Overlay to find and replace specified text.</description>
+        <topic label="Find/Replace with regular expressions"
+            href="reference/ref-regex-find-replace.htm" />
     </context>
     <context id="switch_workspace_dialog_context">
         <description>Dialog to switch workspaces.</description>
-		<topic label="Switching Workspaces" href="reference/ref-workspaceswitch.htm" />
+        <topic label="Switching Workspaces" href="reference/ref-workspaceswitch.htm" />
     </context>
     <context id="open_resource_dialog">
         <description>Dialog to open files by name or path.</description>
-        <topic label="Open Resource dialog" href="reference/ref-dialog-open-resource.htm"/>
-        <topic label="Opening Resources" href="tasks/tasks-46.htm"/>
+        <topic label="Open Resource dialog" href="reference/ref-dialog-open-resource.htm" />
+        <topic label="Opening Resources" href="tasks/tasks-46.htm" />
     </context>
     <!-- Editors -->
     <context id="welcome_editor_context">
         <description>A quick, simple guide to introduce new users to some basic tasks.</description>
-        <topic label="Help Menu" href="reference/ref-61.htm"/>
+        <topic label="Help Menu" href="reference/ref-61.htm" />
     </context>
     <context id="text_editor_context">
         <description>A text editor is used to edit files.</description>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
-        <topic label="Accessibility features in textual editors" href="concepts/accessibility/text_editor.htm"/>
+        <topic label="Editors" href="concepts/concepts-6.htm" />
+        <topic label="Accessibility features in textual editors"
+            href="concepts/accessibility/text_editor.htm" />
     </context>
     <context id="system_summary_dialog_context">
         <description>Shows the product configuration details.</description>
-  	    <topic label="Installation Details for the Configuration" href="tasks/tasks-133.htm" />
+        <topic label="Installation Details for the Configuration" href="tasks/tasks-133.htm" />
     </context>
     <!-- Preference pages -->
     <context id="file_editors_preference_page_context">
-        <description>On this preferences page, you can associate various embedded and external editors with the various types of workbench resources.</description>
-        <topic label="Preferences - File Associations" href="reference/ref-13.htm"/>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
+        <description>On this preferences page, you can associate various embedded and external
+            editors with the various types of workbench resources.</description>
+        <topic label="Preferences - File Associations" href="reference/ref-13.htm" />
+        <topic label="Editors" href="concepts/concepts-6.htm" />
     </context>
     <context id="build_order_preference_page_context">
         <description>Allows you to change the order that projects in the workspace are built.</description>
-        <topic label="Changing the Build Order" href="tasks/tasks-14.htm"/>
+        <topic label="Changing the Build Order" href="tasks/tasks-14.htm" />
     </context>
     <context id="file_states_preference_page_context">
-        <description>This preference page is used to configure the local file history for the workbench.</description>
-        <topic label="Local History" href="concepts/concepts-17a.htm"/>
-        <topic label="Preferences - Local History" href="reference/ref-14.htm"/>
-        <topic label="Project Explorer - Local History" href="reference/ref-27.htm"/>
+        <description>This preference page is used to configure the local file history for the
+            workbench.</description>
+        <topic label="Local History" href="concepts/concepts-17a.htm" />
+        <topic label="Preferences - Local History" href="reference/ref-14.htm" />
+        <topic label="Project Explorer - Local History" href="reference/ref-27.htm" />
     </context>
     <context id="perspectives_preference_page_context">
         <description>Allows you to set the state of existing perspectives.</description>
-        <topic label="Preferences - Perspectives" href="reference/ref-15.htm"/>
-        <topic label="Perspectives" href="concepts/concepts-4.htm"/>
+        <topic label="Preferences - Perspectives" href="reference/ref-15.htm" />
+        <topic label="Perspectives" href="concepts/concepts-4.htm" />
     </context>
     <context id="views_preference_page_context">
-        <description>This preference page is used to set preferences for the look and layout of views in the workbench.</description>
-        <topic label="Preferences - Appearance" href="reference/ref-16.htm"/>
-        <topic label="Views" href="concepts/concepts-5.htm"/>
+        <description>This preference page is used to set preferences for the look and layout of
+            views in the workbench.</description>
+        <topic label="Preferences - Appearance" href="reference/ref-16.htm" />
+        <topic label="Views" href="concepts/concepts-5.htm" />
     </context>
     <context id="workspace_preference_page_context">
-        <description>This preference page is used to set the IDE-specific preferences settings related in workspace.</description>
-        <topic label="Preferences - Workspace" href="reference/ref-9.htm"/>
+        <description>This preference page is used to set the IDE-specific preferences settings
+            related in workspace.</description>
+        <topic label="Preferences - Workspace" href="reference/ref-9.htm" />
     </context>
     <context id="workbench_preference_page_context">
         <description>Allows you to set general workbench preferences.</description>
-        <topic label="Preferences - General" href="reference/ref-10.htm"/>
+        <topic label="Preferences - General" href="reference/ref-10.htm" />
     </context>
     <context id="font_preference_page_context">
         <description>This preference page is used to set the fonts used within the workbench.</description>
-        <topic label="Preferences - Colors and Fonts" href="reference/ref-fonts.htm"/>
+        <topic label="Preferences - Colors and Fonts" href="reference/ref-fonts.htm" />
     </context>
     <context id="keys_preference_page_context">
         <description>This preference page is used to set the key bindings used within the workbench.</description>
-        <topic label="Preferences - Keys" href="concepts/accessibility/keyboardshortcuts.htm"/>
+        <topic label="Preferences - Keys" href="concepts/accessibility/keyboardshortcuts.htm" />
     </context>
     <context id="workbench_editor_preference_page_context">
-        <description>This preference page is used to set preferences for the editor area in the workbench.</description>
-        <topic label="Preferences - Editors" href="reference/ref-12.htm"/>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
+        <description>This preference page is used to set preferences for the editor area in the
+            workbench.</description>
+        <topic label="Preferences - Editors" href="reference/ref-12.htm" />
+        <topic label="Editors" href="concepts/concepts-6.htm" />
     </context>
-	<context id="capabilities_preference_page_context">
-		<description>This preference page is used to set preferences relating to workbench capabilities.</description>
-		<topic label="Preferences - Capabilities" href="reference/ref-capabilitiespref.htm"/>
-	</context>
+    <context id="capabilities_preference_page_context">
+        <description>This preference page is used to set preferences relating to workbench
+            capabilities.</description>
+        <topic label="Preferences - Capabilities" href="reference/ref-capabilitiespref.htm" />
+    </context>
     <context id="content_types_preference_page_context">
-        <description>This preference page is used to set preferences relating to resource content types.</description>
-        <topic label="Preferences - Content Types" href="reference/ref-content-type.htm"/>
-        <topic label="Preferences - File Associations" href="reference/ref-13.htm"/>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
-        <topic label="Resources" href="concepts/concepts-12.htm"/>
+        <description>This preference page is used to set preferences relating to resource content
+            types.</description>
+        <topic label="Preferences - Content Types" href="reference/ref-content-type.htm" />
+        <topic label="Preferences - File Associations" href="reference/ref-13.htm" />
+        <topic label="Editors" href="concepts/concepts-6.htm" />
+        <topic label="Resources" href="concepts/concepts-12.htm" />
     </context>
     <context id="large_file_associations_preference_page_context">
-        <description>On this preference page you can specify which editors are used to open large files and specify file size limits for specific editors.</description>
-        <topic label="Preferences - Large File Associations" href="reference/ref-large-file-associations.htm"/>
-        <topic label="Customization - Large File Associations" href="tasks/large-file-associations.htm"/>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
+        <description>On this preference page you can specify which editors are used to open large
+            files and specify file size limits for specific editors.</description>
+        <topic label="Preferences - Large File Associations"
+            href="reference/ref-large-file-associations.htm" />
+        <topic label="Customization - Large File Associations"
+            href="tasks/large-file-associations.htm" />
+        <topic label="Editors" href="concepts/concepts-6.htm" />
     </context>
     <!-- Property pages -->
     <context id="project_reference_property_page_context">
         <description>Allows you to set referenced projects.</description>
-        <topic label="Project Explorer View - Properties Page" href="reference/ref-27.htm"/>
-        <topic label="Viewing Resource Properties" href="tasks/tasks-49.htm"/>
+        <topic label="Project Explorer View - Properties Page" href="reference/ref-27.htm" />
+        <topic label="Viewing Resource Properties" href="tasks/tasks-49.htm" />
     </context>
     <context id="resource_info_property_page_context">
         <description>Allows you to view information about the selected resource.</description>
-        <topic label="Project Explorer View - Properties Page" href="reference/ref-27.htm"/>
-        <topic label="Viewing Resource Properties" href="tasks/tasks-49.htm"/>
+        <topic label="Project Explorer View - Properties Page" href="reference/ref-27.htm" />
+        <topic label="Viewing Resource Properties" href="tasks/tasks-49.htm" />
     </context>
     <context id="linked_resource_page_context">
         <description>Allows you to view path variables and linked resources in the project</description>
-        <topic label="Path Variables" href="concepts/cpathvars.htm"/>
-        <topic label="Virtual Folders" href="concepts/virtualfolders.htm"/>
-        <topic label="Linked Resources" href="concepts/concepts-13.htm"/>
+        <topic label="Path Variables" href="concepts/cpathvars.htm" />
+        <topic label="Virtual Folders" href="concepts/virtualfolders.htm" />
+        <topic label="Linked Resources" href="concepts/concepts-13.htm" />
     </context>
     <context id="linked_resource_preference_page_context">
         <description>Allows you to view path variables in the workspace</description>
-        <topic label="Path Variables" href="concepts/cpathvars.htm"/>
-        <topic label="Linked Resources" href="concepts/concepts-13.htm"/>
+        <topic label="Path Variables" href="concepts/cpathvars.htm" />
+        <topic label="Linked Resources" href="concepts/concepts-13.htm" />
     </context>
     <context id="resource_filter_property_page_context">
         <description>Allows you to view and configure resources filters on a project or folder</description>
-        <topic label="Resource Filters" href="concepts/resourcefilters.htm"/>
+        <topic label="Resource Filters" href="concepts/resourcefilters.htm" />
     </context>
     <context id="edit_resource_filter_property_page_context">
         <description>Allows you to create and edit resources filters</description>
-        <topic label="Create Resource Filters" href="tasks/tasks-97.htm"/>
-        <topic label="Resource Filters" href="concepts/resourcefilters.htm"/>
+        <topic label="Create Resource Filters" href="tasks/tasks-97.htm" />
+        <topic label="Resource Filters" href="concepts/resourcefilters.htm" />
     </context>
     <context id="edit_resource_filter_dialog_context">
         <description>Allows you to create and edit resources filters</description>
-        <topic label="Create Resource Filters" href="tasks/tasks-97.htm"/>
-        <topic label="Resource Filters" href="concepts/resourcefilters.htm"/>
+        <topic label="Create Resource Filters" href="tasks/tasks-97.htm" />
+        <topic label="Resource Filters" href="concepts/resourcefilters.htm" />
     </context>
     <!-- Views -->
     <context id="bookmark_view_context">
         <description>View to show all bookmarks.</description>
-        <topic label="Views" href="concepts/concepts-5.htm"/>
-        <topic label="Bookmarks View" href="reference/ref-28.htm"/>
+        <topic label="Views" href="concepts/concepts-5.htm" />
+        <topic label="Bookmarks View" href="reference/ref-28.htm" />
     </context>
     <context id="content_outline_context">
         <description>View to show the outline (if applicable) of a resource being edited.</description>
-        <topic label="Views" href="concepts/concepts-5.htm"/>
-        <topic label="Outline View" href="concepts/coutline.htm"/>
+        <topic label="Views" href="concepts/concepts-5.htm" />
+        <topic label="Outline View" href="concepts/coutline.htm" />
     </context>
     <context id="resource_view_context">
         <description>This view shows all resources in the workspace.</description>
-        <topic label="Views" href="concepts/concepts-5.htm"/>
+        <topic label="Views" href="concepts/concepts-5.htm" />
     </context>
     <context id="property_sheet_view_context">
         <description>This view shows the properties of a selected resource.</description>
-        <topic label="Views" href="concepts/concepts-5.htm"/>
-        <topic label="Properties View" href="concepts/cpropview.htm"/>
+        <topic label="Views" href="concepts/concepts-5.htm" />
+        <topic label="Properties View" href="concepts/cpropview.htm" />
     </context>
     <context id="task_list_view_context">
-        <description>This view shows tasks (reminders) that are either user-created or are automatically generated during building.</description>
-        <topic label="Views" href="concepts/concepts-5.htm"/>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <description>This view shows tasks (reminders) that are either user-created or are
+            automatically generated during building.</description>
+        <topic label="Views" href="concepts/concepts-5.htm" />
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="problem_view_context">
         <description>This view shows problems that are generated during building.</description>
-        <topic label="Views" href="concepts/concepts-5.htm"/>
-        <topic label="Problems View" href="reference/ref-31a.htm"/>
-        <topic label="Quick Fix" href="tasks/tquickfix.htm"/>
+        <topic label="Views" href="concepts/concepts-5.htm" />
+        <topic label="Problems View" href="reference/ref-31a.htm" />
+        <topic label="Quick Fix" href="tasks/tquickfix.htm" />
     </context>
     <!-- Property sheet -->
     <context id="property_sheet_page_help_context">
         <description>The Properties view displays the properties of the selected resource.</description>
-        <topic label="Views" href="concepts/concepts-5.htm"/>
-        <topic label="Properties View" href="concepts/cpropview.htm"/>
+        <topic label="Views" href="concepts/concepts-5.htm" />
+        <topic label="Properties View" href="concepts/cpropview.htm" />
     </context>
     <!-- Windows -->
     <context id="detached_window_context">
-        <description>Views can be undocked from a workbench window and can exist in floating windows on the desktop.</description>
-        <topic label="Docking Views" href="tasks/tasks-3e.htm"/>
-        <topic label="Workbench Window Layout" href="reference/ref-23.htm"/>
-        <topic label="Views" href="concepts/concepts-5.htm"/>
+        <description>Views can be undocked from a workbench window and can exist in floating windows
+            on the desktop.</description>
+        <topic label="Docking Views" href="tasks/tasks-3e.htm" />
+        <topic label="Workbench Window Layout" href="reference/ref-23.htm" />
+        <topic label="Views" href="concepts/concepts-5.htm" />
     </context>
     <context id="workbench_window_context">
-        <description>Each workbench window contains one or more perspectives, which are made up of various views and editors.</description>
-        <topic label="Workbench" href="concepts/concepts-2.htm"/>
-        <topic label="Perspectives" href="concepts/concepts-4.htm"/>
-        <topic label="Customizing the Workbench" href="tasks/tasks-1.htm"/>
+        <description>Each workbench window contains one or more perspectives, which are made up of
+            various views and editors.</description>
+        <topic label="Workbench" href="concepts/concepts-2.htm" />
+        <topic label="Perspectives" href="concepts/concepts-4.htm" />
+        <topic label="Customizing the Workbench" href="tasks/tasks-1.htm" />
     </context>
     <!-- Wizard pages -->
     <context id="new_project_wizard_page_context">
         <description>This wizard helps you create a new project in the workbench.</description>
-        <topic label="New Project Wizard" href="reference/ref-37.htm"/>
-        <topic label="Resources" href="concepts/concepts-12.htm"/>
-        <topic label="Creating Resources - Projects" href="tasks/tasks-42.htm"/>
+        <topic label="New Project Wizard" href="reference/ref-37.htm" />
+        <topic label="Resources" href="concepts/concepts-12.htm" />
+        <topic label="Creating Resources - Projects" href="tasks/tasks-42.htm" />
     </context>
     <context id="new_project_reference_wizard_page_context">
-        <description>This wizard page allows you to select other projects which this project will reference.</description>
-        <topic label="Select Referenced Projects Page" href="reference/ref-37.htm"/>
-        <topic label="Resources" href="concepts/concepts-12.htm"/>
+        <description>This wizard page allows you to select other projects which this project will
+            reference.</description>
+        <topic label="Select Referenced Projects Page" href="reference/ref-37.htm" />
+        <topic label="Resources" href="concepts/concepts-12.htm" />
     </context>
     <context id="new_folder_wizard_page_context">
         <description>Wizard to guide you through creation of a new folder resource.</description>
-        <topic label="New Folder Wizard" href="reference/ref-38.htm"/>
-        <topic label="Resources" href="concepts/concepts-12.htm"/>
-        <topic label="Virtual Folders" href="concepts/virtualfolders.htm"/>
-        <topic label="Linked Resources" href="concepts/concepts-13.htm"/>
-        <topic label="Creating Resources - Folders" href="tasks/tasks-43.htm"/>
+        <topic label="New Folder Wizard" href="reference/ref-38.htm" />
+        <topic label="Resources" href="concepts/concepts-12.htm" />
+        <topic label="Virtual Folders" href="concepts/virtualfolders.htm" />
+        <topic label="Linked Resources" href="concepts/concepts-13.htm" />
+        <topic label="Creating Resources - Folders" href="tasks/tasks-43.htm" />
     </context>
     <context id="new_folder_dialog">
         <description>This dialog allows to create a new folder in the file system.</description>
     </context>
     <context id="new_file_wizard_page_context">
         <description>Wizard to guide you through creation of a new file resource.</description>
-        <topic label="New File Wizard" href="reference/ref-39.htm"/>
-        <topic label="Resources" href="concepts/concepts-12.htm"/>
-        <topic label="Creating Resources - Files" href="tasks/tasks-44.htm"/>
+        <topic label="New File Wizard" href="reference/ref-39.htm" />
+        <topic label="Resources" href="concepts/concepts-12.htm" />
+        <topic label="Creating Resources - Files" href="tasks/tasks-44.htm" />
     </context>
     <context id="new_wizard_selection_wizard_page_context">
         <description>Choose the type of resource you would like to create.</description>
-        <topic label="Resources" href="concepts/concepts-12.htm"/>
+        <topic label="Resources" href="concepts/concepts-12.htm" />
     </context>
     <context id="export_wizard_selection_wizard_page_context">
         <description>Choose the type of export you would like to do.</description>
-        <topic label="Using the Export Wizard" href="reference/ref-71.htm"/>
-        <topic label="Exporting resources" href="tasks/tasks-57.xhtml"/>
-        <topic label="Exporting to the File System" href="tasks/tasks-59.htm"/>
-        <topic label="Exporting to a Zip File" href="tasks/tasks-59ag.htm"/>
+        <topic label="Using the Export Wizard" href="reference/ref-71.htm" />
+        <topic label="Exporting resources" href="tasks/tasks-57.xhtml" />
+        <topic label="Exporting to the File System" href="tasks/tasks-59.htm" />
+        <topic label="Exporting to a Zip File" href="tasks/tasks-59ag.htm" />
     </context>
     <context id="import_wizard_selection_wizard_page_context">
         <description>Choose the type of import you would like to do.</description>
-        <topic label="Using the Import Wizard" href="reference/ref-70.htm"/>
-        <topic label="Importing resources with the Import Wizard" href="tasks/tasks-55.htm"/>
+        <topic label="Using the Import Wizard" href="reference/ref-70.htm" />
+        <topic label="Importing resources with the Import Wizard" href="tasks/tasks-55.htm" />
     </context>
     <context id="file_system_export_wizard_page">
-        <description>This page helps you to provide all the information required to export resources to the file system.</description>
-        <topic label="Using the Export Wizard" href="tasks/tasks-59.htm"/>
-        <topic label="Export Wizard" href="reference/ref-71.htm"/>
+        <description>This page helps you to provide all the information required to export resources
+            to the file system.</description>
+        <topic label="Using the Export Wizard" href="tasks/tasks-59.htm" />
+        <topic label="Export Wizard" href="reference/ref-71.htm" />
     </context>
     <context id="file_system_import_wizard_page">
-        <description>This page helps you to provide all the information required to import files from the file system.</description>
-        <topic label="Importing from File System" href="tasks/tasks-55.htm"/>
-        <topic label="Import Wizard" href="reference/ref-70.htm"/>
+        <description>This page helps you to provide all the information required to import files
+            from the file system.</description>
+        <topic label="Importing from File System" href="tasks/tasks-55.htm" />
+        <topic label="Import Wizard" href="reference/ref-70.htm" />
     </context>
     <context id="zip_file_export_wizard_page">
-        <description>This page helps you to provide all the information required to export resources from the workspace to an archive file.</description>
-        <topic label="Exporting to a Zip File" href="tasks/tasks-59ag.htm"/>
-        <topic label="Export Wizard" href="reference/ref-71.htm"/>
+        <description>This page helps you to provide all the information required to export resources
+            from the workspace to an archive file.</description>
+        <topic label="Exporting to a Zip File" href="tasks/tasks-59ag.htm" />
+        <topic label="Export Wizard" href="reference/ref-71.htm" />
     </context>
     <context id="zip_file_import_wizard_page">
-        <description>This page helps you to provide all the information required to import files from an archive file into the workspace.</description>
-        <topic label="Importing from a Zip File" href="tasks/tasks-55bg.htm"/>
-        <topic label="Import Wizard" href="reference/ref-70.htm"/>
+        <description>This page helps you to provide all the information required to import files
+            from an archive file into the workspace.</description>
+        <topic label="Importing from a Zip File" href="tasks/tasks-55bg.htm" />
+        <topic label="Import Wizard" href="reference/ref-70.htm" />
     </context>
     <context id="preferences_export_wizard_page">
-        <description>This page helps you to provide all the information required to export preferences from the workspace to a file system.</description>
-        <topic label="Importing and Exporting Preferences" href="tasks/timpandexp.htm"/>
-        <topic label="Export Wizard" href="reference/ref-71.htm"/>
+        <description>This page helps you to provide all the information required to export
+            preferences from the workspace to a file system.</description>
+        <topic label="Importing and Exporting Preferences" href="tasks/timpandexp.htm" />
+        <topic label="Export Wizard" href="reference/ref-71.htm" />
     </context>
     <context id="preferences_import_wizard_page">
-        <description>This page helps you to provide all the information required to import preferences from a file system into the workspace.</description>
-        <topic label="Importing and Exporting Preferences" href="tasks/timpandexp.htm"/>
-        <topic label="Import Wizard" href="reference/ref-70.htm"/>
+        <description>This page helps you to provide all the information required to import
+            preferences from a file system into the workspace.</description>
+        <topic label="Importing and Exporting Preferences" href="tasks/timpandexp.htm" />
+        <topic label="Import Wizard" href="reference/ref-70.htm" />
     </context>
     <!-- Wizards -->
     <context id="new_wizard_context">
         <description>These wizards allow you to create new resources and/or elements</description>
-        <topic label="Resources" href="concepts/concepts-12.htm"/>
+        <topic label="Resources" href="concepts/concepts-12.htm" />
     </context>
     <context id="new_wizard_shortcut_context">
         <description>Opens a creation wizard.</description>
     </context>
     <context id="new_file_wizard_context">
         <description>Wizard to assist in creating a new file resource.</description>
-        <topic label="New File Wizard" href="reference/ref-39.htm"/>
-        <topic label="Resources" href="concepts/concepts-12.htm"/>
-        <topic label="Creating Resources - Files" href="tasks/tasks-44.htm"/>
+        <topic label="New File Wizard" href="reference/ref-39.htm" />
+        <topic label="Resources" href="concepts/concepts-12.htm" />
+        <topic label="Creating Resources - Files" href="tasks/tasks-44.htm" />
     </context>
     <context id="new_folder_wizard_context">
         <description>Wizard to assist in creating a new folder resource.</description>
-        <topic label="New Folder Wizard" href="reference/ref-38.htm"/>
-        <topic label="Resources" href="concepts/concepts-12.htm"/>
-        <topic label="Creating Resources - Folders" href="tasks/tasks-43.htm"/>
+        <topic label="New Folder Wizard" href="reference/ref-38.htm" />
+        <topic label="Resources" href="concepts/concepts-12.htm" />
+        <topic label="Creating Resources - Folders" href="tasks/tasks-43.htm" />
     </context>
     <context id="new_project_wizard_context">
         <description>Wizard to assist in creating a new project.</description>
-        <topic label="New Project Wizard" href="reference/ref-37.htm"/>
-        <topic label="Resources" href="concepts/concepts-12.htm"/>
-        <topic label="Creating Resources - Projects" href="tasks/tasks-42.htm"/>
+        <topic label="New Project Wizard" href="reference/ref-37.htm" />
+        <topic label="Resources" href="concepts/concepts-12.htm" />
+        <topic label="Creating Resources - Projects" href="tasks/tasks-42.htm" />
     </context>
     <context id="import_wizard_context">
         <description>Wizard to assist in importing resources.</description>
-        <topic label="Using the Import Wizard" href="tasks/tasks-55.htm"/>
+        <topic label="Using the Import Wizard" href="tasks/tasks-55.htm" />
     </context>
     <context id="export_wizard_context">
         <description>Wizard to assist in exporting resources.</description>
-        <topic label="Exporting files" href="tasks/tasks-57.xhtml"/>
-        <topic label="Exporting to the File System" href="tasks/tasks-59.htm"/>
-        <topic label="Exporting to a Zip File" href="tasks/tasks-59ag.htm"/>
-        <topic label="Export Wizard" href="reference/ref-71.htm"/>
+        <topic label="Exporting files" href="tasks/tasks-57.xhtml" />
+        <topic label="Exporting to the File System" href="tasks/tasks-59.htm" />
+        <topic label="Exporting to a Zip File" href="tasks/tasks-59ag.htm" />
+        <topic label="Export Wizard" href="reference/ref-71.htm" />
     </context>
-    <!-- terminal reference commented out in org.eclipse.ui.internal.WorkbenchActionBuilder, line 301
-  <context id="close_all_saved_action_context">
-    <description></description>
-  </context>
-  -->
+    <!-- terminal reference commented out in org.eclipse.ui.internal.WorkbenchActionBuilder, line
+    301
+<context id="close_all_saved_action_context">
+<description></description>
+</context>
+-->
     <context id="show_view_menu_action_context">
         <description>Displays the menu for the active view.</description>
     </context>
     <context id="workbench_editors_action_context">
         <description>Displays the Switch to Editors dialog.</description>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
+        <topic label="Editors" href="concepts/concepts-6.htm" />
     </context>
     <context id="text_cut_action_context">
         <description>Cut the selected text to the clipboard.</description>
-        <topic label="Edit Menu - Cut" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Cut" href="reference/ref-57.htm" />
     </context>
     <context id="text_copy_action_context">
         <description>Copy the selection to the clipboard.</description>
-        <topic label="Edit Menu - Copy" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Copy" href="reference/ref-57.htm" />
     </context>
     <context id="text_paste_action_context">
         <description>Paste the contents of the clipboard at the current cursor position.</description>
-        <topic label="Edit Menu - Paste" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Paste" href="reference/ref-57.htm" />
     </context>
     <context id="text_select_all_action_context">
         <description>Select all contents.</description>
-        <topic label="Edit Menu - Select All" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Select All" href="reference/ref-57.htm" />
     </context>
     <context id="text_delete_action_context">
         <description>Delete the selection.</description>
-        <topic label="Edit Menu - Delete" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Delete" href="reference/ref-57.htm" />
     </context>
     <context id="cell_cut_action_context">
         <description>Cut the selected text to the clipboard.</description>
-        <topic label="Edit Menu - Cut" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Cut" href="reference/ref-57.htm" />
     </context>
     <context id="cell_copy_action_context">
         <description>Copy the selection to the clipboard.</description>
-        <topic label="Edit Menu - Copy" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Copy" href="reference/ref-57.htm" />
     </context>
     <context id="cell_paste_action_context">
         <description>Paste the contents of the clipboard at the current cursor position.</description>
-        <topic label="Edit Menu - Paste" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Paste" href="reference/ref-57.htm" />
     </context>
     <context id="cell_delete_action_context">
         <description>Delete the selection.</description>
-        <topic label="Edit Menu - Delete" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Delete" href="reference/ref-57.htm" />
     </context>
     <context id="cell_find_action_context">
         <description>This will bring up a dialog to specify text to search for in the editor.</description>
-        <topic label="Edit Menu - Find/Replace" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Find/Replace" href="reference/ref-57.htm" />
     </context>
     <context id="cell_select_all_action_context">
         <description>Select all contents.</description>
-        <topic label="Edit Menu - Select All" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Select All" href="reference/ref-57.htm" />
     </context>
     <context id="cell_undo_action_context">
         <description>Undo the previous edit.</description>
-        <topic label="Edit Menu - Undo" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Undo" href="reference/ref-57.htm" />
     </context>
     <context id="cell_redo_action_context">
         <description>Redo the previous edit.</description>
-        <topic label="Edit Menu - Redo" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Redo" href="reference/ref-57.htm" />
     </context>
     <context id="working_set_selection_dialog_context">
-        <description>This dialog allows you to add, remove, or configure working sets for use within the workbench.  A working set is a subset of the workspace.</description>
+        <description>This dialog allows you to add, remove, or configure working sets for use within
+            the workbench. A working set is a subset of the workspace.</description>
     </context>
     <context id="delete_project_dialog_context">
-        <description>This dialog asks you to confirm whether or not you wish to delete the selected project, and if so, whether you wish to also delete the underlying project files on the local file system corresponding to your project.</description>
+        <description>This dialog asks you to confirm whether or not you wish to delete the selected
+            project, and if so, whether you wish to also delete the underlying project files on the
+            local file system corresponding to your project.</description>
     </context>
     <context id="marker_resolution_selection_dialog_context">
         <description>This dialog allows you to select from a list of possible resolutions.</description>
     </context>
     <context id="workbench_editors_dialog">
-        <description>This dialog displays all open editors, allowing you to conveniently choose those you wish to close or save.</description>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
+        <description>This dialog displays all open editors, allowing you to conveniently choose
+            those you wish to close or save.</description>
+        <topic label="Editors" href="concepts/concepts-6.htm" />
     </context>
     <context id="welcome_page_selection_dialog">
-        <description>This dialog allows you to one of the set of available welcome pages. Welcome pages can help you get started using particular parts of the workbench.</description>
+        <description>This dialog allows you to one of the set of available welcome pages. Welcome
+            pages can help you get started using particular parts of the workbench.</description>
     </context>
     <context id="decorators_preference_page_context">
-        <description>This page allows you to specify which decorators you would like to be displayed on items within the workbench. Decorators give you more information about an item, at the expense of visual clutter.</description>
-        <topic label="Preferences - Label decorations" href="reference/ref-decorations.htm"/>
+        <description>This page allows you to specify which decorators you would like to be displayed
+            on items within the workbench. Decorators give you more information about an item, at
+            the expense of visual clutter.</description>
+        <topic label="Preferences - Label decorations" href="reference/ref-decorations.htm" />
     </context>
     <context id="startup_preference_page_context">
-        <description>This page shows you all of the plug-ins that are activated when the workbench starts.</description>
-        <topic label="Preferences - Startup" href="reference/ref-startup.htm"/>
+        <description>This page shows you all of the plug-ins that are activated when the workbench
+            starts.</description>
+        <topic label="Preferences - Startup" href="reference/ref-startup.htm" />
     </context>
     <context id="workspaces_preference_page_context">
-        <description>This page allows you to control the prompting to select a workspace when the workbench starts.</description>
-        <topic label="Preferences - Startup Workspaces" href="reference/ref-startup-workspaces.htm"/>
+        <description>This page allows you to control the prompting to select a workspace when the
+            workbench starts.</description>
+        <topic label="Preferences - Startup Workspaces" href="reference/ref-startup-workspaces.htm" />
     </context>
     <context id="working_set_new_wizard_context">
         <description>This wizard will guide you through the process of creating a working set.</description>
@@ -894,199 +952,208 @@
         <description>This wizard will guide you through the process of editing a working set.</description>
     </context>
     <context id="filters_action_context">
-        <description>Displays a dialog to allow you to select filters to isolate specific elements of the workspace only.</description>
+        <description>Displays a dialog to allow you to select filters to isolate specific elements
+            of the workspace only.</description>
     </context>
     <context id="mark_completed_action_context">
         <description>Marks the currently selected task as &apos;complete&apos;.</description>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="resolve_marker_action_context">
         <description>Displays a dialog to allow you to select from a list of possible resolutions.</description>
     </context>
     <context id="select_all_tasks_action_context">
         <description>Selects all tasks in the task view.</description>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="task_properties_action_context">
         <description>Displays a dialog to allow you to set properties for the selected task.</description>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="back_action_context">
         <description>Move back one frame.</description>
-        <topic label="Project Explorer View" href="concepts/cnav.htm"/>
+        <topic label="Project Explorer View" href="concepts/cnav.htm" />
     </context>
     <context id="forward_action_context">
         <description>Move forward one frame.</description>
-        <topic label="Project Explorer View" href="concepts/cnav.htm"/>
+        <topic label="Project Explorer View" href="concepts/cnav.htm" />
     </context>
     <context id="go_into_action_context">
         <description>Drill down into selected element</description>
-        <topic label="Project Explorer View" href="concepts/cnav.htm"/>
+        <topic label="Project Explorer View" href="concepts/cnav.htm" />
     </context>
     <context id="up_action_context">
         <description>Move up one frame.</description>
-        <topic label="Project Explorer View" href="concepts/cnav.htm"/>
+        <topic label="Project Explorer View" href="concepts/cnav.htm" />
     </context>
     <context id="lock_toolbar_action_context">
         <description>Locks the toolbars within the workbench.</description>
     </context>
     <context id="about_plugins_dialog_context">
         <description>This dialog shows details about all installed plug-ins.</description>
-     	<topic label="Installation Details for Plug-ins" href="tasks/tasks-131.htm" />
-  	</context>
+        <topic label="Installation Details for Plug-ins" href="tasks/tasks-131.htm" />
+    </context>
     <context id="about_features_plugins_dialog_context">
         <description>This dialog shows details about all plug-ins within a particular feature.</description>
         <topic label="Installation Details for Features" href="tasks/tasks-132.htm" />
-      	<topic label="Installation Details for Plug-ins" href="tasks/tasks-131.htm" />
-  	</context>
+        <topic label="Installation Details for Plug-ins" href="tasks/tasks-131.htm" />
+    </context>
     <context id="about_features_dialog_context">
         <description>This dialog shows details about all installed features.</description>
         <topic label="Installation Details for Features" href="tasks/tasks-132.htm" />
-  	 </context>
+    </context>
     <context id="working_set_resource_page">
-        <description>This page allows you to choose the resources that will be part of your working set.</description>
+        <description>This page allows you to choose the resources that will be part of your working
+            set.</description>
     </context>
     <context id="working_set_type_page">
         <description>This page allows you to select the type of working set you want to create.</description>
     </context>
     <context id="copy_bookmark_action_context">
         <description>Copies the selected bookmark to the clipboard.</description>
-        <topic label="Edit Menu - Copy" href="reference/ref-57.htm"/>
-        <topic label="Bookmarks" href="concepts/cbookmrk.htm"/>
+        <topic label="Edit Menu - Copy" href="reference/ref-57.htm" />
+        <topic label="Bookmarks" href="concepts/cbookmrk.htm" />
     </context>
     <context id="paste_bookmark_action_context">
         <description>Pastes the bookmark(s) on the clipboard.</description>
-        <topic label="Edit Menu - Paste" href="reference/ref-57.htm"/>
-        <topic label="Bookmarks" href="concepts/cbookmrk.htm"/>
+        <topic label="Edit Menu - Paste" href="reference/ref-57.htm" />
+        <topic label="Bookmarks" href="concepts/cbookmrk.htm" />
     </context>
     <context id="bookmark_properties_action_context">
         <description>Displays a dialog to allow you to set properties for the selected bookmark.</description>
-        <topic label="Bookmarks" href="concepts/cbookmrk.htm"/>
+        <topic label="Bookmarks" href="concepts/cbookmrk.htm" />
     </context>
     <context id="bookmark_sort_ascending_action_context">
         <description>Sorts bookmarks in ascending order.</description>
-        <topic label="Bookmarks" href="concepts/cbookmrk.htm"/>
+        <topic label="Bookmarks" href="concepts/cbookmrk.htm" />
     </context>
     <context id="bookmark_sort_descending_action_context">
         <description>Sorts bookmarks in descending order.</description>
-        <topic label="Bookmarks" href="concepts/cbookmrk.htm"/>
+        <topic label="Bookmarks" href="concepts/cbookmrk.htm" />
     </context>
     <context id="bookmark_sort_description_action_context">
         <description>Sorts bookmarks by description.</description>
-        <topic label="Bookmarks" href="concepts/cbookmrk.htm"/>
+        <topic label="Bookmarks" href="concepts/cbookmrk.htm" />
     </context>
     <context id="bookmark_sort_resource_action_context">
         <description>Sorts bookmarks by resource.</description>
-        <topic label="Bookmarks" href="concepts/cbookmrk.htm"/>
+        <topic label="Bookmarks" href="concepts/cbookmrk.htm" />
     </context>
     <context id="bookmark_sort_folder_action_context">
         <description>Sorts bookmarks by folder.</description>
-        <topic label="Bookmarks" href="concepts/cbookmrk.htm"/>
+        <topic label="Bookmarks" href="concepts/cbookmrk.htm" />
     </context>
     <context id="bookmark_sort_location_action_context">
         <description>Sorts bookmarks by location.</description>
-        <topic label="Bookmarks" href="concepts/cbookmrk.htm"/>
+        <topic label="Bookmarks" href="concepts/cbookmrk.htm" />
     </context>
     <context id="bookmark_sort_creation_time_action_context">
         <description>Sorts bookmarks by creation time.</description>
-        <topic label="Bookmarks" href="concepts/cbookmrk.htm"/>
+        <topic label="Bookmarks" href="concepts/cbookmrk.htm" />
     </context>
     <context id="resource_navigator_copy_action_context">
         <description>Copies the selected resource to the clipboard.</description>
-        <topic label="Edit Menu - Copy" href="reference/ref-57.htm"/>
-        <topic label="Project Explorer View" href="concepts/cnav.htm"/>
+        <topic label="Edit Menu - Copy" href="reference/ref-57.htm" />
+        <topic label="Project Explorer View" href="concepts/cnav.htm" />
     </context>
     <context id="resource_navigator_paste_action_context">
-        <description>Pastes the resource on the clipboard to the location of the currently selected resource.</description>
-        <topic label="Edit Menu - Paste" href="reference/ref-57.htm"/>
-        <topic label="Project Explorer View" href="concepts/cnav.htm"/>
+        <description>Pastes the resource on the clipboard to the location of the currently selected
+            resource.</description>
+        <topic label="Edit Menu - Paste" href="reference/ref-57.htm" />
+        <topic label="Project Explorer View" href="concepts/cnav.htm" />
     </context>
     <context id="properties_copy_action_context">
         <description>Copies the selected property to the clipboard.</description>
-        <topic label="Edit Menu - Copy" href="reference/ref-57.htm"/>
+        <topic label="Edit Menu - Copy" href="reference/ref-57.htm" />
     </context>
     <context id="copy_task_action_context">
         <description>Copies the selected task to the clipboard.</description>
-        <topic label="Edit Menu - Copy" href="reference/ref-57.htm"/>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Edit Menu - Copy" href="reference/ref-57.htm" />
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="paste_task_action_context">
         <description>Paste the contents of the clipboard at the current cursor position.</description>
-        <topic label="Edit Menu - Paste" href="reference/ref-57.htm"/>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Edit Menu - Paste" href="reference/ref-57.htm" />
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="task_properties_dialog_context">
         <description>This dialog allows you to set properties for the selected task.</description>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="task_sort_type_action_context">
         <description>Sorts tasks by type.</description>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="task_sort_completed_action_context">
         <description>Sorts tasks by completion.</description>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="task_sort_priority_action_context">
         <description>Sorts tasks by priority.</description>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="task_sort_description_action_context">
         <description>Sorts tasks by description.</description>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="task_sort_resource_action_context">
         <description>Sorts tasks by resource.</description>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="task_sort_folder_action_context">
         <description>Sorts tasks by folder.</description>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="task_sort_location_action_context">
         <description>Sorts tasks by location.</description>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="task_sort_creation_time_action_context">
         <description> Sorts tasks by creation time.</description>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="task_sort_ascending_action_context">
         <description>Sorts tasks in ascending order.</description>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="task_sort_descending_action_context">
         <description>Sorts tasks in descending order.</description>
-        <topic label="Tasks View" href="reference/ref-31.htm"/>
+        <topic label="Tasks View" href="reference/ref-31.htm" />
     </context>
     <context id="show_part_pane_menu_action_context">
         <description>Opens the system menu of the active view or editor.</description>
     </context>
     <context id="cycle_part_forward_action_context">
-        <description>Displays a menu which allows you navigate forward through the currently open views.</description>
+        <description>Displays a menu which allows you navigate forward through the currently open
+            views.</description>
     </context>
     <context id="cycle_part_backward_action_context">
-        <description>Displays a menu which allows you navigate backward through the currently open views.</description>
+        <description>Displays a menu which allows you navigate backward through the currently open
+            views.</description>
     </context>
     <context id="cycle_editor_forward_action_context">
-        <description>Displays a menu which allows you navigate forward through the currently open editors.</description>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
+        <description>Displays a menu which allows you navigate forward through the currently open
+            editors.</description>
+        <topic label="Editors" href="concepts/concepts-6.htm" />
     </context>
     <context id="cycle_editor_backward_action_context">
-        <description>Displays a menu which allows you navigate backward through the currently open editors.</description>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
+        <description>Displays a menu which allows you navigate backward through the currently open
+            editors.</description>
+        <topic label="Editors" href="concepts/concepts-6.htm" />
     </context>
     <context id="cycle_perspective_forward_action_context">
-        <description>Displays a menu which allows you navigate forward through the currently open perspectives.</description>
-        <topic label="Perspectives" href="concepts/concepts-4.htm"/>
+        <description>Displays a menu which allows you navigate forward through the currently open
+            perspectives.</description>
+        <topic label="Perspectives" href="concepts/concepts-4.htm" />
     </context>
     <context id="cycle_perspective_backward_action_context">
-        <description>Displays a menu which allows you navigate backward through the currently open perspectives.</description>
-        <topic label="Perspectives" href="concepts/concepts-4.htm"/>
+        <description>Displays a menu which allows you navigate backward through the currently open
+            perspectives.</description>
+        <topic label="Perspectives" href="concepts/concepts-4.htm" />
     </context>
     <context id="activate_editor_action_context">
         <description>Activates the editor pane.</description>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
+        <topic label="Editors" href="concepts/concepts-6.htm" />
     </context>
 
     <!--new context ids-->
@@ -1095,11 +1162,13 @@
     </context>
 
     <context id="goto_next_annotation_action_context">
-        <description>Selects the next annotation in the resource that is currently active in the editor area.</description>
+        <description>Selects the next annotation in the resource that is currently active in the
+            editor area.</description>
     </context>
 
     <context id="goto_previous_annotation_action_context">
-        <description>Selects the previous annotation in the resource that is currently active in the editor area.</description>
+        <description>Selects the previous annotation in the resource that is currently active in the
+            editor area.</description>
     </context>
 
     <context id="ConvertLineDelimitersToMAC_action_context">
@@ -1112,13 +1181,16 @@
         <description>This command converts the file to use Windows line delimiters (CRLF).</description>
     </context>
     <context id="FindIncrementalReverse_action_context">
-        <description>This command enters the incremental find previous mode or goes to the previous match if already in incremental mode. Esc quits the incremental find mode.</description>
+        <description>This command enters the incremental find previous mode or goes to the previous
+            match if already in incremental mode. Esc quits the incremental find mode.</description>
     </context>
     <context id="DeleteLineToBeginning_action_context">
-        <description>This command deletes the text form the current caret position to the beginning of the line.</description>
+        <description>This command deletes the text form the current caret position to the beginning
+            of the line.</description>
     </context>
     <context id="DeleteLineToEnd_action_context">
-        <description>This command deletes the text from the current caret position to the end of the line.</description>
+        <description>This command deletes the text from the current caret position to the end of the
+            line.</description>
     </context>
     <context id="SetMark_action_context">
         <description>This command sets a mark in the editor.</description>
@@ -1133,10 +1205,12 @@
         <description>This command deletes the whole line.</description>
     </context>
     <context id="CutLineToEnd_action_context">
-        <description>This command cuts the text from the current caret position to the end of the line to the clipboard.</description>
+        <description>This command cuts the text from the current caret position to the end of the
+            line to the clipboard.</description>
     </context>
     <context id="JoinLines_action_context">
-        <description>This command joins the selected lines or appends the next line if the selection is empty.</description>
+        <description>This command joins the selected lines or appends the next line if the selection
+            is empty.</description>
     </context>
     <context id="ClearMark_action_context">
         <description>This command clears the previously set mark in the editor.</description>
@@ -1145,13 +1219,15 @@
         <description>Swaps the current curet position with the previously set mark.</description>
     </context>
     <context id="FindIncremental_action_context">
-        <description>This command enters the incremental find mode or goes to the next match if already in incremental mode. Esc quits the incremental find mode.</description>
+        <description>This command enters the incremental find mode or goes to the next match if
+            already in incremental mode. Esc quits the incremental find mode.</description>
     </context>
     <context id="FindPrevious_action_context">
         <description>This command finds the previous match in the editor.</description>
     </context>
     <context id="CutLineToBeginning_action_context">
-        <description>This command cuts the text from the current caret position to the beginning of the line to the clipboard.</description>
+        <description>This command cuts the text from the current caret position to the beginning of
+            the line to the clipboard.</description>
     </context>
     <context id="US-ASCII_action_context">
         <description>This command sets the encoding to US-ASCII.</description>
@@ -1182,38 +1258,40 @@
     </context>
     <context id="text_editor_preference_page_context">
         <description>This preference page is used to set preferences for the text editor.</description>
-        <topic label="Preferences - Text Editor" href="reference/ref-texteditorprefs.htm"/>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
+        <topic label="Preferences - Text Editor" href="reference/ref-texteditorprefs.htm" />
+        <topic label="Editors" href="concepts/concepts-6.htm" />
     </context>
     <context id="accessibility_preference_page_context">
         <description>On this page you can configure the text editor's accessibility preferences.</description>
-        <topic label="Accessibility preference page" href="reference/ref-7.htm"/>
-        <topic label="Accessibility features in textual editors" href="concepts/accessibility/text_editor.htm"/>
-        <topic label="Accessibility in Eclipse" href="concepts/accessibility/accessmain.htm"/>
-        <topic label="Preferences - Text Editor" href="reference/ref-texteditorprefs.htm"/>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
+        <topic label="Accessibility preference page" href="reference/ref-7.htm" />
+        <topic label="Accessibility features in textual editors"
+            href="concepts/accessibility/text_editor.htm" />
+        <topic label="Accessibility in Eclipse" href="concepts/accessibility/accessmain.htm" />
+        <topic label="Preferences - Text Editor" href="reference/ref-texteditorprefs.htm" />
+        <topic label="Editors" href="concepts/concepts-6.htm" />
     </context>
     <context id="spelling_preference_page_context">
-        <description>On this page you can indicate your spelling preferences.
-
-<b>Hint</b>: If your preferred language is not available as <b>Platform dictionary</b> choose <b>none</b> and then search the internet for a word list with the words of your preferred language and set it as <b>User defined dictionary</b>.
-</description>
-        <topic label="Preferences - Text Editor" href="reference/ref-texteditorprefs.htm"/>
-        <topic label="Editors" href="concepts/concepts-6.htm"/>
+        <description>On this page you can indicate your spelling preferences. <b>Hint</b>: If your
+            preferred language is not available as <b>Platform dictionary</b> choose <b>none</b> and
+            then search the internet for a word list with the words of your preferred language and
+            set it as <b>User defined dictionary</b>. </description>
+        <topic label="Preferences - Text Editor" href="reference/ref-texteditorprefs.htm" />
+        <topic label="Editors" href="concepts/concepts-6.htm" />
     </context>
     <context id="content_assist_action_context">
         <description>This command opens content assist.</description>
-        <topic label="Edit actions" href="reference/ref-menu-edit.htm"/>
+        <topic label="Edit actions" href="reference/ref-menu-edit.htm" />
     </context>
     <context id="content_assist_context_information_action_context">
         <description>This command shows content assist context information.</description>
-        <topic label="Edit actions" href="reference/ref-menu-edit.htm"/>
+        <topic label="Edit actions" href="reference/ref-menu-edit.htm" />
     </context>
     <context id="quick_assist_action_context">
         <description>This command provides quick assists and quick fixes.</description>
     </context>
     <context id="show_information_action_context">
-        <description>This command displays information for the current caret location in a sticky hover.</description>
+        <description>This command displays information for the current caret location in a sticky
+            hover.</description>
     </context>
     <context id="show_whitepsace_characters_action_context">
         <description>This command allows to show whitespace characters in the editor.</description>
@@ -1223,78 +1301,92 @@
     </context>
     <context id="templates_view_context">
         <description>The Templates view shows the templates for the active editor.</description>
-        <topic label="Templates view" href="reference/ref-templates-view.htm"/>
+        <topic label="Templates view" href="reference/ref-templates-view.htm" />
     </context>
-
-     <context id="tips_and_tricks_page_selection_dialog">
+    <context id="tips_and_tricks_page_selection_dialog">
         <description>This dialog allows you to open a feature specific tips and tricks page.</description>
-        <topic label="Help Menu - Tips and Tricks" href="reference/ref-61.htm"/>
+        <topic label="Help Menu - Tips and Tricks" href="reference/ref-61.htm" />
     </context>
-	<!-- Help Menu: Help Contents -->
-    <context  id="help_contents_action_context" >
-        <description>This command displays the help view. The help view contains help books, topics, and information related to the workbench and installed components.</description>
-        <topic label="Help" href="/org.eclipse.platform.doc.user/concepts/help.htm"/>
-        <topic label="Help Menu - Help Contents" href="/org.eclipse.platform.doc.user/reference/ref-61.htm"/>
+    <!-- Help Menu: Help Contents -->
+    <context id="help_contents_action_context">
+        <description>This command displays the help view. The help view contains help books, topics,
+            and information related to the workbench and installed components.</description>
+        <topic label="Help" href="/org.eclipse.platform.doc.user/concepts/help.htm" />
+        <topic label="Help Menu - Help Contents"
+            href="/org.eclipse.platform.doc.user/reference/ref-61.htm" />
     </context>
-    <context  id="help_search_action_context" >
+    <context id="help_search_action_context">
         <description>This command displays the help view opened on the search page.</description>
-        <topic label="Searching help" href="/org.eclipse.platform.doc.user/tasks/help_search.htm"/>
-        <topic label="Help Menu - Search" href="/org.eclipse.platform.doc.user/reference/ref-61.htm"/>
+        <topic label="Searching help" href="/org.eclipse.platform.doc.user/tasks/help_search.htm" />
+        <topic label="Help Menu - Search" href="/org.eclipse.platform.doc.user/reference/ref-61.htm" />
     </context>
-   <!-- Browser support: Help Contents -->
+    <!-- Browser support: Help Contents -->
     <context id="browser_preference_page_context">
-        <description>This preference page is used to set preferences for launching Web browsers from the workbench.</description>
-        <topic label="Web Browser preferences" href="/org.eclipse.platform.doc.user/reference/ref-42.htm"/>
+        <description>This preference page is used to set preferences for launching Web browsers from
+            the workbench.</description>
+        <topic label="Web Browser preferences"
+            href="/org.eclipse.platform.doc.user/reference/ref-42.htm" />
     </context>
     <context id="browser_preference_page_dialog_context">
-        <description>This dialog allows you to modify the properties of an externally launched browser.</description>
+        <description>This dialog allows you to modify the properties of an externally launched
+            browser.</description>
     </context>
     <context id="browser_context">
-        <description>This view allows you to display web pages. By default, it is used to display web pages when they are opened from the workbench. You can modify this setting in the Web Browser preferences available from the link below.</description>
-        <topic label="Web Browser preferences" href="/org.eclipse.platform.doc.user/reference/ref-42.htm"/>
+        <description>This view allows you to display web pages. By default, it is used to display
+            web pages when they are opened from the workbench. You can modify this setting in the
+            Web Browser preferences available from the link below.</description>
+        <topic label="Web Browser preferences"
+            href="/org.eclipse.platform.doc.user/reference/ref-42.htm" />
     </context>
     <context id="import_type_dialog">
-        <description>This dialog allows you to customize how a file and folder hierarchy is recreated in a project.</description>
+        <description>This dialog allows you to customize how a file and folder hierarchy is
+            recreated in a project.</description>
     </context>
-    <context id="project_explorer_customization_dialog" title="Project Explorer View Customization Dialog">
-       <description>This dialog allows you to set filters and select content for the Project Explorer.</description>
-       <topic href="tasks/tasks-48b.htm" label="Project Explorer Customization Dialog"/>
+    <context id="project_explorer_customization_dialog"
+        title="Project Explorer View Customization Dialog">
+        <description>This dialog allows you to set filters and select content for the Project
+            Explorer.</description>
+        <topic href="tasks/tasks-48b.htm" label="Project Explorer Customization Dialog" />
     </context>
     <context id="project_explorer_context" title="Project Explorer">
-       <description>The Project Explorer allows you to navigate the contents of your workspace.</description>
-       <topic label="Project Explorer" href="reference/ref-27.htm"/>
-       <topic label="Views" href="concepts/concepts-5.htm"/>
+        <description>The Project Explorer allows you to navigate the contents of your workspace.</description>
+        <topic label="Project Explorer" href="reference/ref-27.htm" />
+        <topic label="Views" href="concepts/concepts-5.htm" />
     </context>
     <context id="open_hyperlink_action_context">
-       <description>Opens a hyperlink at the current caret location.</description>
-       <topic href="reference/ref-58.htm" label="Navigate Menu - Open Hyperlink"/>
+        <description>Opens a hyperlink at the current caret location.</description>
+        <topic href="reference/ref-58.htm" label="Navigate Menu - Open Hyperlink" />
     </context>
     <context id="error_log">
-		<description>The error log view captures warnings and internal errors thrown by the internal platform or your code.</description>
-		<topic label="Error Log" href="reference/ref-error_log_view.htm"/>
-	</context>
-	<context id="log_eventdetails">
-		<description>This dialog shows detailed information about a logged event.</description>
-		<topic label="Error Log" href="reference/ref-error_log_view.htm"/>
-	</context>
-	<context id="log_filter">
-		<description>This dialog allows you to filter the Error Log view.</description>
-		<topic label="Error Log" href="reference/ref-error_log_view.htm"/>
-	</context>
-	<context id="tracing_preference_page">
-		<description>The tracing preference page allows you to dynamically change the tracing options of plug-ins and output settings.</description>
-		<topic label="Tracing preference page" href="reference/ref-tracing_preference_page.htm"/>
-	</context>
-	<context id="uiresponsiveness_preference_page">
-		<description>The UI Responsiveness Monitoring preference page allows you to enable automatic detection of UI freezes and to modify parameters affecting freeze detection and logging.</description>
-		<topic label="UI Responsiveness Monitoring preference page" href="reference/ref-uiresponsiveness_preference_page.htm"/>
-	</context>
-	<context id="globalization_preference_page_context">
-		<description>Allows you to configure Bidi and other globalization preferences.</description>
-		<topic label="Preferences - Globalization" href="reference/ref-globalizationprefs.htm"/>
-	</context>
-	<context id="link_handlers_page_context">
-		<description>This preference page is used to enable and disable link handlers.</description>
-		<topic label="Preferences - Link Handlers" href="reference/ref-linkhandlersprefs.htm"/>
-	</context>
+        <description>The error log view captures warnings and internal errors thrown by the internal
+            platform or your code.</description>
+        <topic label="Error Log" href="reference/ref-error_log_view.htm" />
+    </context>
+    <context id="log_eventdetails">
+        <description>This dialog shows detailed information about a logged event.</description>
+        <topic label="Error Log" href="reference/ref-error_log_view.htm" />
+    </context>
+    <context id="log_filter">
+        <description>This dialog allows you to filter the Error Log view.</description>
+        <topic label="Error Log" href="reference/ref-error_log_view.htm" />
+    </context>
+    <context id="tracing_preference_page">
+        <description>The tracing preference page allows you to dynamically change the tracing
+            options of plug-ins and output settings.</description>
+        <topic label="Tracing preference page" href="reference/ref-tracing_preference_page.htm" />
+    </context>
+    <context id="uiresponsiveness_preference_page">
+        <description>The UI Responsiveness Monitoring preference page allows you to enable automatic
+            detection of UI freezes and to modify parameters affecting freeze detection and logging.</description>
+        <topic label="UI Responsiveness Monitoring preference page"
+            href="reference/ref-uiresponsiveness_preference_page.htm" />
+    </context>
+    <context id="globalization_preference_page_context">
+        <description>Allows you to configure Bidi and other globalization preferences.</description>
+        <topic label="Preferences - Globalization" href="reference/ref-globalizationprefs.htm" />
+    </context>
+    <context id="link_handlers_page_context">
+        <description>This preference page is used to enable and disable link handlers.</description>
+        <topic label="Preferences - Link Handlers" href="reference/ref-linkhandlersprefs.htm" />
+    </context>
 </contexts>


### PR DESCRIPTION
Adds a help context for the find/replace overlay which links to the help context for the dialog.

related to
https://github.com/eclipse-platform/eclipse.platform.ui/pull/2045