### PR TITLE
Bump version to match jar signatures

### DIFF
--- a/eclipse.platform.releng/bundles/org.eclipse.test.performance/META-INF/MANIFEST.MF
+++ b/eclipse.platform.releng/bundles/org.eclipse.test.performance/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.test.performance; singleton:=true
-Bundle-Version: 3.20.200.qualifier
+Bundle-Version: 3.20.300.qualifier
 Bundle-Activator: org.eclipse.test.internal.performance.PerformanceTestPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/eclipse.platform.releng/bundles/org.eclipse.test.performance/pom.xml
+++ b/eclipse.platform.releng/bundles/org.eclipse.test.performance/pom.xml
@@ -19,6 +19,6 @@
   </parent>
   <groupId>org.eclipse.test</groupId>
   <artifactId>org.eclipse.test.performance</artifactId>
-  <version>3.20.200-SNAPSHOT</version>
+  <version>3.20.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/eclipse.platform.releng/bundles/org.eclipse.test/META-INF/MANIFEST.MF
+++ b/eclipse.platform.releng/bundles/org.eclipse.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.test; singleton:=true
-Bundle-Version: 3.6.100.qualifier
+Bundle-Version: 3.6.200.qualifier
 Eclipse-BundleShape: dir
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/eclipse.platform.releng/bundles/org.eclipse.test/pom.xml
+++ b/eclipse.platform.releng/bundles/org.eclipse.test/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.test</groupId>
   <artifactId>org.eclipse.test</artifactId>
-  <version>3.6.100-SNAPSHOT</version>
+  <version>3.6.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars> 


### PR DESCRIPTION
- Both need to be bumped because neither is signed by the latest available signing certificate.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2335