### PR TITLE
[Build] Double number of kept smoke test runs

### DIFF
--- a/JenkinsJobs/SmokeTests/StartSmokeTests.jenkinsfile
+++ b/JenkinsJobs/SmokeTests/StartSmokeTests.jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
 	options {
 		timeout(time: 300, unit: 'MINUTES')
 		timestamps()
-		buildDiscarder(logRotator(numToKeepStr:'5'))
+		buildDiscarder(logRotator(numToKeepStr:'10'))
 	}
 	agent {
 		kubernetes { // a lean basic agent is sufficient.


### PR DESCRIPTION
Smoke tests are launched by I-builds and Y-builds and their results are currently not stored elsewhere. Therefore we should keep 10 old runs instead of just five.