### PR TITLE
Add workflow that automatically updates target dependencies

### DIFF
--- a/.github/workflows/updateTarget.yml
+++ b/.github/workflows/updateTarget.yml
@@ -1,0 +1,38 @@
+name: Update Target Platform
+
+on:
+  schedule:
+    - cron:  '0 0 * * *'
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        fetch-depth: 0
+        ref: master
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
+      with:
+        maven-version: 3.9.7
+    - name: Set up JDK
+      uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Update Target Platform
+      run: >-
+          mvn -f eclipse.platform.releng.prereqs.sdk 
+          org.eclipse.tycho.extras:tycho-version-bump-plugin:4.0.9-SNAPSHOT:update-target
+          -Dtarget=eclipse-sdk-prereqs.target
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
+      with:
+        commit-message: Update target-platform with latest version
+        branch: update_target
+        title: Dependency Updates
+        body: Please review the changes and merge if appropriate.
+        delete-branch: true
+        add-paths: |
+            **/*.target


### PR DESCRIPTION
Currently we need to keep track of new versions manually what can become quite cumbersome.

This creates an (experimental) automatic job that is triggered each day and check if there are updates available and suggests a PR to update them.