### PR TITLE
[I-Build-Tests] Clean-up and unify test launch scripts

### DIFF
--- a/JenkinsJobs/AutomatedTests/I_unit_linux.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_linux.groovy
@@ -88,6 +88,7 @@ spec:
               JAVA_HOME = tool(type:'jdk', name:'openjdk-jdk''' + JAVA_VERSION + '''-latest')
               ANT_HOME = tool(type:'ant', name:'apache-ant-latest')
               PATH = "${JAVA_HOME}/bin:${ANT_HOME}/bin:${PATH}"
+              ANT_OPTS = "-Djava.io.tmpdir=${WORKSPACE}/tmp -Djava.security.manager=allow"
           }
           steps {
               container ('custom'){
@@ -95,52 +96,38 @@ spec:
                       sh \'\'\'#!/bin/bash -x
                         
                         buildId=$(echo $buildId|tr -d ' ')
-                        RAW_DATE_START="$(date +%s )"
-                        
                         export LANG=en_US.UTF-8
                         cat /etc/*release
-                        echo -e "\\n\\tRAW Date Start: ${RAW_DATE_START} \\n"
-                        echo -e "\\n\\t whoami:  $( whoami )\\n"
-                        echo -e "\\n\\t uname -a: $(uname -a)\\n"
+                        echo "whoami:  $(whoami)"
+                        echo "uname -a: $(uname -a)"
                         
                         # 0002 is often the default for shell users, but it is not when ran from
                         # a cron job, so we set it explicitly, to be sure of value, so releng group has write access to anything
                         # we create on shared area.
                         oldumask=$(umask)
                         umask 0002
-                        
                         echo "umask explicitly set to 0002, old value was $oldumask"
                         
                         # we want java.io.tmpdir to be in $WORKSPACE, but must already exist, for Java to use it.
-                        mkdir -p ${WORKSPACE}/tmp
+                        mkdir -p tmp
                         
-                        wget -O ${WORKSPACE}/getEBuilder.xml --no-verbose --no-check-certificate https://download.eclipse.org/eclipse/relengScripts/production/testScripts/hudsonBootstrap/getEBuilder.xml 2>&1
-                        wget -O ${WORKSPACE}/buildproperties.shsource --no-check-certificate https://download.eclipse.org/eclipse/downloads/drops4/${buildId}/buildproperties.shsource
-                        cat ${WORKSPACE}/buildproperties.shsource
-                        source ${WORKSPACE}/buildproperties.shsource
+                        curl -o getEBuilder.xml https://download.eclipse.org/eclipse/relengScripts/production/testScripts/hudsonBootstrap/getEBuilder.xml
+                        curl -o buildproperties.shsource https://download.eclipse.org/eclipse/downloads/drops4/${buildId}/buildproperties.shsource
+                        source buildproperties.shsource
                         
                         echo JAVA_HOME: $JAVA_HOME
                         echo ANT_HOME: $ANT_HOME
                         echo PATH: $PATH
-                        export ANT_OPTS="${ANT_OPTS} -Djava.io.tmpdir=${WORKSPACE}/tmp -Djava.security.manager=allow"
                         
                         env 1>envVars.txt 2>&1
                         ant -diagnostics 1>antDiagnostics.txt 2>&1
                         java -XshowSettings -version 1>javaSettings.txt 2>&1
                         
-                        ant -f getEBuilder.xml -Djava.io.tmpdir=${WORKSPACE}/tmp -DbuildId=$buildId -DeclipseStream=$STREAM -DEBUILDER_HASH=${EBUILDER_HASH} \\
+                        ant -f getEBuilder.xml -DbuildId=${buildId} -DeclipseStream=${STREAM} -DEBUILDER_HASH=${EBUILDER_HASH} \\
                           -DdownloadURL=https://download.eclipse.org/eclipse/downloads/drops4/${buildId} \\
                           -Dosgi.os=linux -Dosgi.ws=gtk -Dosgi.arch=x86_64 \\
-                          -DtestSuite=all \\
-                          -Djvm=${JAVA_HOME}/bin/java
-                        
-                        RAW_DATE_END="$(date +%s )"
-                        
-                        echo -e "\\n\\tRAW Date End: ${RAW_DATE_END} \\n"
-                        
-                        TOTAL_TIME=$((${RAW_DATE_END} - ${RAW_DATE_START}))
-                        
-                        echo -e "\\n\\tTotal elapsed time: ${TOTAL_TIME} \\n"
+                          -DtestSuite=all
+                        # For smaller test-suites see: https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/be721e33c916b03c342e7b6f334220c6124946f8/production/testScripts/configuration/sdk.tests/testScripts/test.xml#L1893-L1903
                       \'\'\'
                   }
               }

--- a/JenkinsJobs/AutomatedTests/I_unit_win32.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_win32.groovy
@@ -29,40 +29,45 @@ pipeline {
       stage('Run tests'){
           environment {
               // Declaring a jdk and ant the usual way in the 'tools' section, because of unknown reasons, breaks the usage of system commands like xvnc, pkill and sh
-              JAVA_HOME = 'C:\\\\PROGRA~1\\\\ECLIPS~1\\\\jdk-17.0.11+9\\\\'
-              PATH = "%JAVA_HOME%\\\\bin;C:\\\\ProgramData\\\\Boxstarter;C:\\\\Program Files\\\\IcedTeaWeb\\\\WebStart\\\\bin;C:\\\\Users\\\\jenkins_vnc\\\\AppData\\\\Local\\\\Microsoft\\\\WindowsApps;${env.PATH}"
+              JAVA_HOME = 'C:\\\\Program Files\\\\Eclipse Adoptium\\\\jdk-17.0.11+9'
+              ANT_HOME = tool(type:'ant', name:'apache-ant-latest')
+              PATH = "${JAVA_HOME}\\\\bin;${ANT_HOME}\\\\bin;${PATH}"
+              ANT_OPTS = "-Djava.io.tmpdir=${WORKSPACE}\\\\tmp -Djava.security.manager=allow"
           }
           steps {
               cleanWs() // workspace not cleaned by default
               bat \'\'\'
-rem May want to try and restrict path, as we do on cron jobs, so we
-rem have more consistent conditions.
-rem export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:~/bin
+@REM May want to try and restrict path, as we do on cron jobs, so we
+@REM have more consistent conditions.
+@REM export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:~/bin
 
-rem tmp must already exist, for Java to make use of it, in subsequent steps
-rem no -p (or /p) needed on Windows. It creates 
+@REM tmp must already exist, for Java to make use of it, in subsequent steps
+@REM no -p (or /p) needed on Windows. It creates 
 mkdir tmp
 
-rem Note: currently this file always comes from master, no matter what branch is being built/tested.
-wget -O getEBuilder.xml --no-verbose https://download.eclipse.org/eclipse/relengScripts/production/testScripts/hudsonBootstrap/getEBuilder.xml 2>&1
-set buildId
-wget -O buildProperties.properties https://download.eclipse.org/eclipse/downloads/drops4/%buildId%/buildproperties.properties
+@REM Note: currently this file always comes from master, no matter what branch is being built/tested.
+curl -o getEBuilder.xml https://download.eclipse.org/eclipse/relengScripts/production/testScripts/hudsonBootstrap/getEBuilder.xml
+curl -o buildProperties.properties https://download.eclipse.org/eclipse/downloads/drops4/%buildId%/buildproperties.properties
 echo off
 For /F "tokens=1* delims==" %%A IN (buildProperties.properties) DO (
  IF "%%A"=="STREAM " set STREAM=%%B
  IF "%%A"=="EBUILDER_HASH " set EBUILDER_HASH=%%B
 ) 
 echo on
-set STREAM
-set EBUILDER_HASH
-set JAVA_HOME
 
-ant -f getEBuilder.xml -Djava.io.tmpdir=%WORKSPACE%/tmp -DbuildId=%buildId%  -DeclipseStream=%STREAM% -DEBUILDER_HASH=%EBUILDER_HASH% ^
+set JAVA_HOME
+set ANT_HOME
+set PATH
+
+env 1>envVars.txt 2>&1
+ant -diagnostics 1>antDiagnostics.txt 2>&1
+java -XshowSettings -version 1>javaSettings.txt 2>&1
+
+ant -f getEBuilder.xml -DbuildId=%buildId%  -DeclipseStream=%STREAM% -DEBUILDER_HASH=%EBUILDER_HASH% ^
   -DdownloadURL="https://download.eclipse.org/eclipse/downloads/drops4/%buildId%" ^
   -Dargs=all -Dosgi.os=win32 -Dosgi.ws=win32 -Dosgi.arch=x86_64 ^
-  -DtestSuite=all ^
-   -Djvm="%JAVA_HOME%\\\\bin\\\\java.exe"
-
+  -DtestSuite=all
+@REM For smaller test-suites see: https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/be721e33c916b03c342e7b6f334220c6124946f8/production/testScripts/configuration/sdk.tests/testScripts/test.xml#L1893-L1903
               \'\'\'
               archiveArtifacts '**/eclipse-testing/results/**, **/eclipse-testing/directorLogs/**, *.properties, *.txt'
               junit keepLongStdio: true, testResults: '**/eclipse-testing/results/xml/*.xml'

--- a/production/testScripts/configuration/sdk.tests/testScripts/runtests.bat
+++ b/production/testScripts/configuration/sdk.tests/testScripts/runtests.bat
@@ -69,8 +69,6 @@ set /p launcher-jar=<launcher-jar-name.txt
 echo "list all environment variables in effect as tests start"
 set
 
-rem -Dtimeout=300000 "%ANT_OPTS%"
-
 IF NOT EXIST %jvm% (
 ECHO ERROR: jvm not defined or does not exist: %jvm%
 exit 1
@@ -80,11 +78,11 @@ REM -XshowSettings is supported on windows VMs but ... not every where. So where
 REM causes VM to not start at all. Can be handy for diagnostics. (without running ant <echoproperties/>
 
 IF DEFINED extdirproperty (
-%jvm%  %extdirproperty%  -Dosgi.os=%os% -Dosgi.ws=%ws% -Dosgi.arch=%arch% -jar eclipse\plugins\%launcher-jar% -data workspace -application org.eclipse.ant.core.antRunner -file test.xml %tests% -Dws=%ws% -Dos=%os% -Darch=%arch%  -D%installmode%=true %properties% -logger org.apache.tools.ant.DefaultLogger
+%jvm% %ANT_OPTS% %extdirproperty% -Dosgi.os=%os% -Dosgi.ws=%ws% -Dosgi.arch=%arch% -jar eclipse\plugins\%launcher-jar% -data workspace -application org.eclipse.ant.core.antRunner -file test.xml %tests% -Dws=%ws% -Dos=%os% -Darch=%arch% -D%installmode%=true %properties% -logger org.apache.tools.ant.DefaultLogger
 GOTO END
 )
 
-%jvm%  -Dosgi.os=%os% -Dosgi.ws=%ws% -Dosgi.arch=%arch% -jar eclipse\plugins\%launcher-jar% -data workspace -application org.eclipse.ant.core.antRunner -file test.xml %tests% -Dws=%ws% -Dos=%os% -Darch=%arch%  -D%installmode%=true %properties% -logger org.apache.tools.ant.DefaultLogger
+%jvm% %ANT_OPTS% -Dosgi.os=%os% -Dosgi.ws=%ws% -Dosgi.arch=%arch% -jar eclipse\plugins\%launcher-jar% -data workspace -application org.eclipse.ant.core.antRunner -file test.xml %tests% -Dws=%ws% -Dos=%os% -Darch=%arch% -D%installmode%=true %properties% -logger org.apache.tools.ant.DefaultLogger
 
 :END
 

--- a/production/testScripts/configuration/sdk.tests/testScripts/runtests.sh
+++ b/production/testScripts/configuration/sdk.tests/testScripts/runtests.sh
@@ -217,12 +217,11 @@ echo "platformParmString: ${platformParmString}"
 echo "platformString: ${platformString}"
 echo "testedPlatform: ${testedPlatform}"
 
-# -Dtimeout=300000 "${ANT_OPTS}"
 if [[ -n "${extdirproperty}" ]]
 then
   echo "running with extdir defined"
-  $jvm ${ANT_OPTS} "${extdirproperty}" ${platformArgString} -jar $launcher -data workspace -application org.eclipse.ant.core.antRunner -file ${PWD}/test.xml ${ANT_OPTS} ${platformParmString} -D$installmode=true $properties -logger org.apache.tools.ant.DefaultLogger $tests 2>&1 | tee $consolelogs
+  $jvm ${ANT_OPTS} "${extdirproperty}" ${platformArgString} -jar $launcher -data workspace -application org.eclipse.ant.core.antRunner -file ${PWD}/test.xml ${platformParmString} -D$installmode=true $properties -logger org.apache.tools.ant.DefaultLogger $tests
 else
   echo "running without extdir defined"
-  $jvm ${ANT_OPTS} ${platformArgString}  -jar $launcher -data workspace -application org.eclipse.ant.core.antRunner -file ${PWD}/test.xml  ${ANT_OPTS} ${platformParmString} -D$installmode=true $properties -logger org.apache.tools.ant.DefaultLogger  $tests 2>&1 | tee $consolelogs
+  $jvm ${ANT_OPTS} ${platformArgString} -jar $launcher -data workspace -application org.eclipse.ant.core.antRunner -file ${PWD}/test.xml ${platformParmString} -D$installmode=true $properties -logger org.apache.tools.ant.DefaultLogger $tests
 fi

--- a/production/testScripts/configuration/sdk.tests/testScripts/runtestsmac.sh
+++ b/production/testScripts/configuration/sdk.tests/testScripts/runtestsmac.sh
@@ -131,12 +131,11 @@ fi
 
 echo "properties: $properties"
 
-# -Dtimeout=300000 "${ANT_OPTS}"
 if [[ ! -z "${extdirproperty}" ]]
 then
-  $jvm "${extdirproperty}" -Dosgi.os=$os -Dosgi.ws=$ws -Dosgi.arch=$arch  -jar $launcher -data workspace -application org.eclipse.ant.core.antRunner -file ${PWD}/test.xml $tests -Dws=$ws -Dos=$os -Darch=$arch -D$installmode=true $properties -logger org.apache.tools.ant.DefaultLogger
+  $jvm ${ANT_OPTS} "${extdirproperty}" -Dosgi.os=$os -Dosgi.ws=$ws -Dosgi.arch=$arch -jar $launcher -data workspace -application org.eclipse.ant.core.antRunner -file ${PWD}/test.xml $tests -Dws=$ws -Dos=$os -Darch=$arch -D$installmode=true $properties -logger org.apache.tools.ant.DefaultLogger
 else
-  $jvm -Dosgi.os=$os -Dosgi.ws=$ws -Dosgi.arch=$arch  -jar $launcher -data workspace -application org.eclipse.ant.core.antRunner -file ${PWD}/test.xml $tests -Dws=$ws -Dos=$os -Darch=$arch -D$installmode=true $properties -logger org.apache.tools.ant.DefaultLogger
+  $jvm ${ANT_OPTS} -Dosgi.os=$os -Dosgi.ws=$ws -Dosgi.arch=$arch -jar $launcher -data workspace -application org.eclipse.ant.core.antRunner -file ${PWD}/test.xml $tests -Dws=$ws -Dos=$os -Darch=$arch -D$installmode=true $properties -logger org.apache.tools.ant.DefaultLogger
 fi
 
 

--- a/production/testScripts/runTests2.xml
+++ b/production/testScripts/runTests2.xml
@@ -842,9 +842,14 @@
       name="VMSource"
       value="VM used for tests, is same that invoked Ant: '${java.home}/bin/java' (that is, 'jvm' not specified by caller)." />
     <echo message="VMSource: ${VMSource}" />
-    <property
-      name="jvm"
-      value="${java.home}/bin/java" />
+    <condition
+      property="jvm"
+      value="${java.home}\bin\java.exe"
+      else="${java.home}/bin/java">
+        <equals
+          arg1="${testPlatform}"
+          arg2="windows" />
+    </condition>
 
     <echo message="full output from 'java -version' of ${jvm} is" />
     <exec

--- a/production/testScripts/test_runTests2.xml.sh
+++ b/production/testScripts/test_runTests2.xml.sh
@@ -51,7 +51,6 @@ export WORKSPACE=${HOME}/tempworkarea
 # This variable signals parts of the script that we are testing the test scripts,
 # and should not actually start the tests.
 export TESTING_TEST_XML=true
-#export ANT_OPTS=-Xms1024m -Xmx1024m -Djava.io.tmpdir=${WORKSPACE}/tmp
 export ANT_OPTS=-Djava.io.tmpdir=${WORKSPACE}/tmp
 mkdir -p ${WORKSPACE}/tmp
 if [[ "$1" == "-c" ]]


### PR DESCRIPTION
- Use curl instead of wget (the former seems to be available on more machines by default, but I'll very this).
- Remove unnecessary whitespace in print-out and just use
- Remove unnecessary print-outs and unnecessary variable references