### PR TITLE
[I-Build-Tests] Simplify archive name computation and don't guess os, ws and arch

### DIFF
--- a/production/testScripts/configuration/sdk.tests/testScripts/test.xml
+++ b/production/testScripts/configuration/sdk.tests/testScripts/test.xml
@@ -215,92 +215,6 @@
 
   </target>
 
-  <!--use an stable version of the director so that instability in the current build doesn't cause all the tests to fail -->
-  <target
-    name="initPlatformArhiveName"
-    unless="platformArchive">
-    <echo message="os.arch ${os.arch}" />
-
-    <condition
-      property="platformArchive"
-      value="eclipse-platform-${previousReleaseVersion}-macosx-cocoa-x86_64.dmg">
-      <and>
-        <os family="mac" />
-        <os family="unix" />
-        <or>
-          <os arch="x86_64" />
-          <os arch="amd64" />
-        </or>
-      </and>
-    </condition>
-    <condition
-      property="platformArchive"
-      value="eclipse-platform-${previousReleaseVersion}-macosx-cocoa-aarch64.dmg">
-      <and>
-        <os family="mac" />
-        <os family="unix" />
-        <or>
-          <os arch="aarch64" />
-          <os arch="arm64" />
-          <os arch="arm64e" />
-        </or>
-      </and>
-    </condition>
-    <condition
-      property="platformArchive"
-      value="eclipse-platform-${previousReleaseVersion}-macosx-cocoa.dmg">
-      <and>
-        <os family="mac" />
-        <os family="unix" />
-        <!-- should not need, as long as x86_64 rules (above) comes first
-          <os arch="i386" />
-        -->
-      </and>
-    </condition>
-    <condition
-      property="platformArchive"
-      value="eclipse-platform-${previousReleaseVersion}-win32-x86_64.zip">
-      <and>
-        <os family="windows" />
-        <or>
-          <os arch="x86_64" />
-          <os arch="amd64" />
-        </or>
-      </and>
-    </condition>
-    <condition
-      property="platformArchive"
-      value="eclipse-platform-${previousReleaseVersion}-linux-gtk-x86_64.tar.gz">
-      <and>
-        <os family="unix" />
-        <or>
-          <os arch="x86_64" />
-          <os arch="amd64" />
-        </or>
-      </and>
-    </condition>
-    <condition
-      property="platformArchive"
-      value="eclipse-platform-${previousReleaseVersion}-linux-gtk-ppc64le.tar.gz">
-      <and>
-        <os family="unix" />
-        <os arch="ppc64le" />
-      </and>
-    </condition>
-    <condition
-      property="platformArchive"
-      value="eclipse-platform-${previousReleaseVersion}-linux-gtk-aarch64.tar.gz">
-      <and>
-        <os family="unix" />
-        <os arch="aarch64" />
-      </and>
-    </condition>
-
-    <fail
-      unless="platformArchive"
-      message="platformArchive is not defined. Check that conditions cover os arch ${os.arch}. May be VM dependent.)" />
-
-  </target>
   <target name="setupPlatform">
     <condition
       property="platformTarget"
@@ -878,7 +792,7 @@
 
   <target
     name="init"
-    depends="initWorkspace,initProductionProperties,initBuildId, initBuildType, initDownloadHosts, initStreamVariables, initCurrentUpdateSite, initBasicDirectories,initOSes, initPlatformArhiveName, setRuntimeArchive"
+    depends="initWorkspace,initProductionProperties,initBuildId, initBuildType, initDownloadHosts, initStreamVariables, initCurrentUpdateSite, initBasicDirectories,initOSes, initPlatformAndRuntimeArchiveName"
     unless="testingIsInitialized">
 
     <property environment="env" />
@@ -990,7 +904,7 @@
     job.
   -->
   <target
-    name="setRuntimeArchive"
+    name="initPlatformAndRuntimeArchiveName"
     unless="runtimeArchive">
 
     <condition
@@ -999,11 +913,11 @@
       else="${buildId}">
       <istrue value="${baselinePerf}" />
     </condition>
-    <echo message="setRuntimeArchive os ${os} ws ${ws} arch ${arch}" />
+    <echo message="Set runtimeArchive and platformArchive for os: ${os}, ws: ${ws}, arch: ${arch}" />
     <echo message="build id of runtimeArchive ${buildIdToUse}" />
     <condition
