### PR TITLE
Remove o.e.core.filesystem.win32.x86_64 fragment from o.e.platform feature

### DIFF
--- a/eclipse.platform.releng/features/org.eclipse.platform-feature/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.platform-feature/feature.xml
@@ -218,12 +218,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.core.filesystem.win32.x86_64"
-         os="win32"
-         arch="x86_64"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.core.filesystem.linux.ppc64le"
          os="linux"
          arch="ppc64le"

--- a/eclipse.platform.releng/features/org.eclipse.platform-feature/pom.xml
+++ b/eclipse.platform.releng/features/org.eclipse.platform-feature/pom.xml
@@ -57,7 +57,6 @@
                 <plugin id="org.eclipse.platform.doc.user"/>
                 <plugin id="org.eclipse.core.filesystem.linux.x86_64"/>
                 <plugin id="org.eclipse.core.filesystem.macosx"/>
-                <plugin id="org.eclipse.core.filesystem.win32.x86_64"/>
                 <plugin id="org.eclipse.core.filesystem.linux.ppc64le"/>
               </excludes>
             </configuration>


### PR DESCRIPTION
That fragment is removed viahttps://github.com/eclipse-platform/eclipse.platform/pull/1476