### PR TITLE
Update Latest ECJ Version for RC2

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -86,7 +86,7 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cbi-jdt-repo.url>https://repo.eclipse.org/content/repositories/eclipse-staging/</cbi-jdt-repo.url>
-    <cbi-ecj-version>3.39.0.v20240807-1629</cbi-ecj-version>
+    <cbi-ecj-version>3.39.0.v20240820-0604</cbi-ecj-version>
 
     <!--
       repo for released versions of CBI. Note, we intentionally use as specific a repo as possible.


### PR DESCRIPTION
3.39.0.v20240820-0604 Need to run https://ci.eclipse.org/jdt/job/copyAndDeployJDTCompiler/