### PR TITLE
[I-Build] Raise max memory limit to 10Gi for I-builds

### DIFF
--- a/JenkinsJobs/Builds/I_build.groovy
+++ b/JenkinsJobs/Builds/I_build.groovy
@@ -64,7 +64,7 @@ spec:
   - name: "jnlp"
     resources:
       limits:
-        memory: "8192Mi"
+        memory: "10Gi"
         cpu: "4000m"
       requests:
         memory: "6144Mi"


### PR DESCRIPTION
Recently the I-build failed occasionally because the container was killed which was very likely due to excessive memory usage.

Let's see if this makes a difference.

Submitting this immediately as well and will abort the running I-build and restart a new one after the job has been regenerated.