### PR TITLE
Update that target platform to a new Orbit milestone

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -41,18 +41,18 @@
       <unit id="org.jdom.source" version="1.1.3.v20230812-1600"/>
 
       <!-- This version contains with notarized *.jnilib -->
-      <unit id="com.sun.jna" version="5.14.0.v20231211-1200"/>
+      <unit id="com.sun.jna" version="5.15.0.v20240915-2000"/>
 
       <!-- Batik dependencies -->
-      <unit id="org.eclipse.orbit.xml-apis-ext" version="1.0.0.v20230923-0644"/>
-      <unit id="org.eclipse.orbit.xml-apis-ext.source" version="1.0.0.v20230923-0644"/>
+      <unit id="org.eclipse.orbit.xml-apis-ext" version="1.0.0.v20240917-0534"/>
+      <unit id="org.eclipse.orbit.xml-apis-ext.source" version="1.0.0.v20240917-0534"/>
 
       <!-- Markdown support for JEP 467 -->
-      <unit id="org.commonmark" version="0.22.0.v20240316-0700"/>
-      <unit id="org.commonmark-gfm-tables" version="0.22.0.v20240316-0700"/>
+      <unit id="org.commonmark" version="0.23.0.v20240917-1000"/>
+      <unit id="org.commonmark-gfm-tables" version="0.23.0.v20240917-1000"/>
 
       <!-- This is the "normal" Orbit repository is expected to be updated on milestones and releases based on Orbit deliveries. -->
-      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202409101601"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202409180633"/>
     </location>
 
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
@@ -139,7 +139,7 @@
 			  <dependency>
 				  <groupId>net.java.dev.jna</groupId>
 				  <artifactId>jna-platform</artifactId>
-				  <version>5.14.0</version>
+				  <version>5.15.0</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>


### PR DESCRIPTION
- Update com.sun.jna/jna-platform to 5.15.0.
- Update org.eclipse.orbit.xml-apis-ext to new qualifier version.
- Update org.commonmark to 0.23.0.