### PR TITLE
Ensure that the project org.eclipse.platform.setup is in a working set

### DIFF
--- a/oomph/Platform.setup
+++ b/oomph/Platform.setup
@@ -274,7 +274,7 @@
           <operand
               xsi:type="predicates:RepositoryPredicate"
               project="org.eclipse.platform"
-              relativePathPattern="platform/.*"/>
+              relativePathPattern="platform/.*|releng/.*"/>
         </predicate>
       </workingSet>
       <workingSet
@@ -343,26 +343,6 @@
         </predicate>
       </workingSet>
       <workingSet
-          name="Platform Runtime">
-        <predicate
-            xsi:type="predicates:AndPredicate">
-          <operand
-              xsi:type="predicates:RepositoryPredicate"
-              project="org.eclipse.core.runtime"
-              relativePathPattern="runtime/(bundles|features).*"/>
-        </predicate>
-      </workingSet>
-      <workingSet
-          name="Platform Runtime Tests">
-        <predicate
-            xsi:type="predicates:AndPredicate">
-          <operand
-              xsi:type="predicates:RepositoryPredicate"
-              project="org.eclipse.core.runtime"
-              relativePathPattern="runtime/tests/.*"/>
-        </predicate>
-      </workingSet>
-      <workingSet
           name="Platform Resources">
         <predicate
             xsi:type="predicates:AndPredicate">
@@ -380,6 +360,26 @@
               xsi:type="predicates:RepositoryPredicate"
               project="org.eclipse.core.resources"
               relativePathPattern="resources/tests/.*"/>
+        </predicate>
+      </workingSet>
+      <workingSet
+          name="Platform Runtime">
+        <predicate
+            xsi:type="predicates:AndPredicate">
+          <operand
+              xsi:type="predicates:RepositoryPredicate"
+              project="org.eclipse.core.runtime"
+              relativePathPattern="runtime/(bundles|features).*"/>
+        </predicate>
+      </workingSet>
+      <workingSet
+          name="Platform Runtime Tests">
+        <predicate
+            xsi:type="predicates:AndPredicate">
+          <operand
+              xsi:type="predicates:RepositoryPredicate"
+              project="org.eclipse.core.runtime"
+              relativePathPattern="runtime/tests/.*"/>
         </predicate>
       </workingSet>
       <workingSet


### PR DESCRIPTION
- Improve the sort order for eclipse-platform/eclipse.platform's work sets.