### PR TITLE
Add debian stable based image to build swt natives

### DIFF
--- a/JenkinsJobs/Builds/DockerImagesBuild.jenkinsfile
+++ b/JenkinsJobs/Builds/DockerImagesBuild.jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
 				script {
 					dir('eclipse.platform.releng.aggregator/cje-production/dockerfiles') {
 						parallel(
+							'debian-swtnative': { buildAndPushImage('debian/swtnativebuild', 'eclipse/platformreleng-debian-swtnativebuild:12') },
 							'centos9-gtk4': { buildAndPushImage('centos-gtk4-mutter/9-gtk4', 'eclipse/platformreleng-centos-gtk4-mutter:9') },
 							'centos9-gtk4-swt': { buildAndPushImage('centos-gtk4-mutter/9-swtBuild', 'eclipse/platformreleng-centos-swt-build:9') },
 							'opensuse-gtk3': { buildAndPushImage('opensuse-gtk3-metacity/15-gtk3', 'eclipse/platformreleng-opensuse-gtk3-metacity:15') },

--- a/cje-production/dockerfiles/debian/swtnativebuild/Dockerfile
+++ b/cje-production/dockerfiles/debian/swtnativebuild/Dockerfile
@@ -1,0 +1,28 @@
+FROM debian:12
+
+### user name recognition at runtime w/ an arbitrary uid - for OpenShift deployments
+COPY scripts/uid_entrypoint /usr/local/bin/uid_entrypoint
+RUN chmod u+x /usr/local/bin/uid_entrypoint && \
+    chgrp 0 /usr/local/bin/uid_entrypoint && \
+    chmod g=u /usr/local/bin/uid_entrypoint /etc/passwd
+### end
+
+ENV LANG=en_US.UTF-8
+RUN apt-get update -qq && apt-get install -qq -y locales libgtk-3-dev libgtk-4-dev freeglut3-dev webkit2gtk-driver build-essential default-jdk
+
+ENV HOME=/home/swtbuild
+ENV DISPLAY :0
+RUN useradd -u 10001 -d ${HOME} testuser
+
+RUN mkdir -p /var/lib/dbus && dbus-uuidgen > /var/lib/dbus/machine-id \
+  && mkdir -p /var/run/dbus
+
+# Make $HOME open to the 'root' group (so Jenkins/OpenShift user can write there)
+WORKDIR $HOME
+RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME}
+
+RUN localedef -i en_US -f UTF-8 en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV SWT_JAVA_HOME=/usr/lib/jvm/default-java/
+
+USER 10001

--- a/cje-production/dockerfiles/debian/swtnativebuild/scripts/uid_entrypoint
+++ b/cje-production/dockerfiles/debian/swtnativebuild/scripts/uid_entrypoint
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+if ! whoami > /dev/null 2>&1; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
+  fi
+fi
+exec "$@"


### PR DESCRIPTION
Currently we build the swt natives with centos-8 but this is now gone,
also centos-9 no longer provides stable releases but only
rolling-streams,

This adds a new container based on debian stable and only adds the
absolute minimum required to build the swt natives.

## Why Debian:
 Debian offers quite conservative dependencies and LTS releases
 so there is a good chance to have a common baseline that works on
 more ahead distributions as well (e.g. GClib /GTK/... versions).