### PR TITLE
Adjust bundle path to match platform ui change

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
@@ -591,8 +591,8 @@
                                 ;${eclipse.platform.ui.bundles}/org.eclipse.ui.navigator.resources/src
                                 ;${eclipse.platform.ui.bundles}/org.eclipse.ui.views/src
                                 ;${eclipse.platform.ui.bundles}/org.eclipse.ui.views.properties.tabbed/src
-                                ;${eclipse.platform.ui.bundles}/org.eclipse.ui.workbench/Eclipse UI
-                                ;${eclipse.platform.ui.bundles}/org.eclipse.ui.workbench/Eclipse UI Editor Support
+                                ;${eclipse.platform.ui.bundles}/org.eclipse.ui.workbench/eclipseui
+                                ;${eclipse.platform.ui.bundles}/org.eclipse.ui.workbench/eclipseuieditorsupport
                                 ;${eclipse.platform.update}/org.eclipse.update.configurator/src
                                 ;${rt.equinox.bundles.bundles}/org.eclipse.equinox.http.jetty/src
                                 ;${rt.equinox.bundles.bundles}/org.eclipse.equinox.app/osgi


### PR DESCRIPTION
Refs : https://github.com/eclipse-platform/eclipse.platform.ui/pull/2411

Corresponding changes in  the workbench bundle in pom.xml in releng aggregator.

Tested locally and this is the only change that is required from releng aggregator.