### PR TITLE
Markdown support for JEP 467 - extension for tables

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -49,6 +49,7 @@
 
       <!-- Markdown support for JEP 467 -->
       <unit id="org.commonmark" version="0.22.0.v20240316-0700"/>
+      <unit id="org.commonmark-gfm-tables" version="0.22.0.v20240316-0700"/>
 
       <!-- This is the "normal" Orbit repository is expected to be updated on milestones and releases based on Orbit deliveries. -->
       <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202407231258"/>


### PR DESCRIPTION
+ add extension for rendering tables

Follow-up from #2190, as required by https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1472 based on https://openjdk.org/jeps/467#Tables
