### PR TITLE
[Build] Fix reference to secManager parameter in smoke test jobs

### DIFF
--- a/JenkinsJobs/SmokeTests/smoke_test_opensuse_leap.groovy
+++ b/JenkinsJobs/SmokeTests/smoke_test_opensuse_leap.groovy
@@ -164,7 +164,7 @@ spec:
                                 export JAVA_HOME=$JAVA_HOME_NEW
                                 echo ANT_HOME: $ANT_HOME
                                 echo PATH: $PATH
-                                export ANT_OPTS="${ANT_OPTS} -Djava.io.tmpdir=${WORKSPACE}/tmp ${secMananger}"
+                                export ANT_OPTS="${ANT_OPTS} -Djava.io.tmpdir=${WORKSPACE}/tmp ${secManager}"
                                 
                                 env 1>envVars.txt 2>&1
                                 ant -diagnostics 1>antDiagnostics.txt 2>&1

--- a/JenkinsJobs/SmokeTests/smoke_test_ppcle.groovy
+++ b/JenkinsJobs/SmokeTests/smoke_test_ppcle.groovy
@@ -79,7 +79,7 @@ export PATH=${JAVA_HOME}/bin:${PATH}
 echo JAVA_HOME: $JAVA_HOME
 echo PATH: $PATH
 
-export ANT_OPTS="${ANT_OPTS} -Djava.io.tmpdir=${WORKSPACE}/tmp ${secMananger}"
+export ANT_OPTS="${ANT_OPTS} -Djava.io.tmpdir=${WORKSPACE}/tmp ${secManager}"
 
 env 1>envVars.txt 2>&1
 ant -diagnostics 1>antDiagnostics.txt 2>&1

--- a/JenkinsJobs/SmokeTests/smoke_test_ubuntu.groovy
+++ b/JenkinsJobs/SmokeTests/smoke_test_ubuntu.groovy
@@ -73,7 +73,7 @@ pipeline {
                                 export JAVA_HOME=$JAVA_HOME_NEW
                                 echo ANT_HOME: $ANT_HOME
                                 echo PATH: $PATH
-                                export ANT_OPTS="${ANT_OPTS} -Djava.io.tmpdir=${WORKSPACE}/tmp ${secMananger}"
+                                export ANT_OPTS="${ANT_OPTS} -Djava.io.tmpdir=${WORKSPACE}/tmp ${secManager}"
                                 
                                 env 1>envVars.txt 2>&1
                                 ant -diagnostics 1>antDiagnostics.txt 2>&1


### PR DESCRIPTION
Maybe this helps to fix some of the smoke-test failures.