### PR TITLE
Stop executing perf tests

### DIFF
--- a/JenkinsJobs/Builds/I_build.groovy
+++ b/JenkinsJobs/Builds/I_build.groovy
@@ -423,7 +423,6 @@ spec:
               build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-macM1-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
               build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-mac64-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
               build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-win32-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
-              build job: 'PerformanceTests/ep''' + MAJOR + MINOR + '''I-perf-lin64-baseline', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
               build job: 'Start-smoke-tests', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
             }
           }


### PR DESCRIPTION
As discussed in
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/discussions/828#discussioncomment-10695397 and https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/discussions/2264 this only takes precious resources and no one actually looks at these results.