### PR TITLE
Remove hamcrest-core from Eclipse SDK

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -33,9 +33,6 @@
       <unit id="org.apache.lucene.analysis-smartcn.source" version="9.11.1.v20240628-1000"/>
       <unit id="org.apache.lucene.analysis-common.source" version="9.11.1.v20240628-1000"/>
 
-      <unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-      <unit id="org.hamcrest.core.source" version="2.2.0.v20230809-1000"/>
-
       <!-- Transitive dependency of jxpath, not available as OSGi bundle on Maven Central -->
       <unit id="org.jdom" version="1.1.3.v20230812-1600"/>
       <unit id="org.jdom.source" version="1.1.3.v20230812-1600"/>

--- a/eclipse.platform.releng/bundles/org.eclipse.releng.tests/ignoreFiles.txt
+++ b/eclipse.platform.releng/bundles/org.eclipse.releng.tests/ignoreFiles.txt
@@ -107,6 +107,5 @@ about_cairo.html
 */plugins/org.apache.commons.codec_*
 */plugins/org.apache.commons.codec.source_*
 */plugins/org.apache.commons.httpclient.source_*
-*/plugins/org.hamcrest.core.source_*
 */eclipse/p2/org.eclipse.equinox.p2.metadata.repository/cache/content*_jar/content.xml
 */eclipse/artifacts.xml

--- a/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
@@ -352,10 +352,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.hamcrest.core"
-         version="0.0.0"/>
-
-   <plugin
          id="org.mockito.mockito-core"
          version="0.0.0"/>
 


### PR DESCRIPTION
Since hamcrest 2.0 the hamcrest-core artifact is just an empty hull to provide metadata that redirect all references to it to the new only hamcrest 'main' artifact.
Nothing in the SDK should require hamcrest-core anymore, so it can be removed.