### PR TITLE
Stop generating and publishing eclipse-test-framework.zip

### DIFF
--- a/cje-production/mbscripts/mb300_gatherEclipseParts.sh
+++ b/cje-production/mbscripts/mb300_gatherEclipseParts.sh
@@ -108,14 +108,6 @@ if [ -z $PATCH_BUILD ]; then
     popd
   fi
 
-  # gather test framework
-  TEST_FRAMEWORK_DIR=$TEST_ZIP_DIR/eclipse-test-framework
-  if [ -d $TEST_FRAMEWORK_DIR ]; then
-    pushd $TEST_FRAMEWORK_DIR
-    zip -r $CJE_ROOT/$DROP_DIR/$BUILD_ID/eclipse-test-framework-$BUILD_ID.zip *
-    popd
-  fi
-
   set -x
   # slice repos
   ANT_SCRIPT=$ECLIPSE_BUILDER_DIR/repos/buildAll.xml

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse-junit-tests/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse-junit-tests/pom.xml
@@ -74,59 +74,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.eclipse.tycho.extras</groupId>
-        <artifactId>tycho-p2-extras-plugin</artifactId>
-        <version>${tycho.version}</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>mirror</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <source>
-            <!-- source repositories to mirror from -->
-            <repository>
-              <url>${project.baseUri}/target/repository</url>
-              <layout>p2</layout>
-              <!-- supported layouts are "p2-metadata", "p2-artifacts", and "p2" (for joint repositories; default) -->
-            </repository>
-          </source>
-
-          <!-- starting from here all configuration parameters are optional -->
-          <!-- they are only shown here with default values for documentation purpose -->
-
-          <!-- List of IUs to mirror. If omitted, allIUs will be mirrored. -->
-          <!-- Omitted IU version element means latest version of the IU -->
-          <ius>
-            <iu>
-              <id>org.eclipse.test.feature.group</id>
-            </iu>
-          </ius>
-          <!-- The destination directory to mirror to. -->
-          <destination>${project.build.directory}/eclipse-test-framework</destination>
-          <!-- Whether only strict dependencies should be followed. -->
-          <!-- "strict" means perfect version match -->
-          <followStrictOnly>false</followStrictOnly>
-          <!-- Whether or not to follow optional requirements. -->
-          <includeOptional>false</includeOptional>
-          <!-- Whether or not to follow non-greedy requirements. -->
-          <includeNonGreedy>false</includeNonGreedy>
-          <!-- Filter properties. E.g. filter only one platform -->
-          <!-- Whether to filter the resulting set of IUs to only -->
-          <!-- include the latest version of each IU -->
-          <latestVersionOnly>true</latestVersionOnly>
-          <!-- don't mirror artifacts, only metadata -->
-          <mirrorMetadataOnly>false</mirrorMetadataOnly>
-          <!-- whether to compress the content.xml/artifacts.xml -->
-          <compress>false</compress>
-          <!-- whether to append to the target repository content -->
-          <append>true</append>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
         <configuration>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/testManifest.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/testManifest.xml
@@ -48,10 +48,6 @@
 
     <zipType name="JUnit test plug-ins">
       <platform
-        id="TF"
-        name="&lt;img src = &quot;repo.gif&quot; alt=&quot;Test Framework&quot; /> All"
-        fileName="eclipse-test-framework-${BUILD_ID}.zip"></platform>
-      <platform
         id="JT"
         name="All"
         fileName="eclipse-Automated-Tests-${BUILD_ID}.zip"></platform>


### PR DESCRIPTION
Its content is included in eclipse-Automated-Tests.zip since forever and whoever needs it should install it from p2 repo.