### PR TITLE
Disable the early 4.34 setup redirects

### DIFF
--- a/oomph/Platform.setup
+++ b/oomph/Platform.setup
@@ -170,28 +170,32 @@
   </setupTask>
   <setupTask
       xsi:type="setup:VariableTask"
+      disabled="true"
       type="BOOLEAN"
-      name="early.redirection.4.34"
+      name="early.redirection.4.35"
       defaultValue="true"
       storageURI="scope://Workspace"
-      label="Early redirect to 4.34">
-    <description>Redirect 4.32 p2 repos to 4.33 and redirect 4.33 repos to 4.34 to begin development on the open master streams immediately.</description>
+      label="Early redirect to 4.35">
+    <description>Redirect 4.33 p2 repos to 4.34 and redirect 4.34 repos to 4.35 to begin development on the open master streams immediately.</description>
   </setupTask>
   <setupTask
       xsi:type="setup:CompoundTask"
-      filter="(early.redirection.4.34=true)"
+      disabled="true"
+      filter="(early.redirection.4.35=true)"
       name="EarlyRedirection">
     <setupTask
         xsi:type="setup:RedirectionTask"
-        sourceURL="https://download.eclipse.org/eclipse/updates/4.33-I-builds"
-        targetURL="https://download.eclipse.org/eclipse/updates/4.34-I-builds">
-      <description>Redirect 4.33 I-builds to 4.34 I-builds</description>
+        disabled="true"
+        sourceURL="https://download.eclipse.org/eclipse/updates/4.34-I-builds"
+        targetURL="https://download.eclipse.org/eclipse/updates/4.35-I-builds">
+      <description>Redirect 4.34 I-builds to 4.35 I-builds</description>
     </setupTask>
     <setupTask
         xsi:type="setup:RedirectionTask"
-        sourceURL="https://download.eclipse.org/eclipse/updates/4.32/R-4.32-202406010610"
-        targetURL="https://download.eclipse.org/eclipse/updates/4.33-I-builds/I20240903-0240">
-      <description>Redirect the release 4.32 build to the final 4.33 I-build which should point at the simple repository to avoid redirecting to 4.33</description>
+        disabled="true"
+        sourceURL="https://download.eclipse.org/eclipse/updates/4.33/R-4.33-202409030240"
+        targetURL="https://download.eclipse.org/eclipse/updates/4.34-I-builds/tbd">
+      <description>Redirect the release 4.33 build to the final 4.34 I-build which should point at the simple repository to avoid redirecting to 4.34 while it's still empty before the actual release</description>
     </setupTask>
   </setupTask>
   <project name="platform"


### PR DESCRIPTION
- The Oomph catalogs are updated such that they aren't needed.
- Rough in early 4.35 redirects for at the end of the current cycle