### PR TITLE
[Oomph-Setup] Add reference to new eclipse.platform configuration setup and unify name of project containing the platform.setup

### DIFF
--- a/oomph/.project
+++ b/oomph/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.eclipse.platform.setup</name>
+	<name>org.eclipse.platform.sdk.setup</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/oomph/Platform.setup
+++ b/oomph/Platform.setup
@@ -17,7 +17,7 @@
     name="platform"
     label="Platform">
   <annotation
-      source="ConfigurationReference">
+      source="http://www.eclipse.org/oomph/setup/ConfigurationReference">
     <reference
         href="PlatformSDKConfiguration.setup#/"/>
   </annotation>
@@ -200,6 +200,11 @@
   </setupTask>
   <project name="platform"
       label="Ant, Base, Debug, Runtime, Resources, Team, User Assistance, and Update">
+    <annotation
+        source="http://www.eclipse.org/oomph/setup/ConfigurationReference">
+      <reference
+          href="https://raw.githubusercontent.com/eclipse-platform/eclipse.platform/master/releng/org.eclipse.platform.setup/PlatformConfiguration.setup#/"/>
+    </annotation>
     <setupTask
         xsi:type="git:GitCloneTask"
         id="github.clone.platform"


### PR DESCRIPTION
Add a reference to the configuration for the eclipse.platform setup added via https://github.com/eclipse-platform/eclipse.platform/pull/1582.
In that PR the project `org.eclipse.platform.setup` is added, which would collide with the project contained in this repository containing the platform-sdk setup.
In order to match the names rename this repo's project from `org.eclipse.platform.setup` to `org.eclipse.platform.sdk.setup`.