### PR TITLE
[Build] Use last successful ECJ snapshot in verification builds

### DIFF
--- a/JenkinsJobs/Builds/I_build.groovy
+++ b/JenkinsJobs/Builds/I_build.groovy
@@ -428,6 +428,11 @@ spec:
           }
 		}
 		stage('Trigger publication to Maven snapshots repo') {
+			when {
+				environment name: 'COMPARATOR_ERRORS_SUBJECT', value: ''
+				// On comparator-erros, skip the deployment of snapshot version to the 'eclipse-snapshots' maven repository to prevent that ECJ snapshot
+				// from being used in verification builds. Similar to how the p2-repository is not added to the I-build composite in that case.
+			}
 			steps {
               container('jnlp') {
 				build job: 'CBIaggregator', parameters: [string(name: 'snapshotOrRelease', value: '-snapshot')], wait: false

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -58,16 +58,6 @@
          - Use the mail template from the promotion build [artifacts](https://ci.eclipse.org/releng/job/eclipse.releng.renameAndPromote/lastSuccessfulBuild/artifact/) in Jenkins to get the download urls.
          - Make sure to mention that the Master branch is now again open for development.
        * For **Milestone builds** return the I-builds to the normal schedule.
-     * **Update ECJ compiler** in the platform build (if it needs to be updated).
-       * To find the new compiler version:
-         - Go to the update site for the release candidate
-         - Click `plugins`
-         - Find `org.eclipse.jdt.core.complier.batch_${ecjversion}.jar`
-       * Edit the [copyAndDeployJDTCompiler](https://ci.eclipse.org/jdt/job/copyAndDeployJDTCompiler) job in Jenkins
-         - Only JDT committers can run the job, but Releng/Platform committers can configure it
-         - Update the default values of the `versionfolder`, `buildid` and `ecjversion` parameters.
-         - Update the build triggers to schedule a build for the current date.
-       * Finally update the `cbi-ecj-version` in [eclipse.platform.releng.aggregator/eclipse-platform-parent/pom.xml](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/master/eclipse-platform-parent/pom.xml)
      * **After RC1**
        * Leave the I-builds running on the milestone schedule for RC2. 
        * Comment on EMF, ECF and Orbit issues to ask for final release builds.
@@ -157,13 +147,21 @@ The release is scheduled for 10AM EST. Typically the jobs are scheduled beforeha
 
 #### **Maintenance Branches:**
   * **Maintenance Branch Creation:**
-    - Create the branch from RC2 using the [create maintenance branch](https://ci.eclipse.org/releng/job/Releng/job/createMaintenanceBranch/) job in the Eclipse Platform Releng jeknins.
+    - Create the branch from RC2 using the [create maintenance branch](https://ci.eclipse.org/releng/job/Releng/job/createMaintenanceBranch/) job in the Eclipse Platform Releng Jenkins.
   * **Update maintenance branch with release version**
     - Once the I-build repo is removed for the previous release the maintenance branch will have to use the release location, i.e. any references to `https://download.eclipse.org/eclipse/updates/4.25-I-builds/` will need to be updated to `https://download.eclipse.org/eclipse/updates/4.26/R-4.26-202211231800/`
     - Functionally this means:
       - Update the ECLIPSE_RUN_REPO in the [cje-production](cje-production) buildproperties.txt files
       - Update eclipserun-repo, comparator.repo and eclipse-p2-repo.url in [eclipse-platform-parent/pom.xml](eclipse-platform-parent/pom.xml)
     - This step can be prepared ahead of time but can't be merged until the release build has been promoted and the update site exists.
+     * **Update ECJ compiler** in the platform build (if it needs to be updated).
+       * To find the new *unqualified* compiler version:
+         - Go to the update site for the release candidate
+         - Click `plugins`
+         - Find the *unqualified* version of the artifact `org.eclipse.jdt.core.complier.batch_${ecjversion}.jar`, i.e. the version consisting only of the _major_._minor_._service_ part, but without qualifier.
+         It's the version of the `org.eclipse.jdt:ecj` artifact at Maven-Central, about to be relased.
+       * Update the `cbi-ecj-version` in [eclipse.platform.releng.aggregator/eclipse-platform-parent/pom.xml](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/master/eclipse-platform-parent/pom.xml)
+       to the exact version of the `org.eclipse.jdt.core.complier.batch` bundle, e.g.: `3.40.0`
 
 #### **Update the Build Calendar:**
   - Create an [issue](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/289) and update the [build calendar](https://calendar.google.com/calendar/u/0?cid=cHJmazI2ZmRtcHJ1MW1wdGxiMDZwMGpoNHNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ) for the next GA release based on the [Simultaneous Release schedule](https://wiki.eclipse.org/Simultaneous_Release).

--- a/cje-production/mbscripts/mb300_gatherEclipseParts.sh
+++ b/cje-production/mbscripts/mb300_gatherEclipseParts.sh
@@ -286,7 +286,7 @@ then
   fn-write-property COMPARATOR_ERRORS_BODY "\"Check unanticipated comparator messages:<br>    <a href='https://download.eclipse.org/eclipse/downloads/drops4/${BUILD_ID}/buildlogs/comparatorlogs/buildtimeComparatorUnanticipated.log.txt'>https://download.eclipse.org/eclipse/downloads/drops4/${BUILD_ID}/buildlogs/comparatorlogs/buildtimeComparatorUnanticipated.log.txt</a><br><br>\""
 else
   echo -e "DEBUG: comparator logSize of $logSize was not greater than comparatorLogMinimumSize of ${comparatorLogMinimumSize}"
-  fn-write-property COMPARATOR_ERRORS_SUBJECT "\" \""
-  fn-write-property COMPARATOR_ERRORS_BODY "\" \""
+  fn-write-property COMPARATOR_ERRORS_SUBJECT "\"\""
+  fn-write-property COMPARATOR_ERRORS_BODY "\"\""
 fi
 

--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -87,8 +87,8 @@
     <!-- only used when Tycho snapshot repo is enabled in <pluginRepositories> further down -->
     <tycho-snapshot-repo.url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</tycho-snapshot-repo.url>
 
-    <cbi-jdt-repo.url>https://repo.eclipse.org/content/repositories/eclipse-staging/</cbi-jdt-repo.url>
-    <cbi-ecj-version>3.40.100.v20241127-0801</cbi-ecj-version>
+    <eclipse-snapshots-repo.url>https://repo.eclipse.org/content/repositories/eclipse-snapshots/</eclipse-snapshots-repo.url>
+    <cbi-ecj-version>[3.39,)</cbi-ecj-version>
 
     <!--
       repo for released versions of CBI. Note, we intentionally use as specific a repo as possible.
@@ -181,9 +181,10 @@
     </pluginRepository>
 
     <pluginRepository>
-      <id>cbi-jdt</id>
-      <url>${cbi-jdt-repo.url}</url>
+      <id>eclipse-snapshots</id>
+      <url>${eclipse-snapshots-repo.url}</url>
     </pluginRepository>
+
     <pluginRepository>
       <id>eclipse-cbi</id>
       <url>${eclipse-cbi-repo.url}</url>


### PR DESCRIPTION
Use the latest ECJ snapshot version from the last successful I-build (without comparator errors) for verification builds, to automatically align with I-builds.
Currently ECJ has to be deployed manually to a JDT snapshot-repository after changes in ECJ that caused comparator-errors:
- https://github.com/eclipse-pde/eclipse.pde/pull/1461#issuecomment-2466780430

This prevents issues like
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1960
- https://github.com/eclipse-pde/eclipse.pde/pull/1467

If there are no other usages of `https://repo.eclipse.org/content/repositories/eclipse-staging`, this should make the JDT Jenkins job to deploy ECJ to it obsolete
- https://ci.eclipse.org/jdt/job/copyAndDeployJDTCompiler/

as well as the target repository and should allow us to delete:
https://repo.eclipse.org/content/repositories/eclipse-staging

@jarthana and @akurtakov this is what we talked about in today's PMC call.
@MohananRahul can you please check if the release process documentation update is correct and fine?