### PR TITLE
Fix licensecheck run

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -18,7 +18,7 @@ jobs:
   call-license-check:
     permissions:
       pull-requests: write
-    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
+    uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
     with:
       projectId: eclipse.platform
       submodules: recursive


### PR DESCRIPTION
As dash project is its own github org the path to the workflow file changes.