### PR TITLE
Remove path-patterns not changed anymore by updateRelease-workflow

### DIFF
--- a/.github/workflows/updateRelease.yml
+++ b/.github/workflows/updateRelease.yml
@@ -23,7 +23,7 @@ jobs:
         cache: maven
     - name: Update Versions
       run: >-
-          mvn -U -Pbuild-individual-bundles -ntp
+          mvn -U -B -ntp
           org.eclipse.tycho:tycho-versions-plugin:set-version -DnewVersion=${{ github.event.milestone.title }}.0-SNAPSHOT
           org.eclipse.tycho:tycho-versions-plugin:set-parent-version -DnewParentVersion=${{ github.event.milestone.title }}.0-SNAPSHOT
     - name: Create Pull Request for Release ${{ github.event.milestone.title }}
@@ -38,5 +38,3 @@ jobs:
         add-paths: |
             pom.xml
             **/pom.xml
-            **/*.MF
-


### PR DESCRIPTION
That workflow now just updates `pom.xml` files.

@laeubi or do I oversaw something?

Follow-up on https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2387