### PR TITLE
Do not report 3rd party deprecations in I-builds

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
@@ -7,6 +7,7 @@ org.apache.ant
 org.apache.commons.codec
 org.objectweb.asm
 org.apache.commons.commons-io
+biz.aQute.bndlib
 
 ## SPECIAL CASE FOR SWT: THE FRAGMENT IS ANALYZED AS PART OF THE HOST
 org.eclipse.swt.win32.win32.x86_64


### PR DESCRIPTION
Clears
```
biz.aQute.bndlib(7.1.0)
DEPRECATED	aQute.bnd.build.model.BndEditModel#boolean isCnf()
DEPRECATED	aQute.bnd.build.model.BndEditModel#void
setIncludeResource(List<String>)
DEPRECATED	aQute.bnd.build.model.BndEditModel#void setProject(Project)
DEPRECATED	aQute.bnd.osgi.Constants#INCLUDE_RESOURCE
```
from deprecation reports e.g.
https://download.eclipse.org/eclipse/downloads/drops4/I20241201-1800/apitools/deprecation/apideprecation.html