### PR TITLE
Update Orbit dependencies

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -52,7 +52,7 @@
       <unit id="org.commonmark-gfm-tables" version="0.22.0.v20240316-0700"/>
 
       <!-- This is the "normal" Orbit repository is expected to be updated on milestones and releases based on Orbit deliveries. -->
-      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202408130653"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202408200619"/>
     </location>
 
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
@@ -133,7 +133,7 @@
 			  <dependency>
 				  <groupId>commons-logging</groupId>
 				  <artifactId>commons-logging</artifactId>
-				  <version>1.3.3</version>
+				  <version>1.3.4</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>


### PR DESCRIPTION
- Update commons-logging to 1.3.4.
- The orbit repository contains no changes to the included IUs.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2166