### PR TITLE
Do not report deprecations for 3rd party libs

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
@@ -6,9 +6,9 @@
 org.apache.ant
 org.apache.commons.codec
 org.objectweb.asm
+org.apache.commons.commons-io
 
 ## SPECIAL CASE FOR SWT: THE FRAGMENT IS ANALYZED AS PART OF THE HOST
-org.eclipse.swt.win32.win32.x86
 org.eclipse.swt.win32.win32.x86_64
 
 ## Can't guarantee jetty bundles API stabiltiy

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/buildScripts/api-tools-builder.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/buildScripts/api-tools-builder.xml
@@ -114,6 +114,7 @@
       baseline="${baseline}"
       profile="${current_location}"
       report="${deprecation_report}"
+      excludelist="${exclude_list_external_location}"
       debug="true" />
     <apitooling.apideprecation_reportconversion
       xmlfile="${deprecation_report}"


### PR DESCRIPTION
Looking at
https://download.eclipse.org/eclipse/downloads/drops4/I20241126-0600/apitools/deprecation/apideprecation.html shows deprecations from Apache Commons IO which are irrelevant for the project as API stability for 3rd party libs can not be guaranteed thus add commons-io to the excluded list and pass the list to apitooling.apideprecation ant task.