### PR TITLE
[Version check] Make SDK number read robust against additional print-out

### DIFF
--- a/.github/workflows/checkVersions.yml
+++ b/.github/workflows/checkVersions.yml
@@ -57,7 +57,9 @@ jobs:
           # Relevant files were staged, i.e. some version were changed
           
           # Read 'releaseNumberSDK' property as stream version
-          streamVersion=$(mvn help:evaluate -Dexpression=releaseNumberSDK --quiet -DforceStdout)
+          mvn help:evaluate -Dexpression=releaseNumberSDK --quiet '-Doutput=releaseNumberSDK-value.txt'
+          streamVersion=$(<releaseNumberSDK-value.txt)
+          rm -f releaseNumberSDK-value.txt
           
           git config --global user.email '${{ inputs.botMail }}'
           git config --global user.name '${{ inputs.botName }}'


### PR DESCRIPTION
To fix the problem discovered in P2: https://github.com/eclipse-equinox/p2/pull/558#issuecomment-2408530095.