### PR TITLE
Add linux.riscv64 environment to eclipse-platform-parent and publish linux.riscv64 artifacts

### DIFF
--- a/cje-production/mbscripts/mb300_gatherEclipseParts.sh
+++ b/cje-production/mbscripts/mb300_gatherEclipseParts.sh
@@ -61,6 +61,7 @@ if [ -z $PATCH_BUILD ]; then
     # sdk
     cp org.eclipse.sdk.ide-linux.gtk.aarch64.tar.gz $CJE_ROOT/$DROP_DIR/$BUILD_ID/eclipse-SDK-$BUILD_ID-linux-gtk-aarch64.tar.gz
     cp org.eclipse.sdk.ide-linux.gtk.ppc64le.tar.gz $CJE_ROOT/$DROP_DIR/$BUILD_ID/eclipse-SDK-$BUILD_ID-linux-gtk-ppc64le.tar.gz
+    cp org.eclipse.sdk.ide-linux.gtk.riscv64.tar.gz $CJE_ROOT/$DROP_DIR/$BUILD_ID/eclipse-SDK-$BUILD_ID-linux-gtk-riscv64.tar.gz
     cp org.eclipse.sdk.ide-linux.gtk.x86_64.tar.gz $CJE_ROOT/$DROP_DIR/$BUILD_ID/eclipse-SDK-$BUILD_ID-linux-gtk-x86_64.tar.gz
     cp org.eclipse.sdk.ide-macosx.cocoa.x86_64.tar.gz $CJE_ROOT/$DROP_DIR/$BUILD_ID/eclipse-SDK-$BUILD_ID-macosx-cocoa-x86_64.tar.gz
     cp org.eclipse.sdk.ide-macosx.cocoa.x86_64.dmg $CJE_ROOT/$DROP_DIR/$BUILD_ID/eclipse-SDK-$BUILD_ID-macosx-cocoa-x86_64.dmg
@@ -71,6 +72,7 @@ if [ -z $PATCH_BUILD ]; then
     # platform
     cp org.eclipse.platform.ide-linux.gtk.aarch64.tar.gz $CJE_ROOT/$DROP_DIR/$BUILD_ID/eclipse-platform-$BUILD_ID-linux-gtk-aarch64.tar.gz
     cp org.eclipse.platform.ide-linux.gtk.ppc64le.tar.gz $CJE_ROOT/$DROP_DIR/$BUILD_ID/eclipse-platform-$BUILD_ID-linux-gtk-ppc64le.tar.gz
+    cp org.eclipse.platform.ide-linux.gtk.riscv64.tar.gz $CJE_ROOT/$DROP_DIR/$BUILD_ID/eclipse-platform-$BUILD_ID-linux-gtk-riscv64.tar.gz
     cp org.eclipse.platform.ide-linux.gtk.x86_64.tar.gz $CJE_ROOT/$DROP_DIR/$BUILD_ID/eclipse-platform-$BUILD_ID-linux-gtk-x86_64.tar.gz
     cp org.eclipse.platform.ide-macosx.cocoa.x86_64.tar.gz $CJE_ROOT/$DROP_DIR/$BUILD_ID/eclipse-platform-$BUILD_ID-macosx-cocoa-x86_64.tar.gz
     cp org.eclipse.platform.ide-macosx.cocoa.x86_64.dmg $CJE_ROOT/$DROP_DIR/$BUILD_ID/eclipse-platform-$BUILD_ID-macosx-cocoa-x86_64.dmg

--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -256,6 +256,11 @@
               <ws>gtk</ws>
               <arch>ppc64le</arch>
             </environment>
+            <environment>
+              <os>linux</os>
+              <ws>gtk</ws>
+              <arch>riscv64</arch>
+            </environment>
              <environment>
               <os>linux</os>
               <ws>gtk</ws>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/testManifest.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/testManifest.xml
@@ -26,6 +26,10 @@
         name="Linux (64 bit version for Power PC)"
         fileName="eclipse-SDK-${BUILD_ID}-linux-gtk-ppc64le.tar.gz"></platform>
       <platform
