### PR TITLE
Drop explicit inlineJSR param to tycho

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -446,7 +446,6 @@
           <configuration>
             <compilerArgs>
               <args>-verbose</args>
-              <args>-inlineJSR</args>
               <args>-enableJavadoc</args>
               <args>-encoding</args>
               <args>${project.build.sourceEncoding}</args>


### PR DESCRIPTION
It's implicit for ECJ when target>=1.5 , aggregator no longer compiles anything to target < 1.5 and ecj is dropping support for target<1.8.