### PR TITLE
Add overwritable indirection for flag to skip version baseline check

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -126,6 +126,7 @@
     <tycho.useJDK>BREE</tycho.useJDK>
     
     <compare-version-with-baselines.skip>true</compare-version-with-baselines.skip>
+    <version.baseline.check.skip>${compare-version-with-baselines.skip}</version.baseline.check.skip> <!-- Allows projects to overwrite the value set on the CLI to skip the check in any case. -->
     <tycho.baseline.replace>all</tycho.baseline.replace>
     <previous-release.baseline>https://download.eclipse.org/eclipse/updates/4.33/R-4.33-202409030240/</previous-release.baseline>
 
@@ -379,7 +380,7 @@
              <goal>compare-version-with-baselines</goal>
            </goals>
            <configuration>
-             <skip>${compare-version-with-baselines.skip}</skip>
+             <skip>${version.baseline.check.skip}</skip>
              <baselines>
                <baseline>${previous-release.baseline}</baseline>
              </baselines>


### PR DESCRIPTION
This can for example be used in https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2994 and can be applied to future version-baseline check mojos that are probably necessary for
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2352