+        id="SLG2RISCV64"
+        name="Linux (64 bit version for RISC-V)"
+        fileName="eclipse-SDK-${BUILD_ID}-linux-gtk-riscv64.tar.gz"></platform>
+      <platform
         id="SLG2AARCH64"
         name="Linux (64 bit version for AArch64)"
         fileName="eclipse-SDK-${BUILD_ID}-linux-gtk-aarch64.tar.gz"></platform>
@@ -70,6 +74,10 @@
         id="PLG2PPC64LE"
         name="Linux (64 bit version for Power PC)"
         fileName="eclipse-platform-${BUILD_ID}-linux-gtk-ppc64le.tar.gz"></platform>
+      <platform
+        id="PLG2RISCV64"
+        name="Linux (64 bit version for RISC-V)"
+        fileName="eclipse-platform-${BUILD_ID}-linux-gtk-riscv64.tar.gz"></platform>
       <platform
         id="PLG2AARCH64"
         name="Linux (64 bit version for AArch64)"
@@ -116,6 +124,10 @@
         id="SWTLG2PPC64LE"
         name="Linux (64 bit version for Power PC)"
         fileName="swt-${BUILD_ID}-gtk-linux-ppc64le.zip"></platform>
+      <platform
+        id="SWTLG2RISCV64"
+        name="Linux (64 bit version for RISC-V)"
+        fileName="swt-${BUILD_ID}-gtk-linux-riscv64.zip"></platform>
       <platform
         id="SWTLG2AARCH64"
         name="Linux (64 bit version for AArch64)"

--- a/eclipse.platform.releng.tychoeclipsebuilder/equinox/buildConfigs/equinox-launchers/build.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/equinox/buildConfigs/equinox-launchers/build.xml
@@ -17,7 +17,8 @@
     <buildRepos os="win32" ws="win32" arch="x86_64" archiveName="${archiveRoot}-win32.win32.x86_64.${buildId}.zip" />
     <buildRepos os="linux" ws="gtk" arch="x86_64" archiveName="${archiveRoot}-linux.gtk.x86_64.${buildId}.tar.gz" />
     <buildRepos os="linux" ws="gtk" arch="ppc64le" archiveName="${archiveRoot}-linux.gtk.ppc64le.${buildId}.tar.gz" />
-  	<buildRepos os="linux" ws="gtk" arch="aarch64" archiveName="${archiveRoot}-linux.gtk.aarch64.${buildId}.tar.gz" />
+    <buildRepos os="linux" ws="gtk" arch="riscv64" archiveName="${archiveRoot}-linux.gtk.riscv64.${buildId}.tar.gz" />
+    <buildRepos os="linux" ws="gtk" arch="aarch64" archiveName="${archiveRoot}-linux.gtk.aarch64.${buildId}.tar.gz" />
     <buildRepos os="macosx" ws="cocoa" arch="x86_64" archiveName="${archiveRoot}-macosx.cocoa.x86_64.${buildId}.tar.gz" />
     <buildRepos os="macosx" ws="cocoa" arch="aarch64" archiveName="${archiveRoot}-macosx.cocoa.aarch64.${buildId}.tar.gz" />
   </target>

--- a/eclipse.platform.releng.tychoeclipsebuilder/equinox/publishingFiles/testManifest.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/equinox/publishingFiles/testManifest.xml
@@ -258,6 +258,11 @@
         fileName="launchers-linux.gtk.ppc64le.${BUILD_ID}.tar.gz" />
       <platform
         format="equinox"
+        id="SLG2RISCV64"
+        name="Linux (RISC-V64/GTK+)"
+        fileName="launchers-linux.gtk.riscv64.${BUILD_ID}.tar.gz" />
+      <platform
+        format="equinox"
         id="SLG2AARCH64"
         name="Linux (AARCH64/GTK+)"
         fileName="launchers-linux.gtk.aarch64.${BUILD_ID}.tar.gz" />


### PR DESCRIPTION
Similiarly like it was done for Windows on ARM:
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1917
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2017


Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2310.

@yuzibo FYI