### PR TITLE
[Build] Temporarily use tycho-apitools:verify mojo in version 4.0.8

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -915,7 +915,7 @@
              <plugin>
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-apitools-plugin</artifactId>
-                <version>${tycho.version}</version>
+                <version>4.0.8</version>
                 <executions>
                     <execution>
                         <id>verify</id>
@@ -923,9 +923,6 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
-                             <apiToolsRepository>
-                                 <url>https://download.eclipse.org/eclipse/updates/4.32/R-4.32-202406010610/</url>
-                             </apiToolsRepository>
                              <baselines>
                                  <repository>
                                      <url>${previous-release.baseline}</url>


### PR DESCRIPTION
Temporarily revert the `tycho-apitools:verify` mojo to version 4.0.8 for API checks to hopefully unblock verification builds that are currently suffering from https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2360#issuecomment-2364207760.
