### PR TITLE
Remove unknown parameters from mojos

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/pom.xml
@@ -36,15 +36,10 @@
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
-        <version>${tycho.version}</version>
-        <configuration>
-          <includePackedArtifacts>false</includePackedArtifacts>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-packaging-plugin</artifactId>
-        <version>${tycho.version}</version>
         <configuration>
           <format>'${buildId}'</format>
         </configuration>
@@ -223,7 +218,6 @@
               <compress>true</compress>
               <!-- whether to append to the target repository content -->
               <append>true</append>
-              <includePacked>false</includePacked>
             </configuration>
           </execution>
           <execution>
@@ -275,7 +269,6 @@
               <compress>true</compress>
               <!-- whether to append to the target repository content -->
               <append>true</append>
-              <includePacked>false</includePacked>
             </configuration>
           </execution>
         </executions>

--- a/eclipse.platform.releng.tychoeclipsebuilder/equinox-sdk/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/equinox-sdk/pom.xml
@@ -57,13 +57,6 @@
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
-        <configuration>
-          <strictBinIncludes>true</strictBinIncludes>
-          <includePackedArtifacts>false</includePackedArtifacts>
-          <sourceReferences>
-            <generate>true</generate>
-          </sourceReferences>
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Fixes warnings in the log like:
```
12:44:26  [WARNING] Parameter 'includePackedArtifacts' is unknown for
plugin 'target-platform-configuration:4.0.10:target-platform
(default-target-platform)'
12:44:26  [WARNING] Parameter 'includePacked' is unknown for plugin
'tycho-p2-extras-plugin:4.0.10:mirror (mirror-org.eclipse.platform)'
12:44:26  [WARNING] Parameter 'includePacked' is unknown for plugin
'tycho-p2-extras-plugin:4.0.10:mirror
(mirror-org.eclipse.platform.source)'
```