### PR TITLE
[Builds] Remove unused 'version-bump' profile from eclipse-parent pom

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -758,32 +758,6 @@
      </repositories>
    </profile>
    <profile>
-      <!-- This provile enables automatic version bumps when running the build -->
-      <id>vb</id>
-      <properties>
-          <compare-version-with-baselines.skip>false</compare-version-with-baselines.skip>
-      </properties>
-       <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-versions-plugin</artifactId>
-             <executions>
-              <execution>
-                <id>bump</id>
-                <goals>
-                  <goal>bump-versions</goal>
-                </goals>
-                <configuration>
-                    <increment>100</increment>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-       </build>
-   </profile>
-   <profile>
       <id>build-individual-bundles</id>
       <activation>
         <property>


### PR DESCRIPTION
With the reusable workflow for automated version increments in pull-requests it is not necessary anymore to enable bumping versions if the property 'compare-version-with-baselines.skip' is set to false. Everything now happens automatically and this profile can therefore be removed.

This is extracted from https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2387#discussion_r1784365777.