### PR TITLE
[I-Build-Test] Fix call of ant-diagnostics on Windows machines

### DIFF
--- a/JenkinsJobs/AutomatedTests/I_unit_win32.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_win32.groovy
@@ -60,7 +60,7 @@ set ANT_HOME
 set PATH
 
 env 1>envVars.txt 2>&1
-ant -diagnostics 1>antDiagnostics.txt 2>&1
+cmd /c ant -diagnostics 1>antDiagnostics.txt 2>&1
 java -XshowSettings -version 1>javaSettings.txt 2>&1
 
 ant -f getEBuilder.xml -DbuildId=%buildId%  -DeclipseStream=%STREAM% -DEBUILDER_HASH=%EBUILDER_HASH% ^


### PR DESCRIPTION
Calling 'ant -diagnostics' on Windows somehow exists the bat script immediately. Call it in a sub-cmd-shell to workaround this problem until a completely correct solution is found.