### PR TITLE
[Build] Unify all smoke test job configurations to be Jenkins-pipelines

### DIFF
--- a/JenkinsJobs/SmokeTests/smoke_test_centos9.groovy
+++ b/JenkinsJobs/SmokeTests/smoke_test_centos9.groovy
@@ -23,8 +23,8 @@ pipeline {
 	}
   agent {
     kubernetes {
-      label 'centos9-pod-' + env.BUILD_NUMBER
       defaultContainer 'custom'
+      inheritFrom 'basic'
       yaml """
 apiVersion: v1
 kind: Pod
@@ -40,32 +40,9 @@ spec:
       requests:
         memory: "512Mi"
         cpu: "1000m"
-    securityContext:
-      privileged: false
     tty: true
     command:
     - cat
-    volumeMounts:
-    - mountPath: "/opt/tools"
-      name: "volume-0"
-      readOnly: false
-    workingDir: "/home/jenkins/agent"
-  nodeSelector: {}
-  restartPolicy: "Never"
-  volumes:
-  - name: "volume-0"
-    persistentVolumeClaim:
-      claimName: "tools-claim-jiro-releng"
-      readOnly: true
-  - configMap:
-      name: "known-hosts"
-    name: "volume-1"
-  - emptyDir:
-      medium: ""
-    name: "workspace-volume"
-  - emptyDir:
-      medium: ""
-    name: "volume-3"
 """
     }
   }

--- a/JenkinsJobs/SmokeTests/smoke_test_opensuse_leap.groovy
+++ b/JenkinsJobs/SmokeTests/smoke_test_opensuse_leap.groovy
@@ -23,8 +23,8 @@ pipeline {
 	}
   agent {
     kubernetes {
-      label 'leap-' + env.BUILD_NUMBER
       defaultContainer 'custom'
+      inheritFrom 'basic'
       yaml """
 apiVersion: v1
 kind: Pod
@@ -40,77 +40,9 @@ spec:
       requests:
         memory: "512Mi"
         cpu: "1000m"
-    securityContext:
-      privileged: false
     tty: true
     command:
     - cat
-    volumeMounts:
-    - mountPath: "/home/jenkins/agent"
-      name: "workspace-volume"
-      readOnly: false
-    - mountPath: "/home/jenkins/.m2/toolchains.xml"
-      name: "toolchains-xml"
-      readOnly: true
-      subPath: "toolchains.xml"
-    - mountPath: "/opt/tools"
-      name: "volume-0"
-      readOnly: false
-    - mountPath: "/home/jenkins"
-      name: "volume-2"
-      readOnly: false
-    - mountPath: "/home/jenkins/.m2/repository"
-      name: "volume-3"
-      readOnly: false
-    - mountPath: "/home/jenkins/.m2/settings-security.xml"
-      name: "settings-security-xml"
-      readOnly: true
-      subPath: "settings-security.xml"
-    - mountPath: "/home/jenkins/.m2/settings.xml"
-      name: "settings-xml"
-      readOnly: true
-      subPath: "settings.xml"
-    - mountPath: "/home/jenkins/.ssh"
-      name: "volume-1"
-      readOnly: false
-    workingDir: "/home/jenkins/agent"
-  nodeSelector: {}
-  restartPolicy: "Never"
-  volumes:
-  - name: "settings-security-xml"
-    secret:
-      items:
-      - key: "settings-security.xml"
-        path: "settings-security.xml"
-      secretName: "m2-secret-dir"
-  - name: "volume-0"
-    persistentVolumeClaim:
-      claimName: "tools-claim-jiro-releng"
-      readOnly: true
-  - configMap:
-      items:
-      - key: "toolchains.xml"
-        path: "toolchains.xml"
-      name: "m2-dir"
-    name: "toolchains-xml"
-  - emptyDir:
-      medium: ""
-    name: "volume-2"
-  - configMap:
-      name: "known-hosts"
-    name: "volume-1"
-  - name: "settings-xml"
-    secret:
-      items:
-      - key: "settings.xml"
-        path: "settings.xml"
-      secretName: "m2-secret-dir"
-  - emptyDir:
-      medium: ""
-    name: "workspace-volume"
-  - emptyDir:
-      medium: ""
-    name: "volume-3"
 """
     }
   }

--- a/JenkinsJobs/SmokeTests/smoke_test_ppcle.groovy
+++ b/JenkinsJobs/SmokeTests/smoke_test_ppcle.groovy
@@ -11,29 +11,28 @@ job('SmokeTests/ep-smoke-test-ppcle'){
     stringParam('secManager', '-Djava.security.manager=allow', null)
   }
 
-  concurrentBuild()
-
-  label('ppctest')
-
-  jdk('openjdk-jdk17-latest')
-
-  wrappers { //adds pre/post actions
-    timestamps()
-    preBuildCleanup()
-    timeout {
-      absolute(60)
-    }
-    xvnc {
-      useXauthority()
-    }
-    withAnt {
-      installation('apache-ant-latest')
-    }
-  }
-  
-  steps {
-    shell('''#!/usr/bin/env bash
-
+  definition {
+    cps {
+      sandbox()
+      script('''
+pipeline {
+	options {
+		timeout(time: 60, unit: 'MINUTES')
+		timestamps()
+		buildDiscarder(logRotator(numToKeepStr:'5'))
+	}
+	agent {
+		label "ppctest"
+	}
+  stages {
+      stage('Run tests'){
+          steps {
+                  cleanWs()
+                  wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
+                      withEnv(["JAVA_HOME_NEW=${ tool 'openjdk-jdk19-latest' }"]) {
+                          withAnt(installation: 'apache-ant-latest') {
+                              sh \'\'\'#!/bin/bash -x
+                               
 buildId=$(echo $buildId|tr -d ' ')
 
 
@@ -94,15 +93,17 @@ echo -e "\\n\\tRAW Date End: ${RAW_DATE_END} \\n"
 TOTAL_TIME=$((${RAW_DATE_END} - ${RAW_DATE_START}))
 
 echo -e "\\n\\tTotal elapsed time: ${TOTAL_TIME} \\n"
-    ''')
+                              \'\'\'
+                      }
+                  }
+              }
+              archiveArtifacts '**/eclipse-testing/results/**, **/eclipse-testing/directorLogs/**, *.properties, *.txt'
+              junit keepLongStdio: true, testResults: '**/eclipse-testing/results/xml/*.xml'
+          }
+      }
   }
-
-  publishers {
-    archiveJunit('**/eclipse-testing/results/xml/*.xml') {
-      healthScaleFactor((1.0).doubleValue())
-    }
-    archiveArtifacts {
-      pattern('**/eclipse-testing/results/**, **/eclipse-testing/directorLogs/**, *.properties, *.txt')
+}
+      ''')
     }
   }
 }


### PR DESCRIPTION
and simplify the definition of kubernetes-agents by inheriting the base configuration from the 'basic' image.