### PR TITLE
[I-Build] Add nightly tests for win32.win32.aarch64

### DIFF
--- a/jobs/buildConfigurations.json
+++ b/jobs/buildConfigurations.json
@@ -74,6 +74,17 @@
 					"type": "local",
 					"path": "C:\\Program Files\\Eclipse Adoptium\\jdk-21.0.5.11-hotspot"
 				}
+			},
+			{
+				"os": "win32",
+				"ws": "win32",
+				"arch": "aarch64",
+				"javaVersion": 21,
+				"agent": "rie8t-win11-arm64",
+				"jdk": {
+					"type": "temurin",
+					"ea": "true"
+				}
 			}
 		]
 	},


### PR DESCRIPTION
Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/577

This is currently a draft since I first have to figure out in a copy of the existing test jobs which software is currently missing from the machine running the tests.