### PR TITLE
[Builds] Remove elements unnecessary with the new version-bump workflow

### DIFF
--- a/.github/workflows/updateRelease.yml
+++ b/.github/workflows/updateRelease.yml
@@ -26,17 +26,6 @@ jobs:
           mvn -U -Pbuild-individual-bundles -ntp
           org.eclipse.tycho:tycho-versions-plugin:set-version -DnewVersion=${{ github.event.milestone.title }}.0-SNAPSHOT
           org.eclipse.tycho:tycho-versions-plugin:set-parent-version -DnewParentVersion=${{ github.event.milestone.title }}.0-SNAPSHOT
-    - name: Build and Bump Versions
-      uses: Wandalen/wretry.action@ffdd254f4eaf1562b8a2c66aeaa37f1ff2231179 # master
-      with:
-        attempt_delay: 120000
-        attempt_limit: 10
-        command: >-
-            mvn -U -Pbuild-individual-bundles -ntp
-            clean verify
-            -DskipTests
-            -Dcompare-version-with-baselines.skip=false
-            org.eclipse.tycho:tycho-versions-plugin:bump-versions -Dtycho.bump-versions.increment=100
     - name: Create Pull Request for Release ${{ github.event.milestone.title }}
       uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
       with:


### PR DESCRIPTION
With the new reusable workflow for automated version increments in pull-requests, introduced with https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2352, it is not necessary anymore to bump versions in advance during release preparation or the enable bumping if the property 'compare-version-with-baselines.skip' is set to false. Everything now happens automatically and these elements can therefore be removed.

Removing these elements avoids partly duplicated configuration and generally reduced the amount of configuration.