### PR TITLE
Update the target platform to the latest Orbit and EMF milestones

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -23,17 +23,15 @@
       <unit id="org.apache.xmlgraphics.source" version="2.9.0.v20230916-1600"/>
 
       <!-- needed because org.eclipse.jdt.feature.group  includes it, but it should include org.hamcrest (direct-from-maven) instead --> 
-      <!--
-      <unit id="org.junit" version="4.13.2.v20230809-1000"/>
-      <unit id="org.junit.source" version="4.13.2.v20230809-1000"/>
-      -->
+      <unit id="org.junit" version="4.13.2.v20240929-1000"/>
+      <unit id="org.junit.source" version="4.13.2.v20240929-1000"/>
 
-      <unit id="org.apache.lucene.core" version="9.11.1.v20240628-1000"/>
-      <unit id="org.apache.lucene.analysis-smartcn" version="9.11.1.v20240628-1000"/>
-      <unit id="org.apache.lucene.analysis-common" version="9.11.1.v20240628-1000"/>
-      <unit id="org.apache.lucene.core.source" version="9.11.1.v20240628-1000"/>
-      <unit id="org.apache.lucene.analysis-smartcn.source" version="9.11.1.v20240628-1000"/>
-      <unit id="org.apache.lucene.analysis-common.source" version="9.11.1.v20240628-1000"/>
+      <unit id="org.apache.lucene.core" version="9.12.0.v20240929-0900"/>
+      <unit id="org.apache.lucene.analysis-smartcn" version="9.12.0.v20240929-0900"/>
+      <unit id="org.apache.lucene.analysis-common" version="9.12.0.v20240929-0900"/>
+      <unit id="org.apache.lucene.core.source" version="9.12.0.v20240929-0900"/>
+      <unit id="org.apache.lucene.analysis-smartcn.source" version="9.12.0.v20240929-0900"/>
+      <unit id="org.apache.lucene.analysis-common.source" version="9.12.0.v20240929-0900"/>
 
       <!-- Transitive dependency of jxpath, not available as OSGi bundle on Maven Central -->
       <unit id="org.jdom" version="1.1.3.v20230812-1600"/>
@@ -51,14 +49,7 @@
       <unit id="org.commonmark-gfm-tables" version="0.23.0.v20240917-1000"/>
 
       <!-- This is the "normal" Orbit repository is expected to be updated on milestones and releases based on Orbit deliveries. -->
-      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202409180633"/>
-    </location>
-
-    <!-- This is temporary to make progress on https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2343 -->
-    <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
-      <unit id="org.junit" version="4.13.2.v20240929-1000"/>
-      <unit id="org.junit.source" version="4.13.2.v20240929-1000"/>
-      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202410030659"/>
     </location>
 
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
@@ -75,7 +66,7 @@
       <unit id="org.eclipse.emf.databinding.source.feature.group" version="1.12.0.v20240604-0832"/>
       <unit id="org.eclipse.emf.databinding.edit.feature.group" version="1.12.0.v20240604-0832"/>
       <unit id="org.eclipse.emf.databinding.edit.source.feature.group" version="1.12.0.v20240604-0832"/>
-      <repository location="https://download.eclipse.org/modeling/emf/emf/builds/milestone/S202409230823"/>
+      <repository location="https://download.eclipse.org/modeling/emf/emf/builds/milestone/S202410011416"/>
     </location>
 
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">


### PR DESCRIPTION
- Removes the workaround for getting an early version of org.junit
- Updates lucene to 9.12.0.