### PR TITLE
[I-Build-Test] Remove CPU-arch as criterion for testPlatform property

### DIFF
--- a/production/testScripts/runTests2.xml
+++ b/production/testScripts/runTests2.xml
@@ -199,11 +199,6 @@
         <equals
           arg1="${osgi.ws}"
           arg2="win32" />
-        <or>
-          <equals
-            arg1="${osgi.arch}"
-            arg2="x86_64" />
-        </or>
       </and>
     </condition>
 
@@ -217,17 +212,6 @@
         <equals
           arg1="${osgi.ws}"
           arg2="gtk" />
-        <or>
-          <equals
-            arg1="${osgi.arch}"
-            arg2="x86_64" />
-          <equals
-            arg1="${osgi.arch}"
-            arg2="ppc64le" />
-          <equals
-            arg1="${osgi.arch}"
-            arg2="aarch64" />
-        </or>
       </and>
     </condition>
     <condition
@@ -240,14 +224,6 @@
         <equals
           arg1="${osgi.ws}"
           arg2="cocoa" />
-        <or>
-          <equals
-            arg1="${osgi.arch}"
-            arg2="x86_64" />
-          <equals
-            arg1="${osgi.arch}"
-            arg2="aarch64" />
-       	</or>
       </and>
     </condition>
     <echo message="[DEBUG] in runTest2.xml: os ws arch ${osgi.os} ${osgi.ws} ${osgi.arch}" />
@@ -267,7 +243,7 @@
       use mirror URLs? (though, that'd not effect production) -->
     <fail
       unless="testPlatform"
-      message="testPlatform did not match any of the supported combinations of osgi.os, osgi.ws, osgi.arch" />
+      message="testPlatform did not match any of the supported combinations of osgi.os, osgi.ws" />
     <condition
       property="getArtifacts"
       value="getwinzips">


### PR DESCRIPTION
All usages depending on the 'testPlatform' variable don't distinguish between architectures.
In case it is attempted to run the tests on a unsupported arch, checking the architecture too produces an explicit error message instead of just having a download that fails because the corresponding artifacts are not available. But those that run I-builds locally or configure a new platform are usually well aware if the executing architecture is supported or not.
And testing for the arch just makes it more complicated to run tests on new platforms.

This helps for example for https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/577.