### PR TITLE
Remove links to non existing javadoc logs

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/staticDropFiles/logs.php
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/staticDropFiles/logs.php
@@ -49,18 +49,6 @@ if (window.attachEvent) window.attachEvent("onload", sfHover);
 <h1>Unit Test Logs for <?= $BUILD_ID ?></h1>
 <div class="homeitem3col">
 
-<!-- 
-     javaDoc logs are "at the top" of the compile logs directory, having been 
-     copied there by "helper.xml". Seems they could easily go into their own directory, 
-     and if so, then there is a releng test that would have to change too, either simply 
-     changing their location in the test.xml, or, changing to whole test to it would know
-     where to find their special directory, and then loop through the whole directory. 
--->
-<h2 id="javadoc">Javadoc Logs</h2>
-<?php
-listLogs("compilelogs");
-?>
-
 <h2 id="console">Console Logs</h2>
 <p>These logs contain the console output captured while running the JUnit automated tests.</p>
 

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/staticDropFiles/perflogs.php
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/staticDropFiles/perflogs.php
@@ -50,21 +50,6 @@ if (window.attachEvent) window.attachEvent("onload", sfHover);
 <div class="homeitem3col">
 <h1>Performance Unit Test Logs for <?= $BUILD_ID ?></h1>
 
-
-<!-- 
- No Javadoc logs.
-
-
-
-
-
-
-
-
-
-
--->
-
 <h2><a name="console" id="console"></a>Console Logs</h2>
 <p>These logs contain the console output captured while running the JUnit automated tests.</p>
 

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/staticDropFiles/testResults.php
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/staticDropFiles/testResults.php
@@ -71,9 +71,6 @@ if (file_exists("buildlogs/reporeports/index.html")) {
         </li>
         <?php } ?>
 
-        <li>
-        <a href="logs.php#javadoc"><b> Javadoc Logs </b></a>
-        </li>
         <li> <a href="logs.php#console"><b> Console Output Logs </b></a>
         </li>
         <li> <a href="buildlogs.php"><b>Release engineering build logs</b></a>


### PR DESCRIPTION
Javadoc failures break the build for some time and no separate log files are kept for later inspection.