### PR TITLE
[I-Build] Unify test job names to schema os-arch-javaVersion

### DIFF
--- a/JenkinsJobs/AutomatedTests/I_unit_linux.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_linux.groovy
@@ -7,7 +7,7 @@ for (JAVA_VERSION in JAVA_VERSIONS){
   def MAJOR = STREAM.split('\\.')[0]
   def MINOR = STREAM.split('\\.')[1]
 
-  pipelineJob('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-cen64-gtk3-java' + JAVA_VERSION){
+  pipelineJob('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-linux-x86_64-java' + JAVA_VERSION){
     description('Run Eclipse SDK Tests for the platform implied by this job\'s name')
     parameters { // Define parameters in job configuration to make them available from the very first build onwards
       stringParam('buildId', null, 'Build Id to test (such as I20240611-1800, N20120716-0800).')
@@ -25,7 +25,7 @@ pipeline {
   }
   agent {
     kubernetes {
-      label 'centos-unitpod&&JAVA_VERSION&&'
+      label 'centos-unitpod''' + JAVA_VERSION + ''''
       defaultContainer 'custom'
       yaml """
 apiVersion: v1
@@ -85,7 +85,7 @@ spec:
       stage('Run tests'){
           environment {
               // Declaring a jdk and ant the usual way in the 'tools' section, because of unknown reasons, breaks the usage of system commands like xvnc, pkill and sh
-              JAVA_HOME = tool(type:'jdk', name:'openjdk-jdk&&JAVA_VERSION&&-latest')
+              JAVA_HOME = tool(type:'jdk', name:'openjdk-jdk''' + JAVA_VERSION + '''-latest')
               ANT_HOME = tool(type:'ant', name:'apache-ant-latest')
               PATH = "${JAVA_HOME}/bin:${ANT_HOME}/bin:${PATH}"
           }
@@ -155,7 +155,7 @@ spec:
       }
   }
 }
-        '''.replace('&&JAVA_VERSION&&', JAVA_VERSION))
+        ''')
       }
     }
   }

--- a/JenkinsJobs/AutomatedTests/I_unit_mac.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_mac.groovy
@@ -2,7 +2,6 @@ def config = new groovy.json.JsonSlurper().parseText(readFileFromWorkspace('Jenk
 def STREAMS = config.Streams
 
 def ARCHS = ['aarch64', 'x86_64']
-def ARCHS_JOB_NAME = ['aarch64': 'macM1', 'x86_64': 'mac64'] // preserve old job labels for now, to affect all downstream scripts
 def ARCHS_AGENT_LABEL = ['aarch64': 'nc1ht-macos11-arm64', 'x86_64': 'nc1ht-macos11-arm64']
 def ARCHS_JAVA_HOME = ['aarch64': '/usr/local/openjdk-17/Contents/Home', 'x86_64': '/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home']
 
@@ -11,7 +10,7 @@ for (ARCH in ARCHS){
   def MAJOR = STREAM.split('\\.')[0]
   def MINOR = STREAM.split('\\.')[1]
 
-  pipelineJob('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-' + ARCHS_JOB_NAME[ARCH] + '-java17'){
+  pipelineJob('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-macosx-' + ARCH + '-java17'){
     description('Run Eclipse SDK Tests for the platform implied by this job\'s name')
     parameters { // Define parameters in job configuration to make them available from the very first build onwards
       stringParam('buildId', null, 'Build Id to test (such as I20240611-1800, N20120716-0800).')
@@ -30,17 +29,17 @@ pipeline {
     buildDiscarder(logRotator(numToKeepStr:'5'))
   }
   agent {
-    label '&&AGENT_LABEL&&'
+    label \'''' + ARCHS_AGENT_LABEL[ARCH] + ''''
   }
 
   stages {
       stage('Run tests'){
           environment {
               // Declaring a jdk and ant the usual way in the 'tools' section, because of unknown reasons, breaks the usage of system commands like xvnc, pkill and sh
-              JAVA_HOME = '&&JAVA_HOME&&'
+              JAVA_HOME = \'''' + ARCHS_JAVA_HOME[ARCH] + ''''
               ANT_HOME = '/opt/homebrew/Cellar/ant/1.10.11/libexec'
               PATH = "${JAVA_HOME}/bin:${ANT_HOME}/bin:${PATH}"
-              eclipseArch = '&&ARCH&&'
+              eclipseArch = \'''' + ARCH + ''''
           }
           steps {
               cleanWs() // workspace not cleaned by default
@@ -105,7 +104,7 @@ echo -e "\\n\\tTotal elapsed time: ${TOTAL_TIME} \\n"
       }
   }
 }
-        '''.replace('&&ARCH&&', ARCH).replace('&&AGENT_LABEL&&', ARCHS_AGENT_LABEL[ARCH]).replace('&&JAVA_HOME&&', ARCHS_JAVA_HOME[ARCH]))
+        ''')
       }
     }
   }

--- a/JenkinsJobs/AutomatedTests/I_unit_win32.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_win32.groovy
@@ -5,7 +5,7 @@ for (STREAM in STREAMS){
   def MAJOR = STREAM.split('\\.')[0]
   def MINOR = STREAM.split('\\.')[1]
 
-  pipelineJob('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-win32-java17'){
+  pipelineJob('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-win32-x86_64-java17'){
     description('Run Eclipse SDK Tests for the platform implied by this job\'s name')
     parameters { // Define parameters in job configuration to make them available from the very first build onwards
       stringParam('buildId', null, 'Build Id to test (such as I20240611-1800, N20120716-0800).')

--- a/JenkinsJobs/Builds/I_build.groovy
+++ b/JenkinsJobs/Builds/I_build.groovy
@@ -417,12 +417,12 @@ spec:
 	  stage('Trigger tests'){
           steps {
             container('jnlp') {
-              build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-cen64-gtk3-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
-              build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-cen64-gtk3-java21', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
-              build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-cen64-gtk3-java23', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
-              build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-macM1-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
-              build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-mac64-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
-              build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-win32-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
+              build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-linux-x86_64-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
+              build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-linux-x86_64-java21', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
+              build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-linux-x86_64-java23', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
+              build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-macosx-aarch64-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
+              build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-macosx-x86_64-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
+              build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-win32-x86_64-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
               build job: 'Start-smoke-tests', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
             }
           }

--- a/cje-production/Y-build/publish.xml
+++ b/cje-production/Y-build/publish.xml
@@ -182,9 +182,15 @@
         substring="-perf-" />
     </condition>
     <!-- else normal unit tests configs -->
-    <property
-      name="testsConfigExpected"
-      value="ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-mac64-java17_macosx.cocoa.x86_64_17,ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-macM1-java17_macosx.cocoa.aarch64_17,ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-win32-java17_win32.win32.x86_64_17,ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-cen64-gtk3-java17_linux.gtk.x86_64_17,ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-cen64-gtk3-java21_linux.gtk.x86_64_21,ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-cen64-gtk3-java24_linux.gtk.x86_64_24" />
+    <resources id="testsConfigExpected">
+      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-mac64-java17_macosx.cocoa.x86_64_17</string>
+      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-macM1-java17_macosx.cocoa.aarch64_17</string>
+      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-win32-java17_win32.win32.x86_64_17</string>
+      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-cen64-gtk3-java17_linux.gtk.x86_64_17</string>
+      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-cen64-gtk3-java21_linux.gtk.x86_64_21</string>
+      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-cen64-gtk3-java24_linux.gtk.x86_64_24</string>
+    </resources>
+    <pathconvert property="testsConfigExpected" refid="testsConfigExpected" pathsep="," />
 
     <condition
       property="expectedConfigFilename"

--- a/cje-production/scripts/publish.xml
+++ b/cje-production/scripts/publish.xml
@@ -182,9 +182,15 @@
         substring="-perf-" />
     </condition>
     <!-- else normal unit tests configs -->
-    <property
-      name="testsConfigExpected"
-      value="ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-mac64-java17_macosx.cocoa.x86_64_17,ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-macM1-java17_macosx.cocoa.aarch64_17,ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-win32-java17_win32.win32.x86_64_17,ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-cen64-gtk3-java17_linux.gtk.x86_64_17,ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-cen64-gtk3-java21_linux.gtk.x86_64_21,ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-cen64-gtk3-java23_linux.gtk.x86_64_23" />
+    <resources id="testsConfigExpected">
+      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-macosx-x86_64-java17_macosx.cocoa.x86_64_17</string>
+      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-macosx-aarch64-java17_macosx.cocoa.aarch64_17</string>
+      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-win32-x86_64-java17_win32.win32.x86_64_17</string>
+      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-linux-x86_64-java17_linux.gtk.x86_64_17</string>
+      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-linux-x86_64-java21_linux.gtk.x86_64_21</string>
+      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-linux-x86_64-java23_linux.gtk.x86_64_23</string>
+    </resources>
+    <pathconvert property="testsConfigExpected" refid="testsConfigExpected" pathsep="," />
 
     <condition
       property="expectedConfigFilename"

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/staticDropFiles/testConfigs.php
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/staticDropFiles/testConfigs.php
@@ -10,9 +10,9 @@
 include("buildproperties.php");
 
 $expectedTestConfigs = array();
-$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-mac64-java17_macosx.cocoa.x86_64_17";
-$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-macM1-java17_macosx.cocoa.aarch64_17";
-$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-win32-java17_win32.win32.x86_64_17";
-$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-cen64-gtk3-java17_linux.gtk.x86_64_17";
-$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-cen64-gtk3-java21_linux.gtk.x86_64_21";
-$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-cen64-gtk3-java23_linux.gtk.x86_64_23";
+$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-macosx-x86_64-java17_macosx.cocoa.x86_64_17";
+$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-macosx-aarch64-java17_macosx.cocoa.aarch64_17";
+$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-win32-x86_64-java17_win32.win32.x86_64_17";
+$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-linux-x86_64-java17_linux.gtk.x86_64_17";
+$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-linux-x86_64-java21_linux.gtk.x86_64_21";
+$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-linux-x86_64-java23_linux.gtk.x86_64_23";


### PR DESCRIPTION
and further simplify variable interpolation.
This simplifies later additions of new os-arch combinations.

I expect that this will change the labels and URLs of test reports accordingly, for example in
https://download.eclipse.org/eclipse/downloads/drops4/I20241025-1840/

But I assume that's not a problem, is it?
@akurtakov or @iloveeclipse or anybody else do you have any objections or do you anything that could be missing?

I tested locally that the changes in how to apply the variables in the job configs leads to the desired results, so from my side this is ready.