-      property="runtimeArchive"
-      value="eclipse-SDK-${buildIdToUse}-win32-x86_64.zip">
+      property="osArchiveNameSuffix"
+      value="win32-${arch}.zip">
       <and>
         <equals
           arg1="${os}"
@@ -1011,14 +925,11 @@
         <equals
           arg1="${ws}"
           arg2="win32" />
-        <equals
-          arg1="${arch}"
-          arg2="x86_64" />
       </and>
     </condition>
     <condition
-      property="runtimeArchive"
-      value="eclipse-SDK-${buildIdToUse}-linux-gtk-x86_64.tar.gz">
+      property="osArchiveNameSuffix"
+      value="linux-gtk-${arch}.tar.gz">
       <and>
         <equals
           arg1="${os}"
@@ -1026,44 +937,11 @@
         <equals
           arg1="${ws}"
           arg2="gtk" />
-        <equals
-          arg1="${arch}"
-          arg2="x86_64" />
       </and>
     </condition>
     <condition
-      property="runtimeArchive"
-      value="eclipse-SDK-${buildIdToUse}-linux-gtk-ppc64le.tar.gz">
-      <and>
-        <equals
-          arg1="${os}"
-          arg2="linux" />
-        <equals
-          arg1="${ws}"
-          arg2="gtk" />
-        <equals
-          arg1="${arch}"
-          arg2="ppc64le" />
-      </and>
-    </condition>
-    <condition
-      property="runtimeArchive"
-      value="eclipse-SDK-${buildIdToUse}-linux-gtk-aarch64.tar.gz">
-      <and>
-        <equals
-          arg1="${os}"
-          arg2="linux" />
-        <equals
-          arg1="${ws}"
-          arg2="gtk" />
-        <equals
-          arg1="${arch}"
-          arg2="aarch64" />
-      </and>
-    </condition>
-    <condition
-      property="runtimeArchive"
-      value="eclipse-SDK-${buildIdToUse}-macosx-cocoa-x86_64.dmg">
+      property="osArchiveNameSuffix"
+      value="macosx-cocoa-${arch}.dmg">
       <and>
         <equals
           arg1="${os}"
@@ -1071,26 +949,19 @@
         <equals
           arg1="${ws}"
           arg2="cocoa" />
-        <equals
-          arg1="${arch}"
-          arg2="x86_64" />
       </and>
     </condition>
-    <condition
-      property="runtimeArchive"
-      value="eclipse-SDK-${buildIdToUse}-macosx-cocoa-aarch64.dmg">
-      <and>
-        <equals
-          arg1="${os}"
-          arg2="macosx" />
-        <equals
-          arg1="${ws}"
-          arg2="cocoa" />
-        <equals
-          arg1="${arch}"
-          arg2="aarch64" />
-      </and>
-    </condition>
+    <fail
+      unless="osArchiveNameSuffix"
+      message="osArchiveNameSuffix is not defined. Check that conditions cover os and ws: ${os} ${ws}" />
+    <property
+      name="runtimeArchive"
+      value="eclipse-SDK-${buildIdToUse}-${osArchiveNameSuffix}"/>
+    <!--use an stable version of the director so that instability in the current build doesn't cause all the tests to fail -->
+    <property
+      name="platformArchive"
+      value="eclipse-platform-${previousReleaseVersion}-${osArchiveNameSuffix}"
+    />
     <echo message="runtimeArchive ${runtimeArchive} !!! " />
   </target>
 

--- a/production/testScripts/configuration/sdk.tests/testScripts/test.xml
+++ b/production/testScripts/configuration/sdk.tests/testScripts/test.xml
@@ -46,7 +46,7 @@
         arg1="${testPlugin}"
         arg2="org.eclipse.pde.build.tests" />
     </condition>
-    	
+
     <condition
       property="extraIU"
       value="org.eclipse.unittest.ui">
@@ -332,7 +332,7 @@
     <delete
       verbose="false"
       dir="${platformLocation}/eclipse" />
