### PR TITLE
Unify labels for Eclipse products and SWT artifacts at eclipse-downloads

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/testManifest.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/testManifest.xml
@@ -10,36 +10,36 @@
 
     <zipType name="Eclipse SDK">
       <platform
-        id="SWAARCH64"
-        name="Windows (ARM 64 bit version)"
-        fileName="eclipse-SDK-${BUILD_ID}-win32-aarch64.zip"></platform>
-      <platform
         id="SWX8664"
-        name="Windows (64 bit version)"
+        name="Windows (x86 64-bit)"
         fileName="eclipse-SDK-${BUILD_ID}-win32-x86_64.zip"></platform>
       <platform
+        id="SWAARCH64"
+        name="Windows (ARM 64-bit)"
+        fileName="eclipse-SDK-${BUILD_ID}-win32-aarch64.zip"></platform>
+      <platform
         id="SLG264"
-        name="Linux (64 bit version)"
+        name="Linux (x86 64-bit)"
         fileName="eclipse-SDK-${BUILD_ID}-linux-gtk-x86_64.tar.gz"></platform>
       <platform
+        id="SLG2AARCH64"
+        name="Linux (ARM 64-bit)"
+        fileName="eclipse-SDK-${BUILD_ID}-linux-gtk-aarch64.tar.gz"></platform>
+      <platform
         id="SLG2PPC64LE"
-        name="Linux (64 bit version for Power PC)"
+        name="Linux (PowerPC 64-bit)"
         fileName="eclipse-SDK-${BUILD_ID}-linux-gtk-ppc64le.tar.gz"></platform>
       <platform
         id="SLG2RISCV64"
-        name="Linux (64 bit version for RISC-V)"
+        name="Linux (RISC-V 64-bit)"
         fileName="eclipse-SDK-${BUILD_ID}-linux-gtk-riscv64.tar.gz"></platform>
       <platform
-        id="SLG2AARCH64"
-        name="Linux (64 bit version for AArch64)"
-        fileName="eclipse-SDK-${BUILD_ID}-linux-gtk-aarch64.tar.gz"></platform>
-      <platform
         id="SMCC64"
-        name="Mac OSX (64 bit version)"
+        name="Mac OSX (x86 64-bit)"
         fileName="eclipse-SDK-${BUILD_ID}-macosx-cocoa-x86_64.dmg"></platform>
       <platform
         id="SMCCARM64"
-        name="Mac OSX (64 bit version for Arm64/AArch64)"
+        name="Mac OSX (ARM 64-bit)"
         fileName="eclipse-SDK-${BUILD_ID}-macosx-cocoa-aarch64.dmg"></platform>     
 
       <!--
@@ -59,36 +59,36 @@
 
     <zipType name="Platform Runtime Binary">
       <platform
-        id="PWAARCH64"
-        name="Windows (ARM 64 bit version)"
-        fileName="eclipse-platform-${BUILD_ID}-win32-aarch64.zip"></platform>
-      <platform
         id="PWX8664"
-        name="Windows (64 bit version)"
+        name="Windows (x86 64-bit)"
         fileName="eclipse-platform-${BUILD_ID}-win32-x86_64.zip"></platform>
       <platform
+        id="PWAARCH64"
+        name="Windows (ARM 64-bit)"
+        fileName="eclipse-platform-${BUILD_ID}-win32-aarch64.zip"></platform>
+      <platform
         id="PLG264"
-        name="Linux (64 bit version)"
+        name="Linux (x86 64-bit)"
         fileName="eclipse-platform-${BUILD_ID}-linux-gtk-x86_64.tar.gz"></platform>
       <platform
+        id="PLG2AARCH64"
+        name="Linux (ARM 64-bit)"
+        fileName="eclipse-platform-${BUILD_ID}-linux-gtk-aarch64.tar.gz"></platform>
+      <platform
         id="PLG2PPC64LE"
-        name="Linux (64 bit version for Power PC)"
+        name="Linux (PowerPC 64-bit)"
         fileName="eclipse-platform-${BUILD_ID}-linux-gtk-ppc64le.tar.gz"></platform>
       <platform
         id="PLG2RISCV64"
