### PR TITLE
[I-Build-Tests] Revert multiple assignments

### DIFF
--- a/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_cen64_gtk3.groovy
@@ -4,7 +4,8 @@ def JAVA_VERSIONS = ['17', '21', '23']
 
 for (STREAM in STREAMS){
 for (JAVA_VERSION in JAVA_VERSIONS){
-  def (MAJOR, MINOR) = STREAM.split('\\.')
+  def MAJOR = STREAM.split('\\.')[0]
+  def MINOR = STREAM.split('\\.')[1]
 
   pipelineJob('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-cen64-gtk3-java' + JAVA_VERSION){
     description('Run Eclipse SDK Tests for the platform implied by this job\'s name')

--- a/JenkinsJobs/AutomatedTests/I_unit_mac_java17.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_mac_java17.groovy
@@ -8,7 +8,8 @@ def ARCHS_JAVA_HOME = ['aarch64': '/usr/local/openjdk-17/Contents/Home', 'x86_64
 
 for (STREAM in STREAMS){
 for (ARCH in ARCHS){
-  def (MAJOR, MINOR) = STREAM.split('\\.')
+  def MAJOR = STREAM.split('\\.')[0]
+  def MINOR = STREAM.split('\\.')[1]
 
   pipelineJob('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-' + ARCHS_JOB_NAME[ARCH] + '-java17'){
     description('Run Eclipse SDK Tests for the platform implied by this job\'s name')

--- a/JenkinsJobs/AutomatedTests/I_unit_win32_java17.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_win32_java17.groovy
@@ -2,7 +2,8 @@ def config = new groovy.json.JsonSlurper().parseText(readFileFromWorkspace('Jenk
 def STREAMS = config.Streams
 
 for (STREAM in STREAMS){
-  def (MAJOR, MINOR) = STREAM.split('\\.')
+  def MAJOR = STREAM.split('\\.')[0]
+  def MINOR = STREAM.split('\\.')[1]
 
   pipelineJob('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-win32-java17'){
     description('Run Eclipse SDK Tests for the platform implied by this job\'s name')


### PR DESCRIPTION
The job creation failed with message:
`General error during canonicalization: The sandbox does not currently support multiple assignment`.

Reverting the assignment simplifications hopefully fixes that.

Follow-up of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2005.