### PR TITLE
[I-Build-Tests] Remove unused consideration of Java extension directory

### DIFF
--- a/production/testScripts/configuration/sdk.tests/testConfigs/linux/testAll.sh
+++ b/production/testScripts/configuration/sdk.tests/testConfigs/linux/testAll.sh
@@ -32,7 +32,6 @@ eclipseArch=${eclipseArch:-x86_64}
 echo "=== properties in testAll.sh"
 echo "    DOWNLOAD_HOST: ${DOWNLOAD_HOST}"
 echo "    jvm in testAll: ${jvm}"
-echo "    extdir in testAll (if any): ${extdir}"
 echo "    propertyFile in testAll: ${propertyFile}"
 echo "    buildId in testAll: ${buildId}"
 echo "    testedPlatform: ${testedPlatform}"
@@ -44,10 +43,5 @@ cat ${propertyFile}
 /bin/chmod 755 runtests.sh
 /bin/mkdir -p results/consolelogs
 
-if [[ -n "${extdir}" ]]
-then
-  ./runtests.sh -os linux -ws gtk -arch $eclipseArch -extdirprop "${extdir}" -vm "${jvm}"  -properties ${propertyFile} "${@}"  > results/consolelogs/${testedPlatform}_consolelog.txt
-else
-  ./runtests.sh -os linux -ws gtk -arch $eclipseArch -vm "${jvm}" -properties ${propertyFile} "${@}" > results/consolelogs/${testedPlatform}_consolelog.txt
-fi
+./runtests.sh -os linux -ws gtk -arch $eclipseArch -vm "${jvm}" -properties ${propertyFile} "${@}" > results/consolelogs/${testedPlatform}_consolelog.txt
 

--- a/production/testScripts/configuration/sdk.tests/testConfigs/macosx/testAll.sh
+++ b/production/testScripts/configuration/sdk.tests/testConfigs/macosx/testAll.sh
@@ -32,7 +32,6 @@ eclipseArch=${eclipseArch:-x86_64}
 echo "=== properties in testAll.sh"
 echo "    DOWNLOAD_HOST: ${DOWNLOAD_HOST}"
 echo "    jvm in testAll: ${jvm}"
-echo "    extdir in testAll (if any): ${extdir}"
 echo "    propertyFile in testAll: ${propertyFile}"
 echo "    buildId in testAll: ${buildId}"
 echo "    testedPlatform: ${testedPlatform}"
@@ -44,9 +43,4 @@ cat ${propertyFile}
 /bin/chmod 755 runtestsmac.sh
 /bin/mkdir -p results/consolelogs
 
-if [[ -n "${extdir}" ]]
-then
-  ./runtestsmac.sh -os macosx -ws cocoa -arch $eclipseArch -extdirprop "${extdir}" -vm "${jvm}" -properties ${propertyFile} $* > results/consolelogs/${testedPlatform}_consolelog.txt
-else
-  ./runtestsmac.sh -os macosx -ws cocoa -arch $eclipseArch -vm "${jvm}" -properties ${propertyFile} $* > results/consolelogs/${testedPlatform}_consolelog.txt
-fi
+./runtestsmac.sh -os macosx -ws cocoa -arch $eclipseArch -vm "${jvm}" -properties ${propertyFile} $* > results/consolelogs/${testedPlatform}_consolelog.txt

--- a/production/testScripts/configuration/sdk.tests/testConfigs/windows/testAll.bat
+++ b/production/testScripts/configuration/sdk.tests/testConfigs/windows/testAll.bat
@@ -30,7 +30,6 @@ IF NOT DEFINED eclipseArch SET eclipseArch=x86_64
 ECHO === properties in testAll.bat
 ECHO     DOWNLOAD_HOST: %DOWNLOAD_HOST%
 ECHO     jvm in testAll: %jvm%
-ECHO     extdir in testAll (if any): %extdir%
 ECHO     propertyFile in testAll: %propertyFile%
 ECHO     buildId in testAll: %buildId%
 ECHO     testedPlatform: %testedPlatform%