-        name="Linux (64 bit version for RISC-V)"
+        name="Linux (RISC-V 64-bit)"
         fileName="eclipse-platform-${BUILD_ID}-linux-gtk-riscv64.tar.gz"></platform>
       <platform
-        id="PLG2AARCH64"
-        name="Linux (64 bit version for AArch64)"
-        fileName="eclipse-platform-${BUILD_ID}-linux-gtk-aarch64.tar.gz"></platform>
-      <platform
         id="PMCC64"
-        name="Mac OSX (64 bit version)"
+        name="Mac OSX (x86 64-bit)"
         fileName="eclipse-platform-${BUILD_ID}-macosx-cocoa-x86_64.dmg"></platform>
       <platform
         id="PMCCARM64"
-        name="Mac OSX (64 bit version for Arm64/AArch64)"
+        name="Mac OSX (ARM 64-bit)"
         fileName="eclipse-platform-${BUILD_ID}-macosx-cocoa-aarch64.dmg"></platform>
       <platform
         id="PLR"
@@ -109,36 +109,36 @@
 
     <zipType name="SWT">
       <platform
-        id="SWTWAARCH64"
-        name="Windows (ARM 64 bit version)"
-        fileName="swt-${BUILD_ID}-win32-win32-aarch64.zip"></platform>
-      <platform
         id="SWTWX86_64"
-        name="Windows (64 bit version)"
+        name="Windows (x86 64-bit)"
         fileName="swt-${BUILD_ID}-win32-win32-x86_64.zip"></platform>
       <platform
+        id="SWTWAARCH64"
+        name="Windows (ARM 64-bit)"
+        fileName="swt-${BUILD_ID}-win32-win32-aarch64.zip"></platform>
+      <platform
         id="SWTLG64"
-        name="Linux (64 bit version)"
+        name="Linux (x86 64-bit)"
         fileName="swt-${BUILD_ID}-gtk-linux-x86_64.zip"></platform>
       <platform
+        id="SWTLG2AARCH64"
+        name="Linux (ARM 64-bit)"
+        fileName="swt-${BUILD_ID}-gtk-linux-aarch64.zip"></platform>
+      <platform
         id="SWTLG2PPC64LE"
-        name="Linux (64 bit version for Power PC)"
+        name="Linux (PowerPC 64-bit)"
         fileName="swt-${BUILD_ID}-gtk-linux-ppc64le.zip"></platform>
       <platform
         id="SWTLG2RISCV64"
-        name="Linux (64 bit version for RISC-V)"
+        name="Linux (RISC-V 64-bit)"
         fileName="swt-${BUILD_ID}-gtk-linux-riscv64.zip"></platform>
       <platform
-        id="SWTLG2AARCH64"
-        name="Linux (64 bit version for AArch64)"
-        fileName="swt-${BUILD_ID}-gtk-linux-aarch64.zip"></platform>
-      <platform
         id="SWTMCC64"
-        name="Mac OSX (64 bit version)"
+        name="Mac OSX (x86 64-bit)"
         fileName="swt-${BUILD_ID}-cocoa-macosx-x86_64.zip"></platform>
       <platform
         id="SWTMCCARM64"
-        name="Mac OSX (64 bit version for Arm64/AArch64)"
+        name="Mac OSX (ARM 64-bit)"
         fileName="swt-${BUILD_ID}-cocoa-macosx-aarch64.zip"></platform>
     </zipType>
 


### PR DESCRIPTION
For the eclipse downloads page at
https://download.eclipse.org/eclipse/downloads/
This unifies the labels for all offered products and artifacts:
- use '64-bit' instead of '64 bit version'
- always list x86_64 artifact first
- unify descriptions of artifacts for other CPU architectures

The current labels can for example be seen at
https://download.eclipse.org/eclipse/downloads/drops4/I20241028-0700/#EclipseSDK

The new labels would be
- `Windows (64-bit)`
- `Windows (64-bit for ARM)`
- `Linux (64-bit)`
- `Linux (64-bit for ARM)`
- `Linux (64-bit for Power PC)`
- `Linux (64-bit for RISC-V)`
- `Mac OSX (64-bit)`
- `Mac OSX (64-bit for ARM)`

Alternatively we could also add the architecture to for the x86_64 artifacts explicitly and label it `(64-bit for x86)`? But I still would list it first since it's the most important arch (at the moment).
What do you think?