### PR TITLE
Update P build scripts to Java 23

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/java23patch/eclipse.releng.repository.java23patch/category.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/java23patch/eclipse.releng.repository.java23patch/category.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature id="org.eclipse.jdt.java22patch" version="0.0.0" patch="true">
-      <category name="Eclipse Java 22 support for 2024-03 development stream"/>
+   <feature id="org.eclipse.jdt.java23patch" version="0.0.0" patch="true">
+      <category name="Eclipse Java 23 support for 2024-09 development stream"/>
    </feature>
-   <feature id="org.eclipse.jdt.java22patch.source" version="0.0.0" patch="true">
-      <category name="Eclipse Java 22 support for 2024-03 development stream"/>
+   <feature id="org.eclipse.jdt.java23patch.source" version="0.0.0" patch="true">
+      <category name="Eclipse Java 23 support for 2024-09 development stream"/>
    </feature>
-   <category-def name="Eclipse Java 22 support for 2024-03 development stream" label="Eclipse Java 22 support for 2024-03 development stream">
+   <category-def name="Eclipse Java 23 support for 2024-09 development stream" label="Eclipse Java 23 support for 2024-09 development stream">
       <description>
-         Eclipse Java 22 support for 2024-03 development stream.
+         Eclipse Java 23 support for 2024-09 development stream.
       </description>
    </category-def>
 </site>

--- a/eclipse.platform.releng.tychoeclipsebuilder/java23patch/eclipse.releng.repository.java23patch/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/java23patch/eclipse.releng.repository.java23patch/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2023 Eclipse Foundation and others.
+  Copyright (c) 2023, 2024 Eclipse Foundation and others.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
@@ -16,13 +16,13 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.platform.releng</groupId>
-    <artifactId>eclipse.platform.releng.java22patch</artifactId>
+    <artifactId>eclipse.platform.releng.java23patch</artifactId>
     <version>4.33.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
   <groupId>eclipse.platform.releng</groupId>
-  <artifactId>eclipse.releng.repository.java22patch</artifactId>
+  <artifactId>eclipse.releng.repository.java23patch</artifactId>
   <version>1.2.300-SNAPSHOT</version>
   <packaging>eclipse-repository</packaging>
 
@@ -158,7 +158,7 @@
         <version>${tycho.version}</version>
         <executions>
           <execution>
-            <id>categories-java22patch</id>
+            <id>categories-java23patch</id>
             <phase>package</phase>
             <goals>
               <goal>publish-categories</goal>
@@ -175,18 +175,18 @@
         </configuration>
         <executions>
           <execution>
-            <id>assemble-java22patch</id>
+            <id>assemble-java23patch</id>
             <phase>package</phase>
             <configuration>
-              <repositoryName>Java 22 support</repositoryName>
-              <finalName>Java22PatchRepo</finalName>
+              <repositoryName>Java 23 support</repositoryName>
+              <finalName>Java23PatchRepo</finalName>
             </configuration>
             <goals>
               <goal>assemble-repository</goal>
             </goals>
           </execution>
           <execution>
-            <id>archive-java22patch</id>
+            <id>archive-java23patch</id>
             <phase>pre-integration-test</phase>
             <configuration>
               <repositoryName>Java 22 support</repositoryName>

--- a/eclipse.platform.releng.tychoeclipsebuilder/java23patch/org.eclipse.jdt-feature-dummy/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/java23patch/org.eclipse.jdt-feature-dummy/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2023 Eclipse Foundation and others.
+  Copyright (c) 2023, 2024 Eclipse Foundation and others.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
@@ -13,7 +13,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.platform.releng</groupId>
-    <artifactId>eclipse.platform.releng.java22patch</artifactId>
+    <artifactId>eclipse.platform.releng.java23patch</artifactId>
     <version>4.33.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jdt.feature</groupId>

--- a/eclipse.platform.releng.tychoeclipsebuilder/java23patch/org.eclipse.jdt.dummy/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/java23patch/org.eclipse.jdt.dummy/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2023 Eclipse Foundation and others.
+  Copyright (c) 2023, 2024 Eclipse Foundation and others.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
@@ -13,7 +13,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.platform.releng</groupId>
-    <artifactId>eclipse.platform.releng.java22patch</artifactId>
+    <artifactId>eclipse.platform.releng.java23patch</artifactId>
     <version>4.33.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jdt</groupId>

--- a/eclipse.platform.releng.tychoeclipsebuilder/java23patch/org.eclipse.jdt.java23patch/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/java23patch/org.eclipse.jdt.java23patch/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2023 Eclipse Foundation and others.
+  Copyright (c) 2023, 2024 Eclipse Foundation and others.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
@@ -16,11 +16,11 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.platform.releng</groupId>
-    <artifactId>eclipse.platform.releng.java21patch</artifactId>
+    <artifactId>eclipse.platform.releng.java23patch</artifactId>
     <version>4.33.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jdt.feature</groupId>
-  <artifactId>org.eclipse.jdt.java22patch</artifactId>
+  <artifactId>org.eclipse.jdt.java23patch</artifactId>
   <version>1.2.300-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 

--- a/eclipse.platform.releng.tychoeclipsebuilder/java23patch/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/java23patch/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2023 Eclipse Foundation and others.
+  Copyright (c) 2023, 2024 Eclipse Foundation and others.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@
   </parent>
 
   <groupId>eclipse.platform.releng</groupId>
-  <artifactId>eclipse.platform.releng.java21patch</artifactId>
+  <artifactId>eclipse.platform.releng.java23patch</artifactId>
   <version>4.33.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
@@ -41,7 +41,7 @@
     <module>../../eclipse.jdt.ui/org.eclipse.jdt.ui</module>
     <module>../../eclipse.jdt.ui/org.eclipse.jdt.core.manipulation</module>
     <module>../../eclipse.jdt.ui/org.eclipse.jdt.astview</module>
-    <module>org.eclipse.jdt.java21patch</module>
-    <module>eclipse.releng.repository.java21patch</module>
+    <module>org.eclipse.jdt.java23patch</module>
+    <module>eclipse.releng.repository.java23patch</module>
   </modules>
 </project>


### PR DESCRIPTION
We need to start making patch builds for Java 23 based on the latest 4.33 build and later on to 4.33 release build.