-	    <echo message="Fresh extract ${runtimeArchive} into ${install} for testing." />
+    <echo message="Fresh extract ${runtimeArchive} into ${install} for testing." />
     <exec
       dir="${platformLocation}"
       executable="hdiutil">
@@ -502,7 +502,7 @@
     <fail
       message="buildId variable had unexpected format. Should be of the form  [IMXYNPSRU] 8 digits '-' 4 digits, but was ${buildId}"
       unless="buildIdOK" />
-  	
+
     <loadresource property="buildType">
       <string value="${buildId}"/>
       <filterchain>
@@ -579,7 +579,7 @@
     <fail
       message="eclipseStream variable had unexpected format. Should be of form digit.digit[.digit], but was ${eclipseStream}"
       unless="streamOK" />
-  	
+
     <loadresource property="eclipseStreamMajor">
       <string value="${eclipseStream}"/>
       <filterchain>
@@ -792,8 +792,19 @@
 
   <target
     name="init"
-    depends="initWorkspace,initProductionProperties,initBuildId, initBuildType, initDownloadHosts, initStreamVariables, initCurrentUpdateSite, initBasicDirectories,initOSes, initPlatformAndRuntimeArchiveName"
+    depends="initWorkspace,initProductionProperties,initBuildId, initBuildType, initDownloadHosts, initStreamVariables, initCurrentUpdateSite, initBasicDirectories,initPlatformAndRuntimeArchiveName"
     unless="testingIsInitialized">
+
+    <!-- Make sure the values of os, ws, and arch are set. -->
+    <fail
+      unless="os"
+      message="Value of 'os' not specified. 'os' must be set as system property" />
+    <fail
+      unless="ws"
+      message="Value of 'ws' not specified. 'ws' must be set as system property" />
+    <fail
+      unless="arch"
+      message="Value of 'arch' not specified. 'arch' must be set as system property" />
 
     <property environment="env" />
 
@@ -1290,10 +1301,10 @@
       basedir="${results}/xml"
       destdir="${results}/html"
       filenameparameter="filename">
-    	<factory>
-    		<feature name="http://www.oracle.com/xml/jaxp/properties/enableExtensionFunctions" value="true"/>
-		</factory>
-	</xslt>
+      <factory>
+        <feature name="http://www.oracle.com/xml/jaxp/properties/enableExtensionFunctions" value="true"/>
+      </factory>
+    </xslt>
   </target>
 
   <target
@@ -1325,7 +1336,7 @@
     depends="init">
     <runTests testPlugin="org.eclipse.equinox.common.tests" />
   </target>
-	
+
   <target
     name="equinoxds"
     depends="init">
@@ -1343,7 +1354,7 @@
     depends="init">
     <runTests testPlugin="org.eclipse.core.tests.resources" />
   </target>
-	
+
   <target
     name="coreresourcessaveparticipant"
     depends="init">
@@ -1404,7 +1415,7 @@
     <runTests testPlugin="org.eclipse.jface.tests.databinding" />
   </target>
 
-	<target
+  <target
     name="jface"
     depends="init">
     <runTests testPlugin="org.eclipse.jface.tests" />
@@ -1441,7 +1452,7 @@
     depends="init">
     <runTests testPlugin="org.eclipse.tips.tests" />
   </target>
-	
+
   <target
     name="ua"
     depends="init">
@@ -1538,7 +1549,7 @@
     depends="init">
     <runTests testPlugin="org.eclipse.pde.ui.tests" />
   </target>
-	
+
   <target
 	name="pdeua"
 	depends="init">
@@ -1997,7 +2008,7 @@
 
 	  </target>
 
-	<!--
+  <!--
     admittedly, not quite all of 'platform', but for
     now serves dual purpose of a "short set" of tests, that area
     relatively quick, and relatively reliable on build.eclipse.org hardware
@@ -2035,7 +2046,7 @@
     <antcall target="uiforms" />
     <antcall target="equinoxp2ui" />
     <antcall target="equinoxsecurity" />
-  	<antcall target="equinoxpreferences" />
+    <antcall target="equinoxpreferences" />
     <antcall target="search" />
     <antcall target="debug" />
     <antcall target="e4Core" />
@@ -2094,9 +2105,9 @@
     <antcall target="pdeds" />
     <antcall target="pdejunit" />
     <antcall target="pdeui" />
