### PR TITLE
[Build] Deploy RelEng scripts in master branch build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
 				sh 'git submodule foreach "git fetch origin master; git checkout FETCH_HEAD"'
 			}
 		}
-		stage('Deploy eclipse-platform-parent pom and eclipse-sdk target') {
+		stage('Deploy parent-pom and SDK-target') {
 			when {
 				anyOf {
 					branch 'master'
@@ -29,6 +29,58 @@ pipeline {
 			steps {
 				sh 'mvn clean deploy -f eclipse-platform-parent/pom.xml'
 				sh 'mvn clean deploy -f eclipse.platform.releng.prereqs.sdk/pom.xml'
+			}
+		}
+		stage('Deploy RelEng scripts') {
+			when {
+				allOf {
+					branch 'master'
+					expression { // Only deploy scripts on actual changes in the deployed folders
+						return !sh(script:'''
+							latestCommitID=$(curl https://download.eclipse.org/eclipse/relengScripts/state)
+							git diff --name-only ${latestCommitID} HEAD \\
+								production/ scripts/ cje-production/ eclipse.platform.releng.tychoeclipsebuilder/
+							''', returnStdout: true).trim().isEmpty()
+					}
+				}
+			}
+			steps {
+				sshagent(['projects-storage.eclipse.org-bot-ssh']) {
+					sh '''
+						serverBase='/home/data/httpd/download.eclipse.org/eclipse'
+						serverStaging="${serverBase}/relengScripts-staging"
+						
+						ssh genie.platform@projects-storage.eclipse.org rm -rf ${serverStaging}
+						ssh genie.platform@projects-storage.eclipse.org mkdir -p ${serverStaging}
+						
+						scp -r production genie.platform@projects-storage.eclipse.org:${serverStaging}
+						scp -r scripts genie.platform@projects-storage.eclipse.org:${serverStaging}
+						scp -r cje-production genie.platform@projects-storage.eclipse.org:${serverStaging}
+						
+						pushd eclipse.platform.releng.tychoeclipsebuilder/eclipse
+						scp -r buildScripts genie.platform@projects-storage.eclipse.org:${serverStaging}
+						popd
+						
+						pushd eclipse.platform.releng.tychoeclipsebuilder
+						scp -r entitlement genie.platform@projects-storage.eclipse.org:${serverStaging}
+						popd
+						
+						# Create state file that contains the current commitID for later diffs in this stage's conditional
+						commitID=$(git rev-parse HEAD)
+						ssh genie.platform@projects-storage.eclipse.org "echo ${commitID}>${serverStaging}/state"
+						
+						#To minimize 'downtime', all files are first transfered to a staging folder on the server, 
+						# then the existing folder is moved to 'disposal' and the 'staging' to the desired target.
+						# Eventually the previously existing content is deleted with the 'disposal'-folder.
+						serverTarget="${serverBase}/relengScripts"
+						serverDisposal="${serverBase}/relengScripts-disposal"
+						
+						ssh genie.platform@projects-storage.eclipse.org "\
+							mv -f ${serverTarget} ${serverDisposal} ;\
+							mv -f ${serverStaging} ${serverTarget} &&\
+							rm -rf ${serverDisposal}"
+					'''
+				}
 			}
 		}
 		stage('Build') {


### PR DESCRIPTION
This ensures that releng scripts are always updated on the download-server as soon as they change in the git repository. Furthermore this avoids the need for the separate Jenkins job to deploy the scripts, thus making
https://ci.eclipse.org/releng/job/Publish_shell_scripts_for_releng_jobs/ obsolete (can be deleted once this is submitted).