### PR TITLE
Remove unused apifreeze releng scripts

### DIFF
--- a/cje-production/P-build/buildproperties.txt
+++ b/cje-production/P-build/buildproperties.txt
@@ -41,12 +41,6 @@ LOCAL_REPO="localMavenRepo"
 # Base builder parameters
 BASEBUILDER_TAG="4.31"
 API_PREV_REF_LABEL="4.31"
-#API_FREEZE_REF_LABEL="4.33RC1"
-API_FREEZE_REF_LABEL=""
-# Change to appropriate versions and uncomment when entering API freeze
-#FREEZE_PARAMS="-DfreezeBaseURL=https://${DOWNLOAD_HOST}/eclipse/downloads/drops4/S-${API_FREEZE_REF_LABEL}-202208241800/eclipse-SDK-${API_FREEZE_REF_LABEL}-win32-x86_64.zip -DfreezeName=Eclipse-SDK-${API_FREEZE_REF_LABEL} -DfreezeFilename=eclipse-SDK-${API_FREEZE_REF_LABEL}-win32-x86_64.zip"
-# Otherwise set to a blank space
-FREEZE_PARAMS=" "
 
 PREVIOUS_RELEASE_VER="4.33"
 PREVIOUS_RELEASE_REPO_ID="4.33"

--- a/cje-production/Y-build/buildproperties.txt
+++ b/cje-production/Y-build/buildproperties.txt
@@ -40,12 +40,6 @@ LOCAL_REPO="localMavenRepo"
 # Base builder parameters
 BASEBUILDER_TAG="4.32"
 API_PREV_REF_LABEL="4.32"
-#API_FREEZE_REF_LABEL="4.33RC1"
-API_FREEZE_REF_LABEL=""
-# Change to appropriate versions and uncomment when entering API freeze
-#FREEZE_PARAMS="-DfreezeBaseURL=https://${DOWNLOAD_HOST}/eclipse/downloads/drops4/S-${API_FREEZE_REF_LABEL}-202108251800/eclipse-SDK-${API_FREEZE_REF_LABEL}-win32-x86_64.zip -DfreezeName=Eclipse-SDK-${API_FREEZE_REF_LABEL} -DfreezeFilename=eclipse-SDK-${API_FREEZE_REF_LABEL}-win32-x86_64.zip"
-# Otherwise set to a blank space
-FREEZE_PARAMS=" "
 
 PREVIOUS_RELEASE_VER="4.33"
 PREVIOUS_RELEASE_REPO_ID="4.33"

--- a/cje-production/buildproperties.txt
+++ b/cje-production/buildproperties.txt
@@ -40,12 +40,6 @@ LOCAL_REPO="localMavenRepo"
 # Base builder parameters
 BASEBUILDER_TAG="4.33"
 API_PREV_REF_LABEL="4.33"
-#API_FREEZE_REF_LABEL="4.33RC1"
-API_FREEZE_REF_LABEL=""
-# Change to appropriate versions and uncomment when entering API freeze
-#FREEZE_PARAMS="-DfreezeBaseURL=https://${DOWNLOAD_HOST}/eclipse/downloads/drops4/S-${API_FREEZE_REF_LABEL}-202208241800/eclipse-SDK-${API_FREEZE_REF_LABEL}-win32-x86_64.zip -DfreezeName=Eclipse-SDK-${API_FREEZE_REF_LABEL} -DfreezeFilename=eclipse-SDK-${API_FREEZE_REF_LABEL}-win32-x86_64.zip"
-# Otherwise set to a blank space
-FREEZE_PARAMS=" "
 
 PREVIOUS_RELEASE_VER="4.33"
 PREVIOUS_RELEASE_REPO_ID="4.33"

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list.txt
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list.txt
@@ -1,5 +1,0 @@
-# List of approved API changes after 4.34 RC2
-
-# The unapproved entry exclude list can be copied from <build>/buildlogs/mb080_publish-eclipse_output.txt
-# Search for: Potential exclude list:
-# Copy the list into this report and remove "[apitooling.apifreeze] "

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/buildScripts/api-tools-builder.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/buildScripts/api-tools-builder.xml
@@ -29,10 +29,8 @@
   name="API Tools builder integration"
   default="apiToolsReports">
 
