### PR TITLE
[Build] Define cron-trigger for DockerImagesBuild in Job definition

### DIFF
--- a/JenkinsJobs/Builds/DockerImagesBuild.jenkinsfile
+++ b/JenkinsJobs/Builds/DockerImagesBuild.jenkinsfile
@@ -6,9 +6,6 @@ pipeline {
 		buildDiscarder(logRotator(numToKeepStr:'5'))
 		disableConcurrentBuilds(abortPrevious: true)
 	}
-	triggers {
-		cron '@weekly'
-	}
 	agent {
 		label 'docker-build'
 	}

--- a/JenkinsJobs/Builds/FOLDER.groovy
+++ b/JenkinsJobs/Builds/FOLDER.groovy
@@ -4,6 +4,13 @@ folder('Builds') {
 
 pipelineJob('Builds/Build-Docker-images'){
 	description('Build and publish custom Docker images')
+	properties {
+		pipelineTriggers {
+			triggers {
+				cron { spec('@weekly') }
+			}
+		}
+	}
 	definition {
 		cpsScm {
 			lightweight(true)


### PR DESCRIPTION
The triggers defined in a Jenkins-pipeline are only applied to the Job-configuration after the first execution of the pipeline. This has the consequence that after each execution of the seed job the configuration of the 'DockerImagesBuild' is reset to have no triggers and consequently it would require a manual execution of that job to restore the cron-trigger each execution of the seed job.