### PR TITLE
[Build] Don't set LIBARCHIVE.creationtime attribute in tar.gz archives

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -534,6 +534,9 @@
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-p2-director-plugin</artifactId>
           <version>${tycho.version}</version>
+          <configuration>
+            <storeCreationTime>false</storeCreationTime>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.eclipse.tycho</groupId>


### PR DESCRIPTION
Requires https://github.com/eclipse-tycho/tycho/pull/4428.

Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2529