### PR TITLE
Temporarily use 2024-06 API-Tools for API checks in verification builds

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -923,6 +923,9 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
+                             <apiToolsRepository>
+                                 <url>https://download.eclipse.org/eclipse/updates/4.32/R-4.32-202406010610/</url>
+                             </apiToolsRepository>
                              <baselines>
                                  <repository>
                                      <url>${previous-release.baseline}</url>


### PR DESCRIPTION
Revert to use previous release's API-Tools to hopefully unblock verification builds that are currently suffering from https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2360#issuecomment-2364207760.

If this doesn't help, the problem is probably not directly within PDE's API-Tools but in the integration with Tycho.