-
-
   <!--
-    The default target that calls apitooling.apifreeze, apitooling.analysis and apitooling.apideprecation
+    The default target that calls apitooling.analysis and apitooling.apideprecation
     and their respective _reportconversion tasks
   -->
   <target
@@ -45,14 +43,6 @@
       name="report"
       value="${buildDirectory}/apitools" />
     <mkdir dir="${report}" />
-    <property
-      name="freeze_report"
-      value="${report}/freeze_report.xml" />
-    <touch file="${freeze_report}" />
-    <property
-      name="freeze_html"
-      value="${report}/freeze_report.html" />
-
 
 
     <!-- we would have to fetch the baseline we wanted, or perhaps just link to its location -->
@@ -61,9 +51,6 @@
       value="${reference}/${previousBaselineFilename}" />
 
     <!-- create properties for the filters -->
-    <property
-      name="exclude_list_location"
-      value="${EBuilderDir}/eclipse/apiexclude/exclude_list.txt" />
     <property
       name="exclude_list_external_location"
       value="${EBuilderDir}/eclipse/apiexclude/exclude_list_external.txt" />
@@ -139,8 +126,7 @@
 
   <target
     name="init"
-    unless="apitoolinginitialized"
-    depends="getfreezereference">
+    unless="apitoolinginitialized">
 
     <!-- The name for the build - i.e. I20130603-2000 -->
     <fail
@@ -210,49 +196,4 @@
       property="currentZipAvailable" />
   </target>
 
-  <!-- there will not always be a freeze report, only after M6 -->
-  <target
-    name="getfreezereference"
-    if="freezeFilename">
-    <fail
-      unless="freezeBaseURL"
-      message="full URL of freeze build must be provided, if freezeFilename is." />
-
-    <!-- if not provided, assume freezeName is same as freezeFilename -->
-    <property
-      name="freezeName"
-      value="freezeFilename" />
-
-    <property
-      name="freezereference"
-      value="${buildDirectory}/apitoolingreference/${freezeName}" />
-    <mkdir dir="${freezereference}" />
-
-    <get
-      dest="${freezereference}"
-      src="${freezeBaseURL}" />
-    <!-- no need to unzip?
-      <unzip
-      src="${freezereference}/${freezeFilename}"
-      dest="${freezereference}" />
-    -->
-
-  </target>
-
-  <!-- there will not always be a freeze report, only after M6 -->
-  <target
-    name="dofreezeReport"
-    if="freezereference">
-    <!-- run the freeze task -->
-    <apitooling.apifreeze
-      baseline="${freezereference}/${freezeFilename}"
-      profile="${current_location}"
-      report="${freeze_report}"
-      excludelist="${exclude_list_location}"
-      debug="true" />
-    <apitooling.apifreeze_reportconversion
-      xmlfile="${freeze_report}"
-      htmlfile="${freeze_html}"
-      debug="true" />
-  </target>
 </project>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/staticDropFiles/testResults.php
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/staticDropFiles/testResults.php
@@ -96,22 +96,6 @@ if (file_exists("buildlogs/reporeports/index.html")) {
 ?>
 
 <?php
-  // have removed coverage measurements for now
-  // echo " <li><a href=\"coverage.php\"><b>JaCoCo code coverage report</b></a></li>";
-?>
-
-<?php
-  $freezeFilename="apitools/freeze_report.html";
-  if (file_exists($freezeFilename)) {
-    echo "<li><a href=\"$freezeFilename\"><b>API Tools Post-API Freeze Report</b></a>&nbsp;&nbsp;";
-    echo "This report describes API changes since ${API_FREEZE_REF_LABEL}.  Exclusions are listed in <a href=\"https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/$BRANCH/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list.txt\">.../apiexclude/exclude_list.txt</a>.</li>";
-  }
-  else {
-    echo "  <li>No freeze report. Only generated in main stream after RC1.</li>";
-  }
-?>
-
-<?php
   echo " <li><a href=\"apitools/apifilters-$BUILD_ID.zip\"><b>Zip of .api_filters files used in the build</b></a></li>";
 ?>
 <?php


### PR DESCRIPTION
Not used in years and just complicate the scripts and stream opening procedures.
Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2555 .