### PR TITLE
[Build] Define all smoke-test parameters in job definition again

### DIFF
--- a/JenkinsJobs/SmokeTests/FOLDER.groovy
+++ b/JenkinsJobs/SmokeTests/FOLDER.groovy
@@ -5,6 +5,22 @@ folder('SmokeTests') {
 
 pipelineJob('SmokeTests/Start-smoke-tests'){
 	description('Start all smoke tests for the Eclipse SDK')
+	// Define parameters in job configuration to make them already available in the very first build
+	parameters {
+		stringParam {
+			name('buildId')
+			description('Build Id to test (such as I20240611-1800, N20120716-0800).')
+			trim(true)
+		}
+	}
+	parameters {
+		stringParam {
+			name('testsToRun')
+			defaultValue('ui')
+			description('This can be any ant target from https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/master/production/testScripts/configuration/sdk.tests/testScripts/test.xml')
+			trim(true)
+		}
+	}
 	definition {
 		cpsScm {
 			lightweight(true)

--- a/JenkinsJobs/SmokeTests/StartSmokeTests.jenkinsfile
+++ b/JenkinsJobs/SmokeTests/StartSmokeTests.jenkinsfile
@@ -23,10 +23,6 @@ spec:
 '''
 		}
 	}
-	parameters {
-		string(name: 'buildId', description: 'Build Id to test (such as I20240611-1800, N20120716-0800).')
-		string(name: 'testsToRun', defaultValue: 'ui', description: 'This can be any ant target from https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/master/production/testScripts/configuration/sdk.tests/testScripts/test.xml')
-	}
 	stages {
 		stage('Trigger tests'){
 			matrix {


### PR DESCRIPTION
Defining them only in the pipeline has the effect that the jobs forgets it's parameter each time the job-configuration is recreated by the seed-job and thus the subsequent first execution of the smoke-test fails because it has 'forgotten' it's parameters and has to re-discover them on the first pipeline execution again.

Follow-up on
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2637