### PR TITLE
[Draft] Bump jna version to 5.15.0

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -41,7 +41,7 @@
       <unit id="org.jdom.source" version="1.1.3.v20230812-1600"/>
 
       <!-- This version contains with notarized *.jnilib -->
-      <unit id="com.sun.jna" version="5.14.0.v20231211-1200"/>
+      <unit id="com.sun.jna" version="5.15.0.v20240916-1200"/>
 
       <!-- Batik dependencies -->
       <unit id="org.eclipse.orbit.xml-apis-ext" version="1.0.0.v20230923-0644"/>


### PR DESCRIPTION
See:
https://groups.google.com/g/jna-users/c/MJswDpdiqWI/m/5c2EYB3XAAAJ

I am not sure how to bump the JNA verison with eclipse style correctly, so flag it as draft. This helps to build Eclipse SDK on riscv64.