### PR TITLE
[Y-Build-Tests] Define Mac and Windows jobs as Jenkins-pipeline

### DIFF
--- a/JenkinsJobs/YBuilds/Y_unit_linux.groovy
+++ b/JenkinsJobs/YBuilds/Y_unit_linux.groovy
@@ -11,13 +11,8 @@ for (STREAM in STREAMS){
   def MAJOR = STREAM.split('\\.')[0]
   def MINOR = STREAM.split('\\.')[1]
   for (BUILD_CONFIG in BUILD_CONFIGURATIONS){
-	
+
     pipelineJob('YPBuilds/ep' + MAJOR + MINOR + 'Y-unit-linux-x86_64-java' + BUILD_CONFIG.javaVersion){
-	
-	  logRotator {
-	    numToKeep(5)
-	  }
-	
 	  parameters {
 	    stringParam('buildId', null, null)
 	    stringParam('javaDownload', BUILD_CONFIG.javaDownload, null)
@@ -107,12 +102,16 @@ pipeline {
               }
               archiveArtifacts '**/eclipse-testing/results/**, **/eclipse-testing/directorLogs/**, *.properties, *.txt'
               junit keepLongStdio: true, testResults: '**/eclipse-testing/results/xml/*.xml'
-              build job: 'YPBuilds/ep-collectYbuildResults', parameters: [string(name: 'triggeringJob', value: "${JOB_BASE_NAME}"), string(name: 'buildURL', value: "${BUILD_URL}"), string(name: 'buildID', value: "${params.buildId}")], wait: false
+              build job: 'YPBuilds/ep-collectYbuildResults', wait: false, parameters: [
+                string(name: 'triggeringJob', value: "${JOB_BASE_NAME}"),
+                string(name: 'buildURL', value: "${BUILD_URL}"),
+                string(name: 'buildID', value: "${params.buildId}")
+              ]
           }
       }
   }
 }
-      ''')
+''')
     }
   }
  }

