### PR TITLE
Add 'incompatibilities' entry about inlined native fragments

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.32/incompatibilities.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.32/incompatibilities.html
@@ -20,5 +20,28 @@
 See also the list of <a href="../removals.html">deprecated API removals</a> for this release.
 </p>
 
+<ol>
+<li><a href="#upstream-bundles">Several bundles renamed for 3rd party libraries</a></li>
+</ol>
+
+<hr>
+
+<!-- ############################################## -->
+
+<h2>1. <a name="native-fragments-merge">Multiple platform-specific fragments merged into their host</a></h2>
+<p>
+	The following platform-specific fragments have been merged into their respective host bundle:
+	<ul>
+		<li><code>org.eclipse.core.resources.win32.win32.x86_64</code></li>
+		<li><code>org.eclipse.core.filesystem.win32.x86_64</code></li>
+		<li><code>org.eclipse.core.net.linux</code></li>
+		<li><code>org.eclipse.core.net.win32</code></li>
+	</ul>
+</p>
+<p>
+	All functionality formerly provided through these platform-specific fragments is now provided by the fragment's host bundle alone and no code change is required.
+	If any of the mentioned fragments is referenced in a PDE <em>feature.xml</em> or listed as content of a product definition it just has to be removed.
+</p>
+
 </body>
 </html>


### PR DESCRIPTION
To inform about changes in
- https://github.com/eclipse-platform/eclipse.platform/pull/1394
- https://github.com/eclipse-platform/eclipse.platform/pull/1476
- https://github.com/eclipse-platform/eclipse.platform/pull/1440

@akurtakov I think this is the right thing to do, isn't it?