### PR TITLE
Update P build to the release version of 4.33

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/java23patch/org.eclipse.jdt-feature-dummy/feature.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/java23patch/org.eclipse.jdt-feature-dummy/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.jdt"
       label="%featureName"
-      version="3.19.600.v20240827-1800"
+      version="3.19.600.v20240903-0240"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/eclipse.platform.releng.tychoeclipsebuilder/java23patch/org.eclipse.jdt-feature-dummy/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/java23patch/org.eclipse.jdt-feature-dummy/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt.feature</groupId>
   <artifactId>org.eclipse.jdt</artifactId>
-  <version>3.19.600.v20240827-1800</version>
+  <version>3.19.600.v20240903-0240</version>
   <packaging>eclipse-feature</packaging>
 
 </project>

--- a/eclipse.platform.releng.tychoeclipsebuilder/java23patch/org.eclipse.jdt.java23patch/feature.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/java23patch/org.eclipse.jdt.java23patch/feature.xml
@@ -20,7 +20,7 @@
    </license>
 
    <requires>
-      <import feature="org.eclipse.jdt" version="3.19.600.v20240827-1800" patch="true"/>
+      <import feature="org.eclipse.jdt" version="3.19.600.v20240903-0240" patch="true"/>
    </requires>
 
    <plugin


### PR DESCRIPTION
Now that we have the final build of 4.33, we should update the P build to use that jdt feature version.

@MohananRahul  please glance at this and release.