### PR TITLE
[I-Build] Fix test result summary configuration label break-up

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/staticDropFiles/logs.php
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/staticDropFiles/logs.php
@@ -66,13 +66,9 @@ listLogs("compilelogs");
 
 <?php
 listLogs("$testresults/consolelogs");
-listDetailedLogs($testresults,$expectedTestConfigs[0]);
-listDetailedLogs($testresults,$expectedTestConfigs[1]);
-listDetailedLogs($testresults,$expectedTestConfigs[2]);
-listDetailedLogs($testresults,$expectedTestConfigs[3]);
-listDetailedLogs($testresults,$expectedTestConfigs[4]);
-listDetailedLogs($testresults,$expectedTestConfigs[5]);
-listDetailedLogs($testresults,$expectedTestConfigs[6]);
+foreach ($expectedTestConfigs as $expectedTestConfig) {
+	listDetailedLogs($testresults, $expectedTestConfig);
+}
 ?>
 
 </div>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/staticDropFiles/utilityFunctions.php
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/staticDropFiles/utilityFunctions.php
@@ -276,7 +276,7 @@ be split as
  */
 function computeDisplayConfig($config) {
   $lastUnderscore = strrpos ($config, "_");
-  $firstUnderscore = strpos ($config, "_"); 
+  $firstUnderscore = strpos ($config, "_", strpos($config, "x86_64") + 6);
   $platformLength=$lastUnderscore - $firstUnderscore - 1;
   //echo "<br/>DEBUG: config: $config firstUnderscore: $firstUnderscore  lastUnderscore: $lastUnderscore  lastMinusFirst: $platformLength"
   $jobname = substr($config,0,$firstUnderscore);
@@ -293,7 +293,7 @@ function computeDisplayConfig($config) {
    which is 'jobname' on Hudson.
  */
 function jobname($config) {
-  $firstUnderscore = strpos ($config, "_");
+  $firstUnderscore = strpos ($config, "_", strpos($config, "x86_64") + 6);
   $jobname = substr($config,0,$firstUnderscore);
   return $jobname;
 }


### PR DESCRIPTION
The underscore in 'x86_64' is still part of the first part, the 'job-name' part, of the configuration label.
Therefore the only the first underscore after x86_64 should be considered as delimiter.

Additionally improve dynamic adaption of listing of log files.

Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2494 (at least it should).

This will also fix the wrong display of label line breaks. The wrong break-up is also the cause for the wrong numbers because, because simplify speaking, the test-result folder name must start with the 'first line' of the label to be considered a match.
Therefore the jobnames for the linux test-configs are all the same and the first one in the file-system is used for all Linux configs:
![grafik](https://github.com/user-attachments/assets/970f0915-7240-4b2c-bee7-c55e492257c3)
