### PR TITLE
Fix path to generated apidoc by maven javadoc

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/pom.xml
@@ -254,7 +254,7 @@
                   <outputDirectory>${basedir}/reference/api</outputDirectory>
                   <resources>          
                     <resource>
-                      <directory>${project.build.directory}/site/apidocs</directory>
+                      <directory>${project.build.directory}/reports/apidocs</directory>
                     </resource>
                   </resources>              
                 </configuration>            

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
@@ -464,7 +464,7 @@
                   <outputDirectory>${basedir}/reference/api</outputDirectory>
                   <resources>          
                     <resource>
-                      <directory>${project.build.directory}/site/apidocs</directory>
+                      <directory>${project.build.directory}/reports/apidocs</directory>
                     </resource>
                   </resources>
                 </configuration>


### PR DESCRIPTION
Part of https://github.com/eclipse-pde/eclipse.pde/issues/1427