### PR TITLE
Changing version from 4.34 to 4.35-I-Builds

### DIFF
--- a/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr
+++ b/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr
@@ -2,10 +2,10 @@
 <aggregator:Aggregation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="SDK4Mvn" packedStrategy="UNPACK_AS_SIBLING" type="R" mavenResult="true" versionFormat="MavenRelease" includeSources="true">
   <validationSets label="main">
     <contributions label="sdk">
-      <repositories enabled="false" location="/home/data/httpd/download.eclipse.org/eclipse/updates/4.34/R-4.34-202411201800"/>
+      <repositories enabled="false" location="/home/data/httpd/download.eclipse.org/eclipse/updates/4.35-I-builds"/>
     </contributions>
     <contributions label="sdk_http">
-      <repositories location="https://download.eclipse.org/eclipse/updates/4.34/R-4.34-202411201800"/>
+      <repositories location="https://download.eclipse.org/eclipse/updates/4.35-I-builds"/>
     </contributions>
   </validationSets>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="aarch64"/>


### PR DESCRIPTION
Changing the version of SDK4Mvn.aggr from 4.34 to 4.35-I-Builds post publishing to maven central.

Refs: https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2606

cc/ @MohananRahul 