### PR TITLE
Run prepareRelease workflow manually and set 'previous-release.baseline'

### DIFF
--- a/.github/workflows/prepareRelease.yml
+++ b/.github/workflows/prepareRelease.yml
@@ -1,7 +1,16 @@
 name: Prepare Next Release
 on:
-  milestone:
-    types: [created]
+  workflow_dispatch:
+    inputs:
+      nextReleaseName:
+        description: 'Next release name, e.g.: 2025-03'
+        required: true
+      nextReleaseVersion:
+        description: 'Next release name, e.g.: 4.35'
+        required: true
+      baselineRepository:
+        description: 'Previous release baseline repository, e.g.: 4.34-I-builds/I20241120-1800'
+        required: true
 
 permissions:
   contents: read
@@ -9,7 +18,6 @@ permissions:
 jobs:
   prepare:
     runs-on: ubuntu-latest
-    if: contains(github.event.milestone.description, 'Release')
     permissions:
       pull-requests: write
       contents: write
@@ -18,10 +26,6 @@ jobs:
       uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
       with:
         maven-version: 3.9.9
-    - id: get-release-name
-      run: |
-        name=$(echo ${{ github.event.milestone.due_on }} | cut -d- -f-2)
-        echo "name=$name" >> $GITHUB_OUTPUT
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: master
@@ -32,15 +36,20 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Update Main Versions
-      run: mvn -U -ntp -f eclipse-platform-parent org.eclipse.tycho:tycho-versions-plugin:set-version -DnewVersion=${{ github.event.milestone.title }}.0-SNAPSHOT -Dmodules=../eclipse.platform.releng.prereqs.sdk
+      run: mvn -U -ntp -f eclipse-platform-parent org.eclipse.tycho:tycho-versions-plugin:set-version -DnewVersion=${{ inputs.nextReleaseVersion }}.0-SNAPSHOT -Dmodules=../eclipse.platform.releng.prereqs.sdk
     - name: Update Release Versions
-      run: mvn -ntp -f eclipse-platform-parent/pom.xml --non-recursive org.eclipse.tycho:tycho-versions-plugin:set-property -Dproperties=releaseVersion,releaseName -DnewReleaseName=${{ steps.get-release-name.outputs.name }} -DnewreleaseVersion=${{ github.event.milestone.title }}
-    - name: Create Pull Request for Release ${{ github.event.milestone.title }}
+      run: >-
+        mvn -ntp -f eclipse-platform-parent/pom.xml --non-recursive org.eclipse.tycho:tycho-versions-plugin:set-property 
+        -Dproperties=releaseVersion,releaseName,previous-release.baseline
+        -DnewReleaseName=${{ inputs.nextReleaseName }}
+        -DnewReleaseVersion=${{ inputs.nextReleaseVersion }}
+        '-DnewPrevious-release.baseline=https://download.eclipse.org/eclipse/updates/${{ inputs.baselineRepository }}'
+    - name: Create Pull Request for Release ${{ inputs.nextReleaseVersion }}
       uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
       with:
-        commit-message: Prepare Release ${{ github.event.milestone.title }}
-        branch: prepare_R${{ github.event.milestone.title }}
-        title: Prepare Release ${{ github.event.milestone.title }}
+        commit-message: Prepare Release ${{ inputs.nextReleaseVersion }}
+        branch: prepare_R${{ inputs.nextReleaseVersion }}
+        title: Prepare Release ${{ inputs.nextReleaseVersion }}
         body: A new Release Milstone was created, please review the changes and merge if appropriate.
         delete-branch: true
         milestone: ${{ github.event.milestone.number }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,6 @@ pipeline {
 				anyOf {
 					branch 'master'
 					branch 'R*_maintenance'
-					branch 'prepare_R*'
 				}
 			}
 			steps {

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -194,8 +194,14 @@ The release is scheduled for 10AM EST. Typically the jobs are scheduled beforeha
 #### **Create new Stream Repos:**
   - Run the [Create New Stream Repos](https://ci.eclipse.org/releng/job/Releng/job/newStreamRepos/) job to make an I-builds repo for the next release.
 
+#### **Prepare eclipse-platform-parent pom:**
+  - Run the [prepareRelease](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/actions/workflows/prepareRelease.yml) GH workflow to create a PR
+  to prepare the eclipse-platform-parent/pom.xml for for the next release.
+  - Review and submit the PR created https://github.com/eclipse-platform/eclipse.platform.releng.aggregator.
+  DO NOT CONTINUE with the next step before this has been completed
+
 #### **Create Git Milestones for the next Release:**
-  - Milestones in git are created by running the create-milestones job in jenkins, usually after RC1 or RC2. Only specific users can access this job for security reasons. If milestones need to be created and have not please contact @sdawley @sravanlakkimsetti or @laeubi to run it.
+  - Milestones in git are created by running the `create-milestones` job in jenkins, usually after RC1 or RC2. Only specific users can access this job for security reasons. If milestones need to be created and have not please contact @sdawley @sravanlakkimsetti or @laeubi to run it.
 
 #### **Version Updates:**
   - Once the milestones are created (see above) the [Prepare Next Release](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/actions/workflows/prepareRelease.yml) workflow will run, which will update pom and product versions for the Eclipse repositories and submit pull requests for the changes.  
@@ -209,7 +215,6 @@ The release is scheduled for 10AM EST. Typically the jobs are scheduled beforeha
     - Update eclipserun-repo, comparator.repo and eclipse-p2-repo.url in [eclipse-platform-parent/pom.xml](eclipse-platform-parent/pom.xml)
   - **Set Previous Version to RC2** 
     - RC2 becomes the new baseline for the week before the GA release.
-    - Update previous-release.baseline in [eclipse-platform-parent/pom.xml](eclipse-platform-parent/pom.xml)
     - Update the last release build versions in [eclipse.platform.releng.tychoeclipsebuilder/eclipse-junit-tests/src/main/resources/equinoxp2tests.properties](eclipse.platform.releng.tychoeclipsebuilder/eclipse-junit-tests/src/main/resources/equinoxp2tests.properties)
     - Update the previousReleaseVersion in [eclipse.platform.releng.tychoeclipsebuilder/eclipse-junit-tests/src/main/resources/label.properties](eclipse.platform.releng.tychoeclipsebuilder/eclipse-junit-tests/src/main/resources/label.properties)
     - Update the name of the copied files in [eclipse.platform.releng.tychoeclipsebuilder/eclipse-junit-tests/src/main/scripts/getPreviousRelease.sh](eclipse.platform.releng.tychoeclipsebuilder/eclipse-junit-tests/src/main/scripts/getPreviousRelease.sh)


### PR DESCRIPTION
As described in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2550#issuecomment-2495044382 ff running the `prepareRelease` workflow and submitting the automatically created changes in the `eclipse-platform-parent/pom.xml` before the milestones are created and thus the `updateRelease` workflow is triggered in all SDK repos, will ensure that in the parent-version update PR created in the other repos the project versions can already be bumped by the automatic version bump workflow. With that all release preparation changes necessary in the other repos are created automatically and one just has to review the PRs and submit it.