### PR TITLE
Define a single property for the releaseVersion and use in property

### DIFF
--- a/.github/workflows/prepareRelease.yml
+++ b/.github/workflows/prepareRelease.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Update Main Versions
       run: mvn -U -ntp -f eclipse-platform-parent org.eclipse.tycho:tycho-versions-plugin:set-version -DnewVersion=${{ github.event.milestone.title }}.0-SNAPSHOT -Dmodules=../eclipse.platform.releng.prereqs.sdk
     - name: Update Release Versions
-      run: mvn -ntp -f eclipse-platform-parent/pom.xml --non-recursive org.eclipse.tycho:tycho-versions-plugin:set-property -Dproperties=releaseNumberSDK,releaseNumberPlatform,releaseName -DnewReleaseName=${{ steps.get-release-name.outputs.name }} -DnewReleaseNumberSDK=${{ github.event.milestone.title }} -DnewReleaseNumberPlatform=${{ github.event.milestone.title }}
+      run: mvn -ntp -f eclipse-platform-parent/pom.xml --non-recursive org.eclipse.tycho:tycho-versions-plugin:set-property -Dproperties=releaseVersion,releaseName -DnewReleaseName=${{ steps.get-release-name.outputs.name }} -DnewreleaseVersion=${{ github.event.milestone.title }}
     - name: Create Pull Request for Release ${{ github.event.milestone.title }}
       uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
       with:

--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -50,6 +50,7 @@
       See bug 328139.
     -->
     <releaseName>2025-03</releaseName>
+    <releaseVersion>4.35</releaseVersion>
     <!--
       The releaseNumbers below, for SDK and Platform, might be
       thought of as the "marketing number" or "branding number",
@@ -64,8 +65,8 @@
       but we'd still want the "marketing number" to be increased to reflect
       "a new yearly release".
     -->
-    <releaseNumberSDK>4.35</releaseNumberSDK>
-    <releaseNumberPlatform>4.35</releaseNumberPlatform>
+    <releaseNumberSDK>${releaseVersion}</releaseNumberSDK>
+    <releaseNumberPlatform>${releaseVersion}</releaseNumberPlatform>
 
     <tycho.version>4.0.10</tycho.version>
 


### PR DESCRIPTION
Actually the both properties 'releaseNumberSDK' and 'releaseNumberPlatform' are always the same and even if the comment mentions they might be different at some time it is better to unify them until then.

Because of this there is now a new 'releaseVersion' defined as a single property.