### PR TITLE
Remove org.hamcrest.core from Eclipse SDK

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -23,8 +23,10 @@
       <unit id="org.apache.xmlgraphics.source" version="2.9.0.v20230916-1600"/>
 
       <!-- needed because org.eclipse.jdt.feature.group  includes it, but it should include org.hamcrest (direct-from-maven) instead --> 
+      <!--
       <unit id="org.junit" version="4.13.2.v20230809-1000"/>
       <unit id="org.junit.source" version="4.13.2.v20230809-1000"/>
+      -->
 
       <unit id="org.apache.lucene.core" version="9.11.1.v20240628-1000"/>
       <unit id="org.apache.lucene.analysis-smartcn" version="9.11.1.v20240628-1000"/>
@@ -32,9 +34,6 @@
       <unit id="org.apache.lucene.core.source" version="9.11.1.v20240628-1000"/>
       <unit id="org.apache.lucene.analysis-smartcn.source" version="9.11.1.v20240628-1000"/>
       <unit id="org.apache.lucene.analysis-common.source" version="9.11.1.v20240628-1000"/>
-
-      <unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-      <unit id="org.hamcrest.core.source" version="2.2.0.v20230809-1000"/>
 
       <!-- Transitive dependency of jxpath, not available as OSGi bundle on Maven Central -->
       <unit id="org.jdom" version="1.1.3.v20230812-1600"/>
@@ -53,6 +52,13 @@
 
       <!-- This is the "normal" Orbit repository is expected to be updated on milestones and releases based on Orbit deliveries. -->
       <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202409180633"/>
+    </location>
+
+    <!-- This is temporary to make progress on https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2343 -->
+    <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
+      <unit id="org.junit" version="4.13.2.v20240929-1000"/>
+      <unit id="org.junit.source" version="4.13.2.v20240929-1000"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest"/>
     </location>
 
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">

--- a/eclipse.platform.releng/bundles/org.eclipse.releng.tests/META-INF/MANIFEST.MF
+++ b/eclipse.platform.releng/bundles/org.eclipse.releng.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.releng.tests;singleton:=true
-Bundle-Version: 3.6.500.qualifier
+Bundle-Version: 3.6.600.qualifier
 Eclipse-BundleShape: dir
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/eclipse.platform.releng/bundles/org.eclipse.releng.tests/ignoreFiles.txt
+++ b/eclipse.platform.releng/bundles/org.eclipse.releng.tests/ignoreFiles.txt
@@ -107,6 +107,5 @@ about_cairo.html
 */plugins/org.apache.commons.codec_*
 */plugins/org.apache.commons.codec.source_*
 */plugins/org.apache.commons.httpclient.source_*
-*/plugins/org.hamcrest.core.source_*
 */eclipse/p2/org.eclipse.equinox.p2.metadata.repository/cache/content*_jar/content.xml
 */eclipse/artifacts.xml

--- a/eclipse.platform.releng/bundles/org.eclipse.releng.tests/pom.xml
+++ b/eclipse.platform.releng/bundles/org.eclipse.releng.tests/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.releng</groupId>
   <artifactId>org.eclipse.releng.tests</artifactId>
-  <version>3.6.500-SNAPSHOT</version>
+  <version>3.6.600-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <testSuite>${project.artifactId}</testSuite>

--- a/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
@@ -352,10 +352,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.hamcrest.core"
-         version="0.0.0"/>
-
-   <plugin
          id="org.mockito.mockito-core"
          version="0.0.0"/>
 


### PR DESCRIPTION
- The org.hamcrest.core bundle is just an empty hull to provide metadata that redirects all references to it to the new org.hamcrest bundle that avoids split packages with the org.hamcrest.library bundle by combining all the content into a single bundle.
- Nothing in the SDK should require org.hamcrest.core anymore, so it can be removed.
- A new org.junit bundle from Orbit is needed that requires the org.hamcrest bundle instead of the org.hamcrest.core bundle.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2343