### PR TITLE
Stop requiring and reexporting o.e.test in o.e.test.performance

### DIFF
--- a/eclipse.platform.releng/bundles/org.eclipse.test.performance/.settings/.api_filters
+++ b/eclipse.platform.releng/bundles/org.eclipse.test.performance/.settings/.api_filters
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.test.performance" version="2">
+    <resource path="META-INF/MANIFEST.MF">
+        <filter comment="Split package with o.e.test fixed" id="926941240">
+            <message_arguments>
+                <message_argument value="3.21.0"/>
+                <message_argument value="3.20.200"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="META-INF/MANIFEST.MF" type="org.eclipse.test.OrderedTestSuite">
+        <filter comment="Split package with o.e.test fixed" id="305324134">
+            <message_arguments>
+                <message_argument value="org.eclipse.test.OrderedTestSuite"/>
+                <message_argument value="org.eclipse.test.performance_3.21.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="META-INF/MANIFEST.MF" type="org.eclipse.test.Screenshots">
+        <filter comment="Split package with o.e.test fixed" id="305324134">
+            <message_arguments>
+                <message_argument value="org.eclipse.test.Screenshots"/>
+                <message_argument value="org.eclipse.test.performance_3.21.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="META-INF/MANIFEST.MF" type="org.eclipse.test.TracingSuite">
+        <filter comment="Split package with o.e.test fixed" id="305324134">
+            <message_arguments>
+                <message_argument value="org.eclipse.test.TracingSuite"/>
+                <message_argument value="org.eclipse.test.performance_3.21.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/eclipse.platform.releng/bundles/org.eclipse.test.performance/META-INF/MANIFEST.MF
+++ b/eclipse.platform.releng/bundles/org.eclipse.test.performance/META-INF/MANIFEST.MF
@@ -2,13 +2,12 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.test.performance; singleton:=true
-Bundle-Version: 3.20.300.qualifier
+Bundle-Version: 3.21.0.qualifier
 Bundle-Activator: org.eclipse.test.internal.performance.PerformanceTestPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Import-Package: org.junit.jupiter.api,
- org.junit.platform.suite.api,
- org.eclipse.test
+ org.junit.platform.suite.api
 Export-Package: org.eclipse.perfmsr.core,
  org.eclipse.test.internal.performance,
  org.eclipse.test.internal.performance.data,
@@ -17,7 +16,6 @@ Export-Package: org.eclipse.perfmsr.core,
  org.eclipse.test.internal.performance.tests,
  org.eclipse.test.performance
 Require-Bundle: org.eclipse.core.runtime,
- org.eclipse.test;visibility:=reexport,
  org.junit
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .

--- a/eclipse.platform.releng/bundles/org.eclipse.test.performance/pom.xml
+++ b/eclipse.platform.releng/bundles/org.eclipse.test.performance/pom.xml
@@ -19,6 +19,6 @@
   </parent>
   <groupId>org.eclipse.test</groupId>
   <artifactId>org.eclipse.test.performance</artifactId>
-  <version>3.20.300-SNAPSHOT</version>
+  <version>3.21.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>


### PR DESCRIPTION
Dependent bundles should be fixed to require what they need direclty so no need for the reexport any more.