### PR TITLE
[Build] Use Jenkins matrix to define setup combinations in smoke tests

### DIFF
--- a/JenkinsJobs/SmokeTests/StartSmokeTests.jenkinsfile
+++ b/JenkinsJobs/SmokeTests/StartSmokeTests.jenkinsfile
@@ -1,9 +1,4 @@
 
-def AGENT_OPENSUSE_LEAP = createKubernetesAgent('eclipse/platformreleng-opensuse-gtk3-metacity:15')
-def AGENT_CENTOS9 = createKubernetesAgent('eclipse/platformreleng-centos-gtk4-mutter:9')
-def AGENT_ARM64 = createLabeledAgent('arm64')
-def AGENT_PPCLE = createLabeledAgent('ppctest')
-
 pipeline {
 	options {
 		timeout(time: 300, unit: 'MINUTES')
@@ -34,57 +29,45 @@ spec:
 	}
 	stages {
 		stage('Trigger tests'){
-          parallel {
-              stage('Opensuse Leap Java17'){
-					steps { script {
-						runSmokeTest(AGENT_OPENSUSE_LEAP, 'opensuse_leap', 'linux', 'x86_64', '17')
-					} }
-              }
-              stage('Centos 9.x Java17'){
-					steps { script {
-						runSmokeTest(AGENT_CENTOS9, 'centos9', 'linux', 'x86_64', '17')
-					} }
-              }
-              stage('Centos 8 arm64 Java17'){
-					steps { script {
-						runSmokeTest(AGENT_ARM64, 'centos8_arm', 'linux', 'aarch64', '17')
-					} }
-              }
-              stage('Centos 8.x ppc64le Java17'){
-					steps { script {
-						runSmokeTest(AGENT_PPCLE, 'centos8_ppc', 'linux', 'ppc64le', '17')
-					} }
-              }
-			  stage('Opensuse Leap Java21'){
-					steps { script {
-						runSmokeTest(AGENT_OPENSUSE_LEAP, 'opensuse_leap', 'linux', 'x86_64', '21')
-					} }
-			  }
-			  stage('Centos 9.x Java21'){
-					steps { script {
-						runSmokeTest(AGENT_CENTOS9, 'centos9', 'linux', 'x86_64', '21')
-					} }
-			  }
-			  stage('Centos 8 arm64 Java21'){
-					steps { script {
-						runSmokeTest(AGENT_ARM64, 'centos8_arm', 'linux', 'aarch64', '21')
-					} }
-			  }
-			  stage('Opensuse Leap Java23'){
-					steps { script {
-						runSmokeTest(AGENT_OPENSUSE_LEAP, 'opensuse_leap', 'linux', 'x86_64', '23')
-					} }
-			  }
-			  stage('Centos 9.x Java23'){
-					steps { script {
-						runSmokeTest(AGENT_CENTOS9, 'centos9', 'linux', 'x86_64', '23')
-					} }
-			  }
-			  stage('Centos 8 arm64 Java23'){
-					steps { script {
-						runSmokeTest(AGENT_ARM64, 'centos8_arm', 'linux', 'aarch64', '23')
-					} }
-			  }
+			matrix {
+				axes {
+					axis {
+						name 'MACHINE'
+						values \
+						'opensuse_leap', \
+						'centos9', \
+						'centos8_arm', \
+						'centos8_ppc'
+					}
+					axis {
+						name 'JAVA_VERSION'
+						values '17', '21', '23'
+					}
+				}
+				stages {
+					stage('Create test setup') {
+						steps{
+							script {
+								def agentId = env.MACHINE
+								def os, arch, executorAgent;
+								if (agentId == 'opensuse_leap') {
+									os = 'linux'; arch = 'x86_64'
+									executorAgent = createKubernetesAgent('eclipse/platformreleng-opensuse-gtk3-metacity:15')
+								} else if (agentId == 'centos9') {
+									os = 'linux'; arch = 'x86_64'
+									executorAgent = createKubernetesAgent('eclipse/platformreleng-centos-gtk4-mutter:9')
+								} else if (agentId == 'centos8_arm') {
+									os = 'linux'; arch = 'aarch64'
+									executorAgent = createLabeledAgent('arm64')
+								} else if (agentId == 'centos8_ppc') {
+									os = 'linux'; arch = 'ppc64le'
+									executorAgent = createLabeledAgent('ppctest')
+								}
+								runSmokeTest(executorAgent, agentId, os, arch, env.JAVA_VERSION)
+							}
+						}
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This makes changes, e.g. using other java versions or adding a new platform simpler.
This also has the effect that ppc64le is now also tested with Java-21 and 23.