### PR TITLE
[Build] Further simplify and unify I/Y-build test job configurations

### DIFF
--- a/JenkinsJobs/AutomatedTests/I_unit_mac.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_mac.groovy
@@ -45,11 +45,6 @@ pipeline {
 echo " whoami:  $(whoami)"
 echo " uname -a: $(uname -a)"
 
-# unset commonly defined system variables, which we either do not need, or want to set ourselves.
-# (this is to improve consistency running on one machine versus another)
-echo "Unsetting variables: JAVA_BINDIR JAVA_ROOT JDK_HOME JRE_HOME CLASSPATH"
-unset -v JAVA_BINDIR JAVA_ROOT JDK_HOME JRE_HOME CLASSPATH
-
 # 0002 is often the default for shell users, but it is not when ran from
 # a cron job, so we set it explicitly, to be sure of value, so releng group has write access to anything
 # we create on shared area.

--- a/JenkinsJobs/AutomatedTests/I_unit_win32.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_win32.groovy
@@ -37,10 +37,6 @@ pipeline {
           steps {
               cleanWs() // workspace not cleaned by default
               bat \'\'\'
-@REM May want to try and restrict path, as we do on cron jobs, so we
-@REM have more consistent conditions.
-@REM export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:~/bin
-
 @REM tmp must already exist, for Java to make use of it, in subsequent steps
 @REM no -p (or /p) needed on Windows. It creates 
 mkdir tmp
@@ -65,7 +61,7 @@ java -XshowSettings -version 1>javaSettings.txt 2>&1
 
 ant -f getEBuilder.xml -DbuildId=%buildId%  -DeclipseStream=%STREAM% -DEBUILDER_HASH=%EBUILDER_HASH% ^
   -DdownloadURL="https://download.eclipse.org/eclipse/downloads/drops4/%buildId%" ^
-  -Dargs=all -Dosgi.os=win32 -Dosgi.ws=win32 -Dosgi.arch=x86_64 ^
+  -Dosgi.os=win32 -Dosgi.ws=win32 -Dosgi.arch=x86_64 ^
   -DtestSuite=all
 @REM For smaller test-suites see: https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/be721e33c916b03c342e7b6f334220c6124946f8/production/testScripts/configuration/sdk.tests/testScripts/test.xml#L1893-L1903
               \'\'\'

--- a/JenkinsJobs/YBuilds/Y_unit_mac.groovy
+++ b/JenkinsJobs/YBuilds/Y_unit_mac.groovy
@@ -44,11 +44,6 @@ pipeline {
 echo "whoami:  $(whoami)"
 echo "uname -a: $(uname -a)"
 
-# unset commonly defined system variables, which we either do not need, or want to set ourselves.
-# (this is to improve consistency running on one machine versus another)
-echo -e "Unsetting variables: JAVA_BINDIR JAVA_HOME JAVA_ROOT JDK_HOME JRE_HOME CLASSPATH ANT_HOME\\n"
-unset -v JAVA_BINDIR JAVA_HOME JAVA_ROOT JDK_HOME JRE_HOME CLASSPATH ANT_HOME
-
 # 0002 is often the default for shell users, but it is not when ran from
 # a cron job, so we set it explicitly, to be sure of value, so releng group has write access to anything
 # we create on shared area.

--- a/JenkinsJobs/YBuilds/Y_unit_win32.groovy
+++ b/JenkinsJobs/YBuilds/Y_unit_win32.groovy
@@ -35,10 +35,6 @@ pipeline {
           steps {
               cleanWs() // workspace not cleaned by default
               bat \'\'\'
-rem May want to try and restrict path, as we do on cron jobs, so we
-rem have more consistent conditions.
-rem export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:~/bin
-
 rem tmp must already exist, for Java to make use of it, in subsequent steps
 rem no -p (or /p) needed on Windows. It creates 
 mkdir tmp
@@ -67,7 +63,7 @@ java -XshowSettings -version 1>javaSettings.txt 2>&1
 ant -f getEBuilder.xml -DbuildId=%buildId% ^
   -DeclipseStream=%STREAM% -DEBUILDER_HASH=%EBUILDER_HASH% ^
   -DdownloadURL="https://download.eclipse.org/eclipse/downloads/drops4/%buildId%" ^
-  -Dargs=all -Dosgi.os=win32 -Dosgi.ws=win32 -Dosgi.arch=x86_64 ^
+  -Dosgi.os=win32 -Dosgi.ws=win32 -Dosgi.arch=x86_64 ^
   -DtestSuite=all
 \'\'\'
               archiveArtifacts '**/eclipse-testing/results/**, **/eclipse-testing/directorLogs/**, *.properties, *.txt'


### PR DESCRIPTION
- Simplify custom JDK download in I-builds on Linux with Java-23 by using the same approach like for Y-builds
- Remove unnecessary '-Dargs=all' property definition for Windows and unnecessary environment variable resets on Mac.