--- a/JenkinsJobs/YBuilds/Y_unit_mac.groovy
+++ b/JenkinsJobs/YBuilds/Y_unit_mac.groovy
@@ -11,77 +11,30 @@ for (STREAM in STREAMS){
   def MINOR = STREAM.split('\\.')[1]
   for (BUILD_CONFIG in BUILD_CONFIGURATIONS){
 
-	job('YPBuilds/ep' + MAJOR + MINOR + 'Y-unit-macosx-' + BUILD_CONFIG.arch + '-java17'){
+    pipelineJob('YPBuilds/ep' + MAJOR + MINOR + 'Y-unit-macosx-' + BUILD_CONFIG.arch + '-java17'){
 	  description('Run Eclipse SDK Tests for ' + BUILD_CONFIG.arch + ' Mac (and ' + BUILD_CONFIG.arch + ' VM and Eclipse)')
-	
-	  logRotator {
-	    numToKeep(5)
-	  }
-	
 	  parameters {
 	    stringParam('buildId', null, 'Build Id to test (such as I20120717-0800, N20120716-0800). ')
 	    stringParam('testSuite', 'all', null)
 	  }
-	
-	
-	  label('nc1ht-macos11-arm64')
-	
-	  jdk('openjdk-jdk11-latest')
-	
-	  wrappers { //adds pre/post actions
-	    timestamps()
-	    timeout {
-	      absolute(600)
-	    }
-	  }
-	  
-	  steps {
-	    shell('''
-#!/usr/bin/env bash
-
-if [[ -z "${WORKSPACE}" ]]
-then
-  echo -e "\\n\\tERROR: WORKSPACE variable was not defined"
-  exit 1
-else
-  if [[ ! -d "${WORKSPACE}" ]]
-  then
-    echo -e "\\n\\tERROR: WORKSPACE was defined, but did not exist?"
-    echo -e "\\t\\tIt was defined as ${WORKSPACE}"
-    exit 1
-  else
-    echo -e "\\n\\tINFO: WORKSPACE was defined as ${WORKSPACE}"
-    echo -e "\\t\\tWill delete contents, for clean run"
-    MaxLoops=15
-    SleepTime=60
-    currentLoop=0
-    nFilesOrDirs=$( find "${WORKSPACE}" -mindepth 1 -maxdepth 1 | wc -l )
-    while [[ ${nFilesOrDirs} -gt 0 ]]
-    do
-      currentLoop=$(( ${currentLoop} + 1 ))
-      if [[ ${currentLoop} -gt ${MaxLoops} ]]
-      then
-        echo -e "\\n\\tERROR: Number of re-try loops, ${currentLoop}, exceeded maximum, ${MaxLoops}. "
-        echo -e " \\t\\tPossibly due to files still being used by another process?"
-        exit 0
-        break
-      fi
-      echo -e "\\tcurrentLoop: ${currentLoop}   nFilesOrDirs:  ${nFilesOrDirs}"
-      find "${WORKSPACE}" -mindepth 1 -maxdepth 1 -execdir rm -fr '{}' \\;
-      nFilesOrDirs=$( find "${WORKSPACE}" -mindepth 1 -maxdepth 1 | wc -l )
-      if [[ ${nFilesOrDirs} -gt 0 ]]
-      then
-        sleep ${SleepTime}
-      fi
-    done
-  fi
-fi
-echo -e "\\t... ending cleaning"
-
-exit 0
-    ''')
-    shell('''
-#!/bin/bash -x
+      definition {
+        cps {
+          sandbox()
+          script('''
+pipeline {
+  options {
+    timeout(time: 600, unit: 'MINUTES')
+    timestamps()
+    buildDiscarder(logRotator(numToKeepStr:'5'))
+  }
+  agent {
+    label \'''' + BUILD_CONFIG.agentLabel + ''''
+  }
+  stages {
+      stage('Run tests'){
+          steps {
+              cleanWs() // workspace not cleaned by default
+              sh \'\'\'#!/bin/bash -x
 
 RAW_DATE_START="$(date +%s )"
 
@@ -136,31 +89,21 @@ echo -e "\\n\\tRAW Date End: ${RAW_DATE_END} \\n"
 TOTAL_TIME=$((${RAW_DATE_END} - ${RAW_DATE_START}))
 
 echo -e "\\n\\tTotal elapsed time: ${TOTAL_TIME} \\n"
-    ''')
+\'\'\'
+              archiveArtifacts '**/eclipse-testing/results/**, **/eclipse-testing/directorLogs/**, *.properties, *.txt'
+              junit keepLongStdio: true, testResults: '**/eclipse-testing/results/xml/*.xml'
+              build job: 'YPBuilds/ep-collectYbuildResults', wait: false, parameters: [
+                string(name: 'triggeringJob', value: "${JOB_BASE_NAME}"),
+                string(name: 'buildURL', value: "${BUILD_URL}"),
+                string(name: 'buildID', value: "${params.buildId}")
+              ]
+          }
+      }
   }
-
-  publishers {
-    archiveJunit('**/eclipse-testing/results/xml/*.xml') {
-      retainLongStdout()
-      healthScaleFactor((1.0).doubleValue())
-    }
-    archiveArtifacts {
-      pattern('**/eclipse-testing/results/**, **/eclipse-testing/directorLogs/**, *.properties, *.txt')
-    }
-    extendedEmail {
-      recipientList("sravankumarl@in.ibm.com")
-    }
-    downstreamParameterized {
-      trigger('YPBuilds/ep-collectYbuildResults') {
-        condition('UNSTABLE_OR_BETTER')
-        parameters {
-          predefinedProp('triggeringJob', '$JOB_BASE_NAME')
-          predefinedProp('buildURL', '$BUILD_URL')
-          predefinedProp('buildID', '$buildId')
+}
+''')
         }
       }
     }
   }
- }
-}
 }

--- a/JenkinsJobs/YBuilds/Y_unit_win32.groovy
+++ b/JenkinsJobs/YBuilds/Y_unit_win32.groovy
@@ -4,95 +4,30 @@ def STREAMS = config.Streams
 for (STREAM in STREAMS){
   def MAJOR = STREAM.split('\\.')[0]
   def MINOR = STREAM.split('\\.')[1]
-  
-	job('YPBuilds/ep' + MAJOR + MINOR + 'Y-unit-win32-x86_64-java17'){
+
+    pipelineJob('YPBuilds/ep' + MAJOR + MINOR + 'Y-unit-win32-x86_64-java17'){
 	  description('Run Eclipse SDK Windows Tests ')
-	
-	  logRotator {
-	    numToKeep(25)
-	  }
-	
 	  parameters {
 	    stringParam('buildId', null, 'Build Id to test (such as I20120717-0800, N20120716-0800). ')
 	  }
-	
-	  label('qa6xd-win11')
-	
-	  wrappers { //adds pre/post actions
-	    timestamps()
-	    timeout {
-	      absolute(901)
-	    }
-	  }
-	  
-	  steps {
-	    batchFile('''
-@echo off
-SETLOCAL ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
-echo start cleaning ...
-IF NOT DEFINED WORKSPACE (
-    echo ERROR: WORKSPACE variable was not defined.
-    exit /B 1
-    ) ELSE (
-      IF NOT EXIST "%WORKSPACE%" (
-        echo ERROR: WORKSPACE was defined, but it did not exist.
-        echo     It was defined as %WORKSPACE%
-        exit /B 1
-        ) ELSE (
-          echo WORSPACE defined as %WORKSPACE%
-          echo Will delete contents, for clean run.
-          rem Note that rmdir and rm do not return ERRORLEVEL.
-          rem Which is why we "do while" until count of files is zero.
-          rem (or, until max loops is reached).
-          set /a maxLoops=15
-          echo maxLoops: !maxLoops!
-          set /a sleepTime=60000
-          echo sleepTime: !sleepTime!
-          set /a currentLoop=0
-
-          set /a nFilesOrDirs=0
-          for /D %%f in ("%WORKSPACE%\\*") do set /a nFilesOrDirs+=1
-          for    %%f in ("%WORKSPACE%\\*") do set /a nFilesOrDirs+=1
-          echo currentLoop: !currentLoop!   nFilesOrDirs:  !nFilesOrDirs!
-
-          :LOOP
-          IF !nFilesOrDirs! GTR 0 (
-            rem this first for loop is for all subdirectories of workspace
-            FOR /D %%p IN ("%WORKSPACE%\\*") DO (
-              echo removing dir: %%p
-              rmdir "%%p" /s /q
-              )
-            rem this for loop is for for all files remaining, directly under workspace
-            FOR %%p IN ("%WORKSPACE%\\*") DO (
-              echo deleting file: %%p
-              del "%%p"  /q
-              )
-            set /a currentLoop+=1
-            IF !currentLoop! GTR !maxLoops! GOTO MAXLOOPS
-            set /a nFilesOrDirs=0
-            for /D %%f in ("%WORKSPACE%\\*") do set /a nFilesOrDirs+=1
-            for    %%f in ("%WORKSPACE%\\*") do set /a nFilesOrDirs+=1
-            echo currentLoop: !currentLoop!   nFilesOrDirs:  !nFilesOrDirs!
-            if !nFilesOrDirs! GTR 0 (
-              rem Pause a bit before retrying, since if we could not delete, likely due to some process still running.
-              rem 'timeout' causes "redirection not allowed" error. See bug 482598. 
-              rem C:\\Windows\\System32\\timeout.exe /t !sleepTime!
-              ping 127.0.0.1 -n1 -w !sleepTime! >NUL 
-              GOTO LOOP
-              )
-            )
-         )
-     )
-echo ... normal end of cleaning section (i.e. max loops NOT reached)
-exit 0
-
-
-:MAXLOOPS
-echo Reached max loops waiting for files to be free to delete
-rem note use of "hard exit" (no /B) as an attempt to get Hudson to fail.
-exit 0
-    ''')
-    batchFile('''
+      definition {
+        cps {
+          sandbox()
+          script('''
+pipeline {
+  options {
+    timeout(time: 600, unit: 'MINUTES')
+    timestamps()
+    buildDiscarder(logRotator(numToKeepStr:'5'))
+  }
+  agent {
+    label 'qa6xd-win11'
+  }
+  stages {
+      stage('Run tests'){
+          steps {
+              cleanWs() // workspace not cleaned by default
+              bat \'\'\'
 rem May want to try and restrict path, as we do on cron jobs, so we
 rem have more consistent conditions.
 rem export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:~/bin
@@ -118,31 +53,20 @@ set JAVA_HOME
 set Path="C:\\PROGRA~1\\ECLIPS~1\\jdk-17.0.5.8-hotspot\\bin";C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\ProgramData\\chocolatey\\bin;C:\\tools\\cygwin\\bin;C:\\Program Files\\IcedTeaWeb\\WebStart\\bin;C:\\WINDOWS\\system32;C:\\WINDOWS;C:\\WINDOWS\\System32\\Wbem;C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\;C:\\WINDOWS\\System32\\OpenSSH\\;C:\\Users\\jenkins_vnc\\AppData\\Local\\Microsoft\\WindowsApps;%PATH%
 
 ant -f getEBuilder.xml -Djava.io.tmpdir=%WORKSPACE%\\tmp -Djvm="C:\\PROGRA~1\\ECLIPS~1\\jdk-17.0.5.8-hotspot\\bin\\java.exe" -DbuildId=%buildId%  -DeclipseStream=%STREAM% -DEBUILDER_HASH=%EBUILDER_HASH%  -DdownloadURL="https://download.eclipse.org/eclipse/downloads/drops4/%buildId%" -Dargs=all -Dosgi.os=win32 -Dosgi.ws=win32 -Dosgi.arch=x86_64 -DtestSuite=all
-
-    ''')
+\'\'\'
+              archiveArtifacts '**/eclipse-testing/results/**, **/eclipse-testing/directorLogs/**, *.properties, *.txt'
+              junit keepLongStdio: true, testResults: '**/eclipse-testing/results/xml/*.xml'
+              build job: 'YPBuilds/ep-collectYbuildResults', wait: false, parameters: [
+                string(name: 'triggeringJob', value: "${JOB_BASE_NAME}"),
+                string(name: 'buildURL', value: "${BUILD_URL}"),
+                string(name: 'buildID', value: "${params.buildId}")
+              ]
+          }
+      }
   }
-
-  publishers {
-    archiveJunit('**/eclipse-testing/results/xml/*.xml') {
-      retainLongStdout()
-      healthScaleFactor((1.0).doubleValue())
-    }
-    archiveArtifacts {
-      pattern('**/eclipse-testing/results/**, **/eclipse-testing/directorLogs/**, *.properties, *.txt')
-    }
-    extendedEmail {
-      recipientList("sravankumarl@in.ibm.com")
-    }
-    downstreamParameterized {
-      trigger('YPBuilds/ep-collectYbuildResults') {
-        condition('ALWAYS')
-        parameters {
-          predefinedProp('triggeringJob', '$JOB_BASE_NAME')
-          predefinedProp('buildURL', '$BUILD_URL')
-          predefinedProp('buildID', '$buildId')
+}
+''')
         }
       }
     }
-  }
- }
 }


### PR DESCRIPTION
and slightly clean-up existing pipeline for linux. 
Unify numbers like time-outs and numbers of retained builds.

This is similar to https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2004, just for Y-build tests.

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2625