### PR TITLE
Removing unjar of content.jar

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/pom.xml
@@ -58,27 +58,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>unpack-content-jar</id>
-            <phase>package</phase>
-            <configuration>
-              <target>
-                <unjar
-                  src="target/repository/content.jar"
-                  dest="target/repository" />
-                <delete file="target/repository/content.jar" />
-                <delete file="target/repository/content.xml.xz" />
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>xml-maven-plugin</artifactId>
         <executions>


### PR DESCRIPTION
This fix will remove the extracing of content.jar file and retain existing content.jar and content.xml.xz

Fix https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1912

Output [local]- 
<img width="788" alt="image" src="https://github.com/user-attachments/assets/e21b431e-5f58-4cfa-bdbc-f438df953231">
