### PR TITLE
Stop dependabot docker for centos 8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,18 +15,6 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-
-
-  - package-ecosystem: docker
-    directory: /cje-production/dockerfiles/centos-gtk3-metacity/8-gtk3
-    schedule:
-      interval: daily
-
-  - package-ecosystem: docker
-    directory: /cje-production/dockerfiles/centos-gtk3-metacity/8-swtBuild
-    schedule:
-      interval: daily
-
   - package-ecosystem: docker
     directory: /cje-production/dockerfiles/centos-gtk4-mutter/9-gtk4
     schedule:


### PR DESCRIPTION
This is gone now and these images are no longer built.