### PR TITLE
[Build] remove windows2012tests authentication token from Jenkins jobs

### DIFF
--- a/JenkinsJobs/AutomatedTests/I_unit_mac.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_mac.groovy
@@ -16,8 +16,6 @@ for (ARCH in ARCHS){
       stringParam('buildId', null, 'Build Id to test (such as I20240611-1800, N20120716-0800).')
     }
 
-    authenticationToken('windows2012tests')
- 
     definition {
       cps {
         sandbox()

--- a/JenkinsJobs/AutomatedTests/I_unit_win32.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_win32.groovy
@@ -11,8 +11,6 @@ for (STREAM in STREAMS){
       stringParam('buildId', null, 'Build Id to test (such as I20240611-1800, N20120716-0800).')
     }
 
-    authenticationToken('windows2012tests')
- 
     definition {
       cps {
         sandbox()

--- a/JenkinsJobs/PerformanceTests/ILR_perf_lin64.groovy
+++ b/JenkinsJobs/PerformanceTests/ILR_perf_lin64.groovy
@@ -49,8 +49,6 @@ jdtuirefactoring
 
     label('performance')
 
-    authenticationToken('windows2012tests')
-
     wrappers { //adds pre/post actions
       timestamps()
       preBuildCleanup()

--- a/JenkinsJobs/PerformanceTests/ILR_perf_lin64_baseline.groovy
+++ b/JenkinsJobs/PerformanceTests/ILR_perf_lin64_baseline.groovy
@@ -49,8 +49,6 @@ jdtuirefactoring
 
     label('performance')
 
-    authenticationToken('windows2012tests')
-
     wrappers { //adds pre/post actions
       timestamps()
       preBuildCleanup()

--- a/JenkinsJobs/PerformanceTests/I_perf_lin64.groovy
+++ b/JenkinsJobs/PerformanceTests/I_perf_lin64.groovy
@@ -49,8 +49,6 @@ jdtuirefactoring
 
     label('performance')
 
-    authenticationToken('windows2012tests')
-
     wrappers { //adds pre/post actions
       timestamps()
       preBuildCleanup()

--- a/JenkinsJobs/PerformanceTests/I_perf_lin64_baseline.groovy
+++ b/JenkinsJobs/PerformanceTests/I_perf_lin64_baseline.groovy
@@ -49,8 +49,6 @@ jdtuirefactoring
 
     label('performance')
 
-    authenticationToken('windows2012tests')
-
     wrappers { //adds pre/post actions
       timestamps()
       preBuildCleanup()

--- a/JenkinsJobs/SmokeTests/smoke_test_ppcle.groovy
+++ b/JenkinsJobs/SmokeTests/smoke_test_ppcle.groovy
@@ -17,8 +17,6 @@ job('SmokeTests/ep-smoke-test-ppcle'){
 
   jdk('openjdk-jdk17-latest')
 
-  authenticationToken('windows2012tests')
- 
   wrappers { //adds pre/post actions
     timestamps()
     preBuildCleanup()

--- a/JenkinsJobs/SmokeTests/smoke_test_win32.groovy
+++ b/JenkinsJobs/SmokeTests/smoke_test_win32.groovy
@@ -13,8 +13,6 @@ job('SmokeTests/ep-smoke-test-win32'){
 
   label('qa6xd-win11')
 
-  authenticationToken('windows2012tests')
- 
   wrappers { //adds pre/post actions
     timestamps()
     preBuildCleanup()

--- a/JenkinsJobs/YBuilds/Y_unit_mac64_java17.groovy
+++ b/JenkinsJobs/YBuilds/Y_unit_mac64_java17.groovy
@@ -23,8 +23,6 @@ for (STREAM in STREAMS){
 	
 	  jdk('openjdk-jdk11-latest')
 	
-	  authenticationToken('windows2012tests')
-	 
 	  wrappers { //adds pre/post actions
 	
 	    timestamps()

--- a/JenkinsJobs/YBuilds/Y_unit_macM1_java17.groovy
+++ b/JenkinsJobs/YBuilds/Y_unit_macM1_java17.groovy
@@ -22,8 +22,6 @@ for (STREAM in STREAMS){
 	
 	  jdk('openjdk-jdk11-latest')
 	
-	  authenticationToken('windows2012tests')
-	 
 	  wrappers { //adds pre/post actions
 	    timestamps()
 	    timeout {

--- a/JenkinsJobs/YBuilds/Y_unit_win32_java17.groovy
+++ b/JenkinsJobs/YBuilds/Y_unit_win32_java17.groovy
@@ -18,8 +18,6 @@ for (STREAM in STREAMS){
 	
 	  label('qa6xd-win11')
 	
-	  authenticationToken('windows2012tests')
-	 
 	  wrappers { //adds pre/post actions
 	    timestamps()
 	    timeout {

--- a/production/testScripts/startTests.sh
+++ b/production/testScripts/startTests.sh
@@ -125,7 +125,7 @@ echo "BUILD_HOME: ${BUILD_HOME}"
 
 echo "DEBUG: invoking test scripts on Hudson"
 
-HUDSON_TOKEN=windows2012tests ant \
+ant \
   -DpostingDirectory=${buildDropDir} \
   -DbuildId=${buildId} \
   -DeclipseStream=${eclipseStream} \


### PR DESCRIPTION
@fredg02 or @heurtematte or anybody else, can you tell if `windows2012tests` authentication token is still useful?
I have the impression it is not.