### PR TITLE
[Build] Create consolelog.txt file in test execution directory again

### DIFF
--- a/production/testScripts/runTests2.xml
+++ b/production/testScripts/runTests2.xml
@@ -816,13 +816,13 @@
     depends="init"
     unless="env.TESTING_TEST_XML">
 
-    <mkdir dir="results/consolelogs"/>
-    <chmod file="${testScript}" perm="755"/>
+    <mkdir dir="${executionDir}/results/consolelogs"/>
+    <chmod file="${executionDir}/${testScript}" perm="755"/>
     <!--run the tests -->
     <exec
       dir="${executionDir}"
       executable="${testExecutable}"
-      output="results/consolelogs/${testedPlatform}_consolelog.txt">
+      output="${executionDir}/results/consolelogs/${testedPlatform}_consolelog.txt">
       <arg line="${executionArguments}" />
       <arg line="-os ${osgi.os} -ws ${osgi.ws} -arch ${osgi.arch}"/>
       <arg value="-vm"/><arg path="${jvm}"/>


### PR DESCRIPTION
This fixes the regression that the the <testedPlatform>_consolelog.txt is created at the wrong location.
It was missed that the <testedPlatform>_consolelog.txt file was created in the executionDir (because the scripted inlined ran in that directory) in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2516

See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2516#issuecomment-2509795054