### PR TITLE
Downgrade Windows JDK used for tests from jdk-17.0.12.7 to jdk-17.0.11+9

### DIFF
--- a/JenkinsJobs/AutomatedTests/I_unit_win32_java17.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_win32_java17.groovy
@@ -31,7 +31,7 @@ pipeline {
       stage('Run tests'){
           environment {
               // Declaring a jdk and ant the usual way in the 'tools' section, because of unknown reasons, breaks the usage of system commands like xvnc, pkill and sh
-              JAVA_HOME = 'C:\\\\PROGRA~1\\\\ECLIPS~1\\\\jdk-17.0.12.7-hotspot\\\\'
+              JAVA_HOME = 'C:\\\\PROGRA~1\\\\ECLIPS~1\\\\jdk-17.0.11+9\\\\'
               PATH = "%JAVA_HOME%\\\\bin;C:\\\\ProgramData\\\\Boxstarter;C:\\\\Program Files\\\\IcedTeaWeb\\\\WebStart\\\\bin;C:\\\\Users\\\\jenkins_vnc\\\\AppData\\\\Local\\\\Microsoft\\\\WindowsApps;${env.PATH}"
           }
           steps {


### PR DESCRIPTION
Bug https://bugs.openjdk.org/browse/JDK-8336862 could be the reason for (all/some?) recent Windows test failures. 
Let try the previous version...

See https://github.com/eclipse-platform/eclipse.platform.swt/issues/1486 and https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5213