### PR TITLE
TracingSuite: add stacktrace to stdout

### DIFF
--- a/eclipse.platform.releng/bundles/org.eclipse.test/src/org/eclipse/test/TracingSuite.java
+++ b/eclipse.platform.releng/bundles/org.eclipse.test/src/org/eclipse/test/TracingSuite.java
@@ -146,6 +146,14 @@ public class TracingSuite extends Suite {
 
         @Override
         public void fireTestFailure(Failure failure) {
+			if (fTracingOptions.logTestStart()) {
+				if (failure.getException() != null) {
+					Date start = new Date();
+					String message = format(start, failure.getDescription());
+					System.out.println(message + " failed:");
+					failure.getException().printStackTrace(System.out);
+				}
+			}
             fNotifier.fireTestFailure(failure);
         }
 
@@ -261,7 +269,7 @@ public class TracingSuite extends Suite {
 
     private static String format(Date time, Description description) {
         String now = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z", Locale.US).format(time);
-        String message = "[" + now + "] " + description.getClassName() + "#" + description.getMethodName() + "()";
+		String message = "[" + now + "] " + description.getClassName() + "." + description.getMethodName() + "()";
         return message;
     }
 


### PR DESCRIPTION
Otherwise it's hard to tell which test failed when/first if error are collected in other logfiles only.