### PR TITLE
Eclipse Platform Binary: Register eclipse+command links for macOS

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.product
@@ -19,7 +19,11 @@
       location="org.eclipse.platform" />
    <launcher name="eclipse">
       <linux icon="icons/icon.xpm"/>
-      <macosx icon="icons/Eclipse.icns"/>
+      <macosx icon="icons/Eclipse.icns">
+         <bundleUrlTypes>
+            <bundleUrlType scheme="eclipse+command" name="Eclipse Command"/>
+         </bundleUrlTypes>
+      </macosx>
       <win useIco="false">
          <bmp/>
       </win>


### PR DESCRIPTION
With
https://github.com/eclipse-platform/eclipse.platform.ui/issues/1901 the auto-registration of link handlers was removed to avoid breaking of code signatures.

In order to use the 'eclipse+command' URI schemes on macOS, this must instead be pre-registered during .app bundle build time before code signing.