### PR TITLE
Latest jarsign service produces CODESIGN.SF/RSA not ECLIPSE_.SF/RSA

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -550,6 +550,8 @@
             <ignoredPatterns>
               <pattern>META-INF/ECLIPSE_.RSA</pattern>
               <pattern>META-INF/ECLIPSE_.SF</pattern>
+              <pattern>META-INF/CODESIGN.RSA</pattern>
+              <pattern>META-INF/CODESIGN.SF</pattern>
             </ignoredPatterns>
             <generateDownloadStatsProperty>true</generateDownloadStatsProperty>
           </configuration>


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2193