### PR TITLE
Remove package import of o.e.test from o.e.test.performance

### DIFF
--- a/eclipse.platform.releng/bundles/org.eclipse.test.performance/META-INF/MANIFEST.MF
+++ b/eclipse.platform.releng/bundles/org.eclipse.test.performance/META-INF/MANIFEST.MF
@@ -7,8 +7,7 @@ Bundle-Activator: org.eclipse.test.internal.performance.PerformanceTestPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Import-Package: org.junit.jupiter.api,
- org.junit.platform.suite.api,
- org.eclipse.test
+ org.junit.platform.suite.api
 Export-Package: org.eclipse.perfmsr.core,
  org.eclipse.test.internal.performance,
  org.eclipse.test.internal.performance.data,


### PR DESCRIPTION
- It already requires bundle org.eclipse.test so the import seems redundant and causes problems running tests.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2369