-  	<antcall target="pdeua" />
+    <antcall target="pdeua" />
     <antcall target="pdeuitemplates" />
-  	<antcall target="pdegenericeditor" />
+    <antcall target="pdegenericeditor" />
   </target>
 
   <target
@@ -2115,7 +2126,7 @@
     <antcall target="jdtcoreperf" />
     <antcall target="jdtcorebuilder" />
     <antcall target="jdtdebug" />
-    <antcall target="jdtjdi" />  	
+    <antcall target="jdtjdi" />
     <antcall target="jdtapt" />
     <antcall target="jdtaptpluggable" />
   </target>
@@ -2213,95 +2224,6 @@
     <echoproperties regex="^os\..*$" />
   </target>
 
-  <!--
-    initOSes is to make sure the values of os, ws, and arch are set.
-    We need them to match their "osgi.X" counterparts, so users often will
-    need to simply set the "osgi.X" values as system variables, since
-    our ability to guess varies from OS to OS and VM to VM ... but, if
-    the osgi.X values are not set, we'll take a guess based on common systems.
-  -->
-  <target name="initOSes">
-
-    <condition
-      property="guessed.os"
-      value="win32">
-      <os family="windows" />
-    </condition>
-    <condition
-      property="guessed.os"
-      value="macosx">
-      <os family="mac" />
-    </condition>
-    <condition
-      property="guessed.os"
-      value="linux">
-      <or>
-        <os family="unix" />
-      </or>
-    </condition>
-    <!-- if not set above, set to a ridiculous value, that will at least give hint of action to take once it causes a failure -->
-    <property
-      name="guessed.os"
-      value="Value of 'os' could not be determined. 'os' must be set as system variable." />
-
-    <condition
-      property="os"
-      value="${os}"
-      else="${guessed.os}">
-      <isset property="os" />
-    </condition>
-
-    <!-- luckily, these days, not multiple windowing systems, for common OSes -->
-    <condition
-      property="guessed.ws"
-      value="win32">
-      <os family="windows" />
-    </condition>
-    <condition
-      property="guessed.ws"
-      value="cocoa">
-      <os family="mac" />
-    </condition>
-    <condition
-      property="guessed.ws"
-      value="gtk">
-      <os family="unix" />
-    </condition>
-    <!-- if not set above, set to a ridiculous value, that will at least give hint of action to take once it causes a failure -->
-    <property
-      name="guessed.ws"
-      value="Value of 'ws' could not be determined. 'ws' must be set as system variable." />
-
-    <condition
-      property="ws"
-      value="${ws}"
-      else="${guessed.ws}">
-      <isset property="ws" />
-    </condition>
-
-    <!-- not sure this will work well? -->
-    <condition
-      property="guessed.arch"
-      value="x86_64">
-      <or>
-        <os arch="x86_64" />
-        <os arch="amd64" />
-      </or>
-    </condition>
-    <!-- if not set above, set to a ridiculous value, that will at least give hint of action to take once it causes a failure -->
-    <property
-      name="guessed.ws"
-      value="Value of 'arch' could not be determined. 'arch' must be set as system variable." />
-
-    <condition
-      property="arch"
-      value="${arch}"
-      else="${guessed.arch}">
-      <isset property="arch" />
-    </condition>
-
-  </target>
-
   <target
     name="test-getJavaMajorVersion"
     depends="debug-allJavaProperties,debug-allOSProperties,getJavaMajorVersion">
@@ -2317,16 +2239,8 @@
   </target>
 
   <target
-    name="test-initOSes"
-    depends="debug-allProperties,initOSes">
-    <printProperty property="os" />
-    <printProperty property="ws" />
-    <printProperty property="arch" />
-  </target>
-
-  <target
     name="test-all"
-    depends="init,test-initOSes,test-getJavaMajorVersion">
+    depends="init,debug-allProperties,test-getJavaMajorVersion">
   </target>
 
   <target


### PR DESCRIPTION
1. Unify archive name computation and make it less static
2. Don't guess os-ws-arch configuration, with the existing infrastructure os, ws and arch properties are explicitly specified anyways.

Additionally sanitize white-space.

This also helps for https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/577