### PR TITLE
[I-Build-Tests] Run Linux tests on 'ubuntu-2404' image agent

### DIFF
--- a/JenkinsJobs/AutomatedTests/I_unit_linux.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_linux.groovy
@@ -24,7 +24,7 @@ pipeline {
     buildDiscarder(logRotator(numToKeepStr:'5'))
   }
   agent {
-    label 'centos-8'
+    label 'ubuntu-2404'
   }
 
   stages {


### PR DESCRIPTION
Follow-up for https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2515

I have already replayed the current linux-java17 configuration to use the ubunut image for the smaller `ui` test-suite:
https://ci.eclipse.org/releng/job/AutomatedTests/job/ep434I-unit-linux-x86_64-java17/21/

Once that has passed I'll create a follow-up run with the complete `all` suite to see if all tests pass, then I think this change is save enough to apply it to all other configs as well.
