### PR TITLE
[Build] Unify and clean-up list of declared CBI plugin-repositories

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -42,6 +42,8 @@
     <buildTimestamp>${maven.build.timestamp}</buildTimestamp>
     <buildType>I</buildType>
     <buildId>${buildType}${buildTimestamp}</buildId>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
      <!--
       releaseName should match the yearly "release train" name.
       For example, "Mars", "Mars.1", "Luna SR2", etc.
@@ -85,7 +87,6 @@
     <!-- only used when Tycho snapshot repo is enabled in <pluginRepositories> further down -->
     <tycho-snapshot-repo.url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</tycho-snapshot-repo.url>
 
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cbi-jdt-repo.url>https://repo.eclipse.org/content/repositories/eclipse-staging/</cbi-jdt-repo.url>
     <cbi-ecj-version>3.40.0.v20241112-0530</cbi-ecj-version>
 
@@ -93,11 +94,7 @@
       repo for released versions of CBI. Note, we intentionally use as specific a repo as possible.
       See bug 471835.
     -->
-    <eclipse-repo.url>https://repo.eclipse.org/content/repositories/cbi/</eclipse-repo.url>
-    <cbi-snapshots-repo.url>https://repo.eclipse.org/content/repositories/cbi-snapshots/</cbi-snapshots-repo.url>
-
-    <cbi-releases-repo.url>https://repo.eclipse.org/content/repositories/cbi-releases/</cbi-releases-repo.url>
-
+    <eclipse-cbi-repo.url>https://repo.eclipse.org/content/repositories/cbi/</eclipse-cbi-repo.url>
 
     <!--
       This eclipse-p2-repo.url is specifically for the build-individual-bundles profile.
@@ -181,50 +178,15 @@
     <pluginRepository>
       <id>tycho-snapshots</id>
       <url>${tycho-snapshot-repo.url}</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
     </pluginRepository>
 
     <pluginRepository>
       <id>cbi-jdt</id>
       <url>${cbi-jdt-repo.url}</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
     </pluginRepository>
     <pluginRepository>
-      <id>cbi-snapshots</id>
-      <url>${cbi-snapshots-repo.url}</url>
-      <snapshots>
-      <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-    <pluginRepository>
-      <id>cbi-releases</id>
-      <url>${cbi-releases-repo.url}</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-    <pluginRepository>
-      <id>eclipse</id>
-      <url>${eclipse-repo.url}</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
+      <id>eclipse-cbi</id>
+      <url>${eclipse-cbi-repo.url}</url>
     </pluginRepository>
   </pluginRepositories>
   <build>

--- a/eclipse-platform-parent/saveproperties/mavenproperties.properties
+++ b/eclipse-platform-parent/saveproperties/mavenproperties.properties
@@ -26,6 +26,4 @@ comparator.repo=${comparator.repo}
 
 eclipse-p2-repo.url=${eclipse-p2-repo.url}
 
-eclipse-repo.url=${eclipse-repo.url}
-
 sun.java.command=${sun.java.command}


### PR DESCRIPTION
From the three declared Eclipse CBI plugin repositories only the maven-plugins with groupId 'org.eclipse.cbi.maven.plugins' are obtained. And at least with respect to these mavne-plugins, the repository at 
- https://repo.eclipse.org/content/repositories/cbi

seems to be the combination of the co-located repositories:
- https://repo.eclipse.org/content/repositories/cbi-releases
- https://repo.eclipse.org/content/repositories/cbi-snapshot

Therefore it seems unnecessary to declare all three repositories.

@akurtakov can you tell if my analysis and this change is correct or if not, can you tell who can tell?