### PR TITLE
Add a ruleset for updating dependencies

### DIFF
--- a/.github/workflows/updateTarget.yml
+++ b/.github/workflows/updateTarget.yml
@@ -25,8 +25,9 @@ jobs:
       run: >-
           mvn -f eclipse.platform.releng.prereqs.sdk 
           org.eclipse.tycho.extras:tycho-version-bump-plugin:4.0.9-SNAPSHOT:update-target
-          -Dmajor=false
+          -DallowMajorUpdates=false
           -Ddiscovery=parent
+          -Dmaven.version.rules=update-rules.xml
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
       with:

--- a/eclipse.platform.releng.prereqs.sdk/update-rules.xml
+++ b/eclipse.platform.releng.prereqs.sdk/update-rules.xml
@@ -1,0 +1,17 @@
+<ruleset comparisonMethod="maven"
+	xmlns="https://www.mojohaus.org/VERSIONS/RULE/2.1.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="https://www.mojohaus.org/VERSIONS/RULE/2.1.0 https://www.mojohaus.org/versions/versions-model/xsd/rule-2.1.0.xsd">
+	<!-- see https://www.mojohaus.org/versions/versions-maven-plugin/version-rules.html -->
+	<ignoreVersions>
+		<ignoreVersion type="regex">.+-(alpha|beta|M)\d*$</ignoreVersion>
+	</ignoreVersions>
+	
+	<rules>
+		<rule groupId="jakarta.inject" comparisonMethod="maven">
+			<ignoreVersions>
+				<ignoreVersion>2.0.1.MR</ignoreVersion>
+			</ignoreVersions>
+		</rule>
+	</rules>
+</ruleset>


### PR DESCRIPTION
This adds a ruleset so we can ignore unwanted versions (beside major updates) from being suggested by the update-target workflow.

This first requires
- https://github.com/eclipse-tycho/tycho/pull/4130

what currently is blocked by IP issue:
- https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/15947