### PR TITLE
[Build] Make staging of relevant files robust against file absence

### DIFF
--- a/.github/workflows/checkVersions.yml
+++ b/.github/workflows/checkVersions.yml
@@ -49,7 +49,10 @@ jobs:
     - name: Commit version increments, if any
       run: |
         set -x
-        git add '*/META-INF/MANIFEST.MF' '*/feature.xml' '*/pom.xml'
+        # Only stage files relevant for version increments and don't fail if the kind of file to be staged does not exist at all.
+        git add '*/META-INF/MANIFEST.MF' || true
+        git add '*/feature.xml' || true
+        git add '*/pom.xml' || true
         if [[ $(git diff --name-only --cached) != '' ]]; then
           # Relevant files were staged, i.e. some version were changed
           


### PR DESCRIPTION
Stage the relevant kind of files in isolation and don't fail if that kind of file does not exist at all in the repository.

Otherwise the entire step fails if the repo for example doesn't contain a feature.xml, because the previous 'git add' command then fails with:
`fatal: pathspec '*/feature.xml' did not match any files`


This became relevant for example in https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/516