@@ -39,11 +38,6 @@ ECHO     ANT_OPTS: %ANT_OPTS%
 mkdir results\consolelogs
 
 set consolelogs=results\consolelogs\%testedPlatform%_consolelog.txt
-
-IF DEFINED extdir (
-runtests.bat -extdirprop "%extdir%" -os win32 -ws win32 -arch %eclipseArch% -vm "%jvm%" -properties %propertyFile% %* > %consolelogs%
-GOTO END
-)
 
 runtests.bat -os win32 -ws win32 -arch %eclipseArch% -vm "%jvm%" -properties %propertyFile% %* > %consolelogs%
 

--- a/production/testScripts/configuration/sdk.tests/testScripts/runtests.bat
+++ b/production/testScripts/configuration/sdk.tests/testScripts/runtests.bat
@@ -48,14 +48,11 @@ if x%1==x-arch set arch=%2 && shift && shift && goto processcmdlineargs
 if x%1==x-noclean set installmode=noclean&& shift && goto processcmdlineargs
 if x%1==x-properties set properties=-propertyfile %2 && shift && shift && goto processcmdlineargs
 if x%1==x-vm set jvm=%2 && shift && shift && goto processcmdlineargs
-if x%1==x-extdirprop SET extdirproperty="-Djava.ext.dirs=%2" && shift && shift && goto processcmdlineargs
-
 
 
 set tests=%tests% %1 && shift && goto processcmdlineargs
 
 echo Specified test targets (if any): %tests%
-echo Specified extdirs (if any): %extdirprop%
 
 :run
 REM ***************************************************************************
@@ -76,11 +73,6 @@ exit 1
 
 REM -XshowSettings is supported on windows VMs but ... not every where. So where not supported
 REM causes VM to not start at all. Can be handy for diagnostics. (without running ant <echoproperties/>
-
-IF DEFINED extdirproperty (
-%jvm% %ANT_OPTS% %extdirproperty% -Dosgi.os=%os% -Dosgi.ws=%ws% -Dosgi.arch=%arch% -jar eclipse\plugins\%launcher-jar% -data workspace -application org.eclipse.ant.core.antRunner -file test.xml %tests% -Dws=%ws% -Dos=%os% -Darch=%arch% -D%installmode%=true %properties% -logger org.apache.tools.ant.DefaultLogger
-GOTO END
-)
 
 %jvm% %ANT_OPTS% -Dosgi.os=%os% -Dosgi.ws=%ws% -Dosgi.arch=%arch% -jar eclipse\plugins\%launcher-jar% -data workspace -application org.eclipse.ant.core.antRunner -file test.xml %tests% -Dws=%ws% -Dos=%os% -Darch=%arch% -D%installmode%=true %properties% -logger org.apache.tools.ant.DefaultLogger
 

--- a/production/testScripts/configuration/sdk.tests/testScripts/runtests.sh
+++ b/production/testScripts/configuration/sdk.tests/testScripts/runtests.sh
@@ -78,9 +78,6 @@ installmode="clean"
 # name of a property file to pass to Ant
 properties=
 
-# ext dir customization. Be sure "blank", if not defined explicitly on command line
-extdirproperty=
-
 # message printed to console
 usage="usage: $0 -os <osType> -ws <windowingSystemType> -arch <architecture> [-noclean] [<test target>][-properties <path>]"
 
@@ -101,8 +98,6 @@ do
       installmode="noclean";;
     -properties)
       properties="-propertyfile ${2}";shift;;
-    -extdirprop)
-      extdirproperty="-Djava.ext.dirs=${2}";shift;;
     -vm)
       jvm="${2}"; shift;;
     *)
@@ -112,8 +107,6 @@ do
 done
 
 echo "Specified test targets (if any): ${tests}"
-
-echo "Specified ext dir (if any): ${extdirproperty}"
 
 # for *nix systems, os, ws and arch values must be specified
 if [[ -z "${os}" || -z "${ws}" || -z "${arch}" ]]
@@ -208,8 +201,6 @@ echo
 
 
 mkdir -p results/consolelogs
