### PR TITLE
[Build] Unify Y-build test job names to schema os-arch-javaVersion

### DIFF
--- a/JenkinsJobs/YBuilds/Y_build.groovy
+++ b/JenkinsJobs/YBuilds/Y_build.groovy
@@ -427,11 +427,11 @@ spec:
 	  stage('Trigger tests'){
           steps {
               container('jnlp') {
-                build job: 'YPBuilds/ep''' + MAJOR + MINOR + '''Y-unit-cen64-gtk3-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
-                build job: 'YPBuilds/ep''' + MAJOR + MINOR + '''Y-unit-cen64-gtk3-java21', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
-                build job: 'YPBuilds/ep''' + MAJOR + MINOR + '''Y-unit-cen64-gtk3-java24', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
-                build job: 'YPBuilds/ep''' + MAJOR + MINOR + '''Y-unit-macM1-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
-                build job: 'YPBuilds/ep''' + MAJOR + MINOR + '''Y-unit-mac64-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
+                build job: 'YPBuilds/ep''' + MAJOR + MINOR + '''Y-unit-linux-x86_64-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
+                build job: 'YPBuilds/ep''' + MAJOR + MINOR + '''Y-unit-linux-x86_64-java21', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
+                build job: 'YPBuilds/ep''' + MAJOR + MINOR + '''Y-unit-linux-x86_64-java24', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
+                build job: 'YPBuilds/ep''' + MAJOR + MINOR + '''Y-unit-macosx-aarch64-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
+                build job: 'YPBuilds/ep''' + MAJOR + MINOR + '''Y-unit-macosx-x86_64-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
                 build job: 'SmokeTests/Start-smoke-tests', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
               }
             }

--- a/JenkinsJobs/YBuilds/Y_unit_linux.groovy
+++ b/JenkinsJobs/YBuilds/Y_unit_linux.groovy
@@ -12,7 +12,7 @@ for (STREAM in STREAMS){
   def MINOR = STREAM.split('\\.')[1]
   for (BUILD_CONFIG in BUILD_CONFIGURATIONS){
 	
-	pipelineJob('YPBuilds/ep' + MAJOR + MINOR + 'Y-unit-cen64-gtk3-java' + BUILD_CONFIG.javaVersion){
+    pipelineJob('YPBuilds/ep' + MAJOR + MINOR + 'Y-unit-linux-x86_64-java' + BUILD_CONFIG.javaVersion){
 	
 	  logRotator {
 	    numToKeep(5)

--- a/JenkinsJobs/YBuilds/Y_unit_mac.groovy
+++ b/JenkinsJobs/YBuilds/Y_unit_mac.groovy
@@ -2,8 +2,8 @@ def config = new groovy.json.JsonSlurper().parseText(readFileFromWorkspace('Jenk
 def STREAMS = config.Streams
 
 def BUILD_CONFIGURATIONS = [ 
-  [name: 'macM1', arch: 'aarch64', agentLabel: 'nc1ht-macos11-arm64', javaHome: '/usr/local/openjdk-17/Contents/Home' ],
-  [name: 'mac64', arch: 'x86_64',  agentLabel: 'nc1ht-macos11-arm64', javaHome: '/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home' ]
+  [arch: 'aarch64', agentLabel: 'nc1ht-macos11-arm64', javaHome: '/usr/local/openjdk-17/Contents/Home' ],
+  [arch: 'x86_64',  agentLabel: 'nc1ht-macos11-arm64', javaHome: '/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home' ]
 ]
 
 for (STREAM in STREAMS){
@@ -11,7 +11,7 @@ for (STREAM in STREAMS){
   def MINOR = STREAM.split('\\.')[1]
   for (BUILD_CONFIG in BUILD_CONFIGURATIONS){
 
-	job('YPBuilds/ep' + MAJOR + MINOR + 'Y-unit-' + BUILD_CONFIG.name + '-java17'){
+	job('YPBuilds/ep' + MAJOR + MINOR + 'Y-unit-macosx-' + BUILD_CONFIG.arch + '-java17'){
 	  description('Run Eclipse SDK Tests for ' + BUILD_CONFIG.arch + ' Mac (and ' + BUILD_CONFIG.arch + ' VM and Eclipse)')
 	
 	  logRotator {

--- a/JenkinsJobs/YBuilds/Y_unit_win32.groovy
+++ b/JenkinsJobs/YBuilds/Y_unit_win32.groovy
@@ -5,7 +5,7 @@ for (STREAM in STREAMS){
   def MAJOR = STREAM.split('\\.')[0]
   def MINOR = STREAM.split('\\.')[1]
   
-	job('YPBuilds/ep' + MAJOR + MINOR + 'Y-unit-win32-java17'){
+	job('YPBuilds/ep' + MAJOR + MINOR + 'Y-unit-win32-x86_64-java17'){
 	  description('Run Eclipse SDK Windows Tests ')
 	
 	  logRotator {

--- a/cje-production/Y-build/publish.xml
+++ b/cje-production/Y-build/publish.xml
@@ -183,12 +183,12 @@
     </condition>
     <!-- else normal unit tests configs -->
     <resources id="testsConfigExpected">
-      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-mac64-java17_macosx.cocoa.x86_64_17</string>
-      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-macM1-java17_macosx.cocoa.aarch64_17</string>
-      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-win32-java17_win32.win32.x86_64_17</string>
-      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-cen64-gtk3-java17_linux.gtk.x86_64_17</string>
-      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-cen64-gtk3-java21_linux.gtk.x86_64_21</string>
-      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-cen64-gtk3-java24_linux.gtk.x86_64_24</string>
+      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-macosx-x86_64-java17_macosx.cocoa.x86_64_17</string>
+      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-macosx-aarch64-java17_macosx.cocoa.aarch64_17</string>
+      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-win32-x86_64-java17_win32.win32.x86_64_17</string>
+      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-linux-x86_64-java17_linux.gtk.x86_64_17</string>
+      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-linux-x86_64-java21_linux.gtk.x86_64_21</string>
+      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-linux-x86_64-java24_linux.gtk.x86_64_24</string>
     </resources>
     <pathconvert property="testsConfigExpected" refid="testsConfigExpected" pathsep="," />
 

--- a/cje-production/Y-build/testConfigs.php
+++ b/cje-production/Y-build/testConfigs.php
@@ -10,8 +10,8 @@
 include("buildproperties.php");
 
 $expectedTestConfigs = array();
-$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-mac64-java17_macosx.cocoa.x86_64_17";
-$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-macM1-java17_macosx.cocoa.aarch64_17";
-$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-cen64-gtk3-java17_linux.gtk.x86_64_17";
-$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-cen64-gtk3-java21_linux.gtk.x86_64_21";
-$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-cen64-gtk3-java24_linux.gtk.x86_64_24";
+$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-macosx-x86_64-java17_macosx.cocoa.x86_64_17";
+$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-macosx-aarch64-java17_macosx.cocoa.aarch64_17";
+$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-linux-x86_64-java17_linux.gtk.x86_64_17";
+$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-linux-x86_64-java21_linux.gtk.x86_64_21";
+$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-linux-x86_64-java24_linux.gtk.x86_64_24";


### PR DESCRIPTION
This simplifies later additions of new os-arch combinations.

This is similar to https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2481, just for Y-build tests.

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2625

