### PR TITLE
Migration Guide Eclipse 4.33

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/4.33/faq.html
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/4.33/faq.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2024 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../../book.css" charset="ISO-8859-1" type="text/css">
+<title>Eclipse JDT 4.33 Plug-in Migration FAQ</title>
+</head>
+
+<body>
+
+<h1>Eclipse JDT 4.33 Plug-in Migration FAQ</h1>
+
+<ol>
+	<li>None</li>
+</ol>
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/4.33/incompatibilities.html
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/4.33/incompatibilities.html
@@ -1,0 +1,19 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2024 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../../book.css" type="text/css">
+<title>Incompatibilities between Eclipse 4.32 and 4.33</title>
+</head>
+<body>
+<h1>Incompatibilities between Eclipse 4.32 and 4.33</h1>
+
+<p>
+  So far Eclipse did not change incompatibly between 4.32 and 4.33 in ways that affect
+  plug-ins. Plug-ins that ran on 4.32 should run on 4.33 without any problems.
+</p>
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/4.33/recommended.html
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/4.33/recommended.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2024 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../../book.css" charset="ISO-8859-1" type="text/css">
+<title>Adopting JDT 4.33 mechanisms and APIs</title>
+</head>
+
+<body>
+
+<h1>Adopting JDT 4.33 mechanisms and APIs</h1>
+<p>
+  This section describes changes that are required if you are trying to change
+  your 4.32 plug-in to adopt the 4.33 mechanisms and APIs.
+</p>
+
+<ol>
+	<li>None</li>
+</ol>
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/eclipse_4_33_porting_guide.html
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/eclipse_4_33_porting_guide.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+
+<head>
+
+<meta name="copyright" content="Copyright (c) IBM 2024 Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
+<title>Eclipse JDT 4.33 Plug-in Migration Guide</title>
+</head>
+
+<body>
+
+<h1>Eclipse JDT 4.33 Plug-in Migration Guide</h1>
+<p>This guide covers migrating Eclipse JDT 4.32 plug-ins to Eclipse JDT 4.33.</p>
+<p>One of the goals of Eclipse 4.33 was to move Eclipse forward while remaining compatible
+  with previous versions to the greatest extent possible. That is, plug-ins written
+  against the Eclipse 4.32 APIs should continue to work in 4.33 in spite of the
+  API changes.</p>
+<p>The key kinds of compatibility are API contract compatibility and binary compatibility.
+  API contract compatibility means that valid use of 4.32 APIs remains valid for
+  4.33, so there is no need to revisit working code. Binary compatibility means
+  that the API method signatures, etc. did not change in ways that would cause
+  existing compiled (&quot;binary&quot;) code to no longer link and run with the
+  new 4.33 libraries.</p>
+<p>While every effort was made to avoid breakage, there are a few areas of incompatibility or new
+  APIs that should be adopted by clients.
+  This document describes those areas and provides instructions for migrating 4.32 plug-ins to
+  4.33.</p>
+<ul>
+  <li><a href="4.33/faq.html">Eclipse JDT 4.33 Plug-in Migration FAQ</a></li>
+  <li><a href="4.33/incompatibilities.html">Incompatibilities between Eclipse JDT 4.32 and 4.33</a></li>
+  <li><a href="4.33/recommended.html">Adopting 4.33 mechanisms and API</a></li>
+</ul>
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/topics_Porting.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/topics_Porting.xml
@@ -4,6 +4,12 @@
 <!-- Define topics for the porting guide index                                     -->
 <!-- ============================================================================= -->
 <toc label="Migration">
+	<topic label="Migrating to Eclipse JDT 4.33 from 4.32">
+		<topic label="Introduction" href="porting/eclipse_4_33_porting_guide.html"/>
+		<topic label="FAQ"                             href="porting/4.33/faq.html" />
+		<topic label="Incompatibilities"               href="porting/4.33/incompatibilities.html" />
+		<topic label="Adopting 4.33 Mechanisms and API" href="porting/4.33/recommended.html" />
+	</topic>
 	<topic label="Migrating to Eclipse JDT 4.32 from 4.31">
 		<topic label="Introduction" href="porting/eclipse_4_32_porting_guide.html"/>
 		<topic label="FAQ"                             href="porting/4.32/faq.html" />

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.33/faq.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.33/faq.html
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2024 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../../book.css" charset="ISO-8859-1" type="text/css">
+<title>Eclipse 4.33 Plug-in Migration FAQ</title>
+</head>
+<body>
+<h1>Eclipse 4.33 Plug-in Migration FAQ</h1>
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.33/incompatibilities.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.33/incompatibilities.html
@@ -1,0 +1,47 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2024 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../../book.css" type="text/css">
+<title>Incompatibilities between Eclipse 4.32 and 4.33</title>
+</head>
+<body>
+<h1>Incompatibilities between Eclipse 4.32 and 4.33</h1>
+
+<p>
+  Eclipse changed in incompatible ways between 4.32 and 4.33 in ways that affect
+  plug-ins. The following entries describe the areas that changed and provide
+  instructions for migrating 4.32 plug-ins to 4.33. Note that you only need to look
+  here if you are experiencing problems running your 4.32 plug-in on 4.33.
+</p>
+<p>
+See also the list of <a href="../removals.html">deprecated API removals</a> for this release.
+</p>
+
+<ol>
+<li><a href="#upstream-bundles">Several bundles renamed for 3rd party libraries</a></li>
+</ol>
+
+<hr>
+
+<!-- ############################################## -->
+
+<h2>1. <a name="native-fragments-merge">Multiple platform-specific fragments merged into their host</a></h2>
+<p>
+	The following platform-specific fragments have been merged into their respective host bundle:
+	<ul>
+		<li><code>org.eclipse.core.resources.win32.win32.x86_64</code></li>
+		<li><code>org.eclipse.core.filesystem.win32.x86_64</code></li>
+		<li><code>org.eclipse.core.net.linux</code></li>
+		<li><code>org.eclipse.core.net.win32</code></li>
+	</ul>
+</p>
+<p>
+	All functionality formerly provided through these platform-specific fragments is now provided by the fragment's host bundle alone and no code change is required.
+	If any of the mentioned fragments is referenced in a PDE <em>feature.xml</em> or listed as content of a product definition it just has to be removed.
+</p>
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.33/recommended.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.33/recommended.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+
+<head>
+	<meta name="copyright"
+		content="Copyright (c) 2024 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+	<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+	<meta http-equiv="Content-Style-Type" content="text/css">
+	<link rel="STYLESHEET" href="../../book.css" type="text/css">
+	<title>Adopting 4.33 mechanisms and APIs</title>
+</head>
+
+<body>
+	<h1>Adopting 4.33 mechanisms and APIs</h1>
+
+	<p>This section describes changes that are required if you are
+		trying to change your 4.32 plug-in to adopt the 4.33 mechanisms and
+		APIs.</p>
+
+	<!-- ##############################################
+	 ############################################## -->
+
+</body>
+
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/eclipse_4_33_porting_guide.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/eclipse_4_33_porting_guide.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2024 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
+<title>Eclipse 4.33 Plug-in Migration Guide</title>
+</head>
+
+<body>
+
+<h1>Eclipse 4.33 Plug-in Migration Guide</h1>
+<p>This guide covers migrating Eclipse 4.32 plug-ins to Eclipse 4.33.</p>
+<p>One of the goals of Eclipse 4.33 was to move Eclipse forward while remaining compatible
+  with previous versions to the greatest extent possible. That is, plug-ins written
+  against the Eclipse 4.32 APIs should continue to work in 4.33 in spite of any API changes.</p>
+<p>The key kinds of compatibility are API contract compatibility and binary compatibility.
+  API contract compatibility means that valid use of 4.32 APIs remains valid for
+  4.33, so there is no need to revisit working code. Binary compatibility means
+  that the API method signatures, etc. did not change in ways that would cause
+  existing compiled (&quot;binary&quot;) code to no longer link and run with the
+  new 4.33 libraries.</p>
+<p>While every effort was made to avoid breakage, there are a few areas of incompatibility or new
+  APIs that should be adopted by clients.
+  This document describes those areas and provides instructions for migrating 4.32 plug-ins to
+  4.33.</p>
+<ul>
+  <li><a href="4.33/faq.html">Eclipse 4.33 Plug-in Migration FAQ</a></li>
+  <li><a href="4.33/incompatibilities.html">Incompatibilities between Eclipse 4.32 and 4.33</a></li>
+  <li><a href="4.33/recommended.html">Adopting 4.33 mechanisms and API</a></li>
+</ul>
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/topics_Porting.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/topics_Porting.xml
@@ -5,6 +5,12 @@
 <!-- ============================================================================= -->
 <toc label="Migration">
 	<topic label="Deprecated API removals" href="porting/removals.html"/>
+	<topic label="Migrating to Eclipse 4.33 from 4.32">
+		<topic label="Introduction" href="porting/eclipse_4_33_porting_guide.html"/>
+		<topic label="FAQ" href="porting/4.33/faq.html" />
+		<topic label="Incompatibilities" href="porting/4.33/incompatibilities.html" />
+		<topic label="Adopting 4.32 mechanisms and API" href="porting/4.33/recommended.html" />
+	</topic>
 	<topic label="Migrating to Eclipse 4.32 from 4.31">
 		<topic label="Introduction" href="porting/eclipse_4_32_porting_guide.html"/>
 		<topic label="FAQ" href="porting/4.32/faq.html" />


### PR DESCRIPTION
Migration guide for Eclipse 4.33 from 4.32