-echo "extdirprop in runtest.sh: ${extdirprop}"
-echo "extdirproperty in runtest.sh: ${extdirproperty}"
 echo "ANT_OPTS in runtests.sh: ${ANT_OPTS}"
 echo "DOWNLOAD_HOST: $DOWNLOAD_HOST"
 echo "platformArgString: ${platformArgString}"
@@ -217,11 +208,4 @@ echo "platformParmString: ${platformParmString}"
 echo "platformString: ${platformString}"
 echo "testedPlatform: ${testedPlatform}"
 
-if [[ -n "${extdirproperty}" ]]
-then
-  echo "running with extdir defined"
-  $jvm ${ANT_OPTS} "${extdirproperty}" ${platformArgString} -jar $launcher -data workspace -application org.eclipse.ant.core.antRunner -file ${PWD}/test.xml ${platformParmString} -D$installmode=true $properties -logger org.apache.tools.ant.DefaultLogger $tests
-else
-  echo "running without extdir defined"
-  $jvm ${ANT_OPTS} ${platformArgString} -jar $launcher -data workspace -application org.eclipse.ant.core.antRunner -file ${PWD}/test.xml ${platformParmString} -D$installmode=true $properties -logger org.apache.tools.ant.DefaultLogger $tests
-fi
+$jvm ${ANT_OPTS} ${platformArgString} -jar $launcher -data workspace -application org.eclipse.ant.core.antRunner -file ${PWD}/test.xml ${platformParmString} -D$installmode=true $properties -logger org.apache.tools.ant.DefaultLogger $tests

--- a/production/testScripts/configuration/sdk.tests/testScripts/runtestsmac.sh
+++ b/production/testScripts/configuration/sdk.tests/testScripts/runtestsmac.sh
@@ -36,9 +36,6 @@ installmode="clean"
 # name of a property file to pass to Ant
 properties=
 
-# ext dir customization. Be sure "blank", if not defined explicitly on command line
-extdirproperty=
-
 # message printed to console
 usage="usage: $0 -os <osType> -ws <windowingSystemType> -arch <architecture> [-noclean] [<test target>][-properties <path>]"
 
@@ -59,8 +56,6 @@ do
       installmode="noclean";;
     -properties)
       properties="-propertyfile ${2}";shift;;
-    -extdirprop)
-      extdirproperty="-Djava.ext.dirs=${2}";shift;;
     -vm)
       jvm="${2}"; shift;;
     *)
@@ -70,8 +65,6 @@ do
 done
 
 echo "Specified test targets (if any): ${tests}"
-
-echo "Specified ext dir (if any): ${extdirproperty}"
 
 # for *nix systems, os, ws and arch values must be specified
 if [ "x$os" = "x" ]
@@ -131,11 +124,5 @@ fi
 
 echo "properties: $properties"
 
-if [[ ! -z "${extdirproperty}" ]]
-then
-  $jvm ${ANT_OPTS} "${extdirproperty}" -Dosgi.os=$os -Dosgi.ws=$ws -Dosgi.arch=$arch -jar $launcher -data workspace -application org.eclipse.ant.core.antRunner -file ${PWD}/test.xml $tests -Dws=$ws -Dos=$os -Darch=$arch -D$installmode=true $properties -logger org.apache.tools.ant.DefaultLogger
-else
-  $jvm ${ANT_OPTS} -Dosgi.os=$os -Dosgi.ws=$ws -Dosgi.arch=$arch -jar $launcher -data workspace -application org.eclipse.ant.core.antRunner -file ${PWD}/test.xml $tests -Dws=$ws -Dos=$os -Darch=$arch -D$installmode=true $properties -logger org.apache.tools.ant.DefaultLogger
-fi
-
+$jvm ${ANT_OPTS} -Dosgi.os=$os -Dosgi.ws=$ws -Dosgi.arch=$arch -jar $launcher -data workspace -application org.eclipse.ant.core.antRunner -file ${PWD}/test.xml $tests -Dws=$ws -Dos=$os -Darch=$arch -D$installmode=true $properties -logger org.apache.tools.ant.DefaultLogger
 


### PR DESCRIPTION
For current I-build tests java.ext.dir is never specified.