### PR TITLE
Complete update of previous release version to 4.34 GA in build scripts

### DIFF
--- a/production/testScripts/configuration/streamSpecific.properties
+++ b/production/testScripts/configuration/streamSpecific.properties
@@ -11,7 +11,7 @@ streamSpecificPropertiesTitle="Properties for 4.35.0 builds and tests"
 # stable version of Eclipse, that is used, for example, for it's p2
 # director, etc., so that "running the tests" is not actually using
 # the "just built" versions.
-previousReleaseLocation=https://${DOWNLOAD_HOST}/eclipse/downloads/drops4/S-4.34RC2-202411201800/
+previousReleaseLocation=https://${DOWNLOAD_HOST}/eclipse/downloads/drops4/R-4.34-202411201800/
 # version here is "build label" ... in general form, the "middle" of archive name,
 # such as  "eclipse-platform-${previousReleaseVersion}-linux-gtk-x86_64.tar.gz
 # Also used used in p2 testing?


### PR DESCRIPTION
This part was missing in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2608