### PR TITLE
Remove remnants from git.eclipse.org

### DIFF
--- a/JenkinsJobs/Releng/createMaintenanceBranch.groovy
+++ b/JenkinsJobs/Releng/createMaintenanceBranch.groovy
@@ -28,7 +28,7 @@ function fn_toPushRepo() {
 	if ! [[ "$from" == http* ]]; then
 		echo $from
 	else
-		echo $(sed -e 's,http://git.eclipse.org/gitroot,ssh://genie.releng@git.eclipse.org:29418,' -e 's,https://git.eclipse.org/r,ssh://genie.releng@git.eclipse.org:29418,' -e 's,https://github.com/,git@github.com:,' <<< $from)
+		echo $(sed -e 's,https://github.com/,git@github.com:,' <<< $from)
 	fi
 }
 

--- a/JenkinsJobs/Releng/tagEclipseRelease.groovy
+++ b/JenkinsJobs/Releng/tagEclipseRelease.groovy
@@ -63,7 +63,7 @@ function toPushRepo() {
 	if ! [[ "$from" == http* ]]; then
 		echo $from
 	else
-		echo $(sed -e 's,http://git.eclipse.org/gitroot,ssh://genie.releng@git.eclipse.org:29418,' -e 's,https://git.eclipse.org/r,ssh://genie.releng@git.eclipse.org:29418,' -e 's/https:\\/\\/github.com/ssh:\\/\\/git@github.com/g' <<< $from)
+		echo $(sed -e 's/https:\\/\\/github.com/ssh:\\/\\/git@github.com/g' <<< $from)
 	fi
 }
 

--- a/cje-production/mbscripts/mb110_tagBuildInputs.sh
+++ b/cje-production/mbscripts/mb110_tagBuildInputs.sh
@@ -61,7 +61,7 @@ function toPushRepo() {
 	if ! [[ "$from" == http* ]]; then
 		echo $from
 	else
-		echo $(sed -e 's,http://git.eclipse.org/gitroot,ssh://genie.releng@git.eclipse.org:29418,' -e 's,https://git.eclipse.org/r,ssh://genie.releng@git.eclipse.org:29418,' -e 's,https://github.com/,git@github.com:,' <<< $from)
+		echo $(sed -e 's,https://github.com/,git@github.com:,' <<< $from)
 	fi
 }
 export -f toPushRepo

--- a/cje-production/promotion/makeVisible.sh
+++ b/cje-production/promotion/makeVisible.sh
@@ -18,7 +18,7 @@ function toPushRepo() {
 	if ! [[ "$from" == http* ]]; then
 		echo $from
 	else
-		echo $(sed -e 's,http://git.eclipse.org/gitroot,ssh://genie.releng@git.eclipse.org:29418,' -e 's,https://git.eclipse.org/r,ssh://genie.releng@git.eclipse.org:29418,' -e 's,https://github.com/,git@github.com:,' <<< $from)
+		echo $(sed -e 's,https://github.com/,git@github.com:,' <<< $from)
 	fi
 }
 


### PR DESCRIPTION
No longer used so these sed calls just make scripts more complex.