### PR TITLE
Do not call removed dofreezereport task

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/buildScripts/api-tools-builder.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/buildScripts/api-tools-builder.xml
@@ -55,9 +55,6 @@
       name="exclude_list_external_location"
       value="${EBuilderDir}/eclipse/apiexclude/exclude_list_external.txt" />
 
-    <!-- run the freeze task -->
-    <antcall target="dofreezeReport" />
-
     <!-- create the Ant filterstore directory -->
     <property
       name="filter_store"


### PR DESCRIPTION
It has been removed with
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2560 as it was not configured to do anything for years.