### PR TITLE
Stop generating 2 PRs for maven updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,6 @@
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
-  - package-ecosystem: maven
-    directory: eclipse-platform-parent
-    schedule:
-      interval: daily
-    commit-message:
-      prefix: fix
-      prefix-development: chore
-      include: scope
-    labels:
-      - dependencies
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
In the past we used to have maven updates for platform-parent only as it was not working for /. Fixes allowed to have dependabot run for / but the run for eclipse-platform-parent was not removed which led to 2 PRs being generated for each update there e.g.:
* https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2412
* https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2411