### PR TITLE
Align Case-Ing to make topic titles consistent

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/toc.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/toc.xml
@@ -4,9 +4,9 @@
 <!-- Define the top level topics                                                   -->
 <!-- ============================================================================= -->
 
-<toc label="Java development user guide">
+<toc label="Java Development User Guide">
     <topic label="Java development overview" href="gettingStarted/intro/overview.htm"/>
-	<topic label="Getting Started">
+	<topic label="Getting started">
 		<link toc="topics_GettingStarted.xml" />
 	</topic>
 	<anchor id="jdt_getstart" />


### PR DESCRIPTION
- Platform and PDE "Development User Guide" instead of "development user guide".
- "Getting started" is used in stead of "Getting Started" by the other projects.