### PR TITLE
Fix Objects inside Icons

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/META-INF/MANIFEST.MF
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.doc.user; singleton:=true
-Bundle-Version: 3.15.2400.qualifier
+Bundle-Version: 3.15.2500.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.2.0,4.0.0)"

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.ui.editors/etool16/next_nav.svg
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.ui.editors/etool16/next_nav.svg
@@ -1,36 +1,285 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16">
-  <defs>
-    <linearGradient id="d">
-      <stop offset="0" stop-color="#8593ae"/>
-      <stop offset="1" stop-color="#979ea3"/>
-    </linearGradient>
-    <linearGradient id="c">
-      <stop offset="0" stop-color="#286296"/>
-      <stop offset="1" stop-color="#778cb4"/>
-    </linearGradient>
-    <linearGradient id="e">
-      <stop offset="0" stop-color="#bcb489"/>
-      <stop offset="1" stop-color="#798da2"/>
-    </linearGradient>
-    <linearGradient id="b">
-      <stop offset="0" stop-color="#ba7f0d"/>
-      <stop offset="1" stop-color="#a2660b"/>
-    </linearGradient>
-    <linearGradient id="a">
-      <stop offset="0" stop-color="#ffe"/>
-      <stop offset="1" stop-color="#fbdd83"/>
-    </linearGradient>
-    <linearGradient xlink:href="#a" id="g" x1="5.13" x2="13.428" y1="1043.898" y2="1043.898" gradientTransform="translate(.24 .432)" gradientUnits="userSpaceOnUse"/>
-    <linearGradient xlink:href="#b" id="h" x1="5.206" x2="16.247" y1="1044.488" y2="1044.488" gradientTransform="translate(.24 .432)" gradientUnits="userSpaceOnUse"/>
-    <linearGradient xlink:href="#c" id="i" x1="-2.586" x2="-1.767" y1="1045.108" y2="1045.108" gradientTransform="matrix(1.22093 0 0 1.131 1052.732 -1175.004)" gradientUnits="userSpaceOnUse"/>
-    <linearGradient xlink:href="#d" id="j" x1="-1052.575" x2="-1048.575" y1="4.504" y2="4.504" gradientUnits="userSpaceOnUse"/>
-    <linearGradient xlink:href="#e" id="f" x1="3.004" x2="3.004" y1="1039.575" y2="1052.575" gradientTransform="translate(14)" gradientUnits="userSpaceOnUse"/>
-  </defs>
-  <path fill="none" stroke="url(#f)" stroke-miterlimit="3.7" d="m 16.503522,1039.5747 0,13" transform="translate(-2.004 -1036.575)"/>
-  <path fill="#c1c6d9" d="M-15.004-1040.575H-11.004V-1039.575H-15.004z" color="#000" overflow="visible" style="marker:none" transform="rotate(180 -1.002 -518.287)"/>
-  <path fill="url(#g)" stroke="url(#h)" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.536" d="m 10.972,1038.0801 2.9e-5,3.072 -8.0132497,0 c -0.6678671,0 -1.2187793,0.109 -1.2187793,0.7769 l 0,4.1465 c 0,0.6678 0.6714571,1.2208 1.3393242,1.2206 l 7.8919678,0 0,3.072 1.001472,0 6.663168,-6.0539 -6.663932,-6.2341 z" transform="matrix(0 .65104 .65104 0 -674.333 -.633)"/>
-  <path fill="url(#i)" d="M1049.575 6.004H1051.575V9.011H1049.575z" transform="matrix(0 1 1 0 -2.004 -1036.575)"/>
-  <path fill="#c1c6d9" d="M-15.004-1042.575H-13.004V-1041.575H-15.004zM-15.004-1044.575H-13.004V-1043.575H-15.004zM-15.004-1048.575H-13.004V-1047.575H-15.004zM-12.004-1048.575H-10.004V-1047.575H-12.004zM-15.004-1050.575H-10.004V-1049.575H-15.004zM-15.004-1046.575H-12.004V-1045.575H-15.004z" color="#000" overflow="visible" style="marker:none" transform="rotate(180 -1.002 -518.287)"/>
-  <path fill="url(#j)" d="M-1052.575 4.004H-1048.575V5.004H-1052.575z" color="#000" overflow="visible" style="marker:none" transform="rotate(-90 -519.29 -517.286)"/>
-  <path fill="none" d="M5.004 1039.575H17.004V1052.575H5.004z" opacity=".157" transform="translate(-2.004 -1036.575)"/>
-</svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   sodipodi:docname="next_nav.svg"
+   xml:space="preserve"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><defs
+     id="defs4"><linearGradient
+       id="linearGradient7038"><stop
+         id="stop7040"
+         offset="0"
+         style="stop-color:#bcb489;stop-opacity:1" /><stop
+         id="stop7042"
+         offset="1"
+         style="stop-color:#798da2;stop-opacity:1" /></linearGradient><linearGradient
+       inkscape:collect="always"
+       id="linearGradient4403"><stop
+         style="stop-color:#8593ae;stop-opacity:1"
+         offset="0"
+         id="stop4405" /><stop
+         style="stop-color:#979ea3;stop-opacity:1"
+         offset="1"
+         id="stop4407" /></linearGradient><linearGradient
+       id="linearGradient4081"><stop
+         style="stop-color:#286296;stop-opacity:1"
+         offset="0"
+         id="stop4083" /><stop
+         style="stop-color:#778cb4;stop-opacity:1"
+         offset="1"
+         id="stop4085" /></linearGradient><linearGradient
+       id="linearGradient4972-6"><stop
+         style="stop-color:#c7e3e7;stop-opacity:1;"
+         offset="0"
+         id="stop4974-71" /><stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-5" /></linearGradient><linearGradient
+       id="linearGradient4972-4-1-2"><stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-4" /><stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-6" /></linearGradient><linearGradient
+       id="linearGradient6799-4-3-3"><stop
+         style="stop-color:#bcb489;stop-opacity:1"
+         offset="0"
+         id="stop6801-4-0-8" /><stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-5-7-9" /></linearGradient><linearGradient
+       id="linearGradient4972-5-7"><stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-4" /><stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-3" /></linearGradient><linearGradient
+       id="linearGradient4972-5-2-6"><stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-3-0" /><stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-9-5" /></linearGradient><linearGradient
+       id="linearGradient4741"
+       inkscape:collect="always"><stop
+         id="stop4743"
+         offset="0"
+         style="stop-color:#ba7f0d;stop-opacity:1" /><stop
+         id="stop4745"
+         offset="1"
+         style="stop-color:#a2660b;stop-opacity:1" /></linearGradient><linearGradient
+       id="linearGradient4749"
+       inkscape:collect="always"><stop
+         id="stop4751"
+         offset="0"
+         style="stop-color:#ffffee;stop-opacity:1" /><stop
+         id="stop4753"
+         offset="1"
+         style="stop-color:#fbdd83;stop-opacity:1" /></linearGradient><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient5232"
+       gradientUnits="userSpaceOnUse"
+       x1="5.1299052"
+       y1="1043.8982"
+       x2="13.428"
+       y2="1043.8982"
+       gradientTransform="matrix(0,0.65104166,0.65104166,0,-672.04862,1036.0982)" /><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient5234"
+       gradientUnits="userSpaceOnUse"
+       x1="5.2061925"
+       y1="1044.488"
+       x2="16.2465"
+       y2="1044.488"
+       gradientTransform="matrix(0,0.65104166,0.65104166,0,-672.04862,1036.0982)" /><linearGradient
+       id="linearGradient4972-5-7-2"><stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-4-9" /><stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-3-7" /></linearGradient><linearGradient
+       id="linearGradient4972-6-5"><stop
+         style="stop-color:#c7e3e7;stop-opacity:1;"
+         offset="0"
+         id="stop4974-71-9" /><stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-5-1" /></linearGradient><linearGradient
+       id="linearGradient4972-4-1-2-8"><stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-4-3" /><stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-6-9" /></linearGradient><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4081"
+       id="linearGradient4087"
+       x1="-2.5863335"
+       y1="1045.1082"
+       x2="-1.7672856"
+       y2="1045.1082"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2209298,0,0,1.1309974,1052.7324,-1175.0041)" /><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4403"
+       id="linearGradient4409"
+       x1="-1052.5747"
+       y1="4.5035412"
+       x2="-1048.5747"
+       y2="4.5035412"
+       gradientUnits="userSpaceOnUse" /><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6799-4-3-3"
+       id="linearGradient7050"
+       x1="3.0035219"
+       y1="1039.5747"
+       x2="3.0035219"
+       y2="1052.5747"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(14,-7.73625e-5)" /></defs><sodipodi:namedview
+     id="base"
+     pagecolor="#efefef"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="30.375011"
+     inkscape:cx="4.8395045"
+     inkscape:cy="10.600819"
+     inkscape:document-units="px"
+     inkscape:current-layer="g5253-5"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     showguides="false"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"><inkscape:grid
+       type="xygrid"
+       id="grid4250"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" /></sodipodi:namedview><metadata
+     id="metadata7"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)"><g
+       id="g5542"
+       transform="translate(-0.94286168,0.40625002)"><g
+         transform="translate(-1.0606602,-0.61871837)"
+         id="g5253-5"
+         style="display:inline"><path
+           style="opacity:1;fill:none;fill-opacity:0.52156863;stroke:url(#linearGradient7050);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:3.70000005;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 16.503522,1039.5747 0,13"
+           id="rect7028"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" /><rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2"
+           width="4"
+           height="1.0000386"
+           x="-15.003522"
+           y="-1040.5747"
+           transform="scale(-1,-1)" /><g
+           id="g1"><path
+             sodipodi:nodetypes="ccsssscccccc"
+             inkscape:connector-curvature="0"
+             id="rect3968"
+             d="m 3.5035215,1043.0851 h 2 v -4.2167 c 0,-0.4348 0.070964,-0.7937 0.5057943,-0.7937 H 8.70886 c 0.4347656,0 0.7946615,0.4374 0.7946615,0.8722 v 4.1378 h 1.9999995 v 0.652 l -3.9413407,4.338 -4.0586588,-4.3385 z"
+             style="fill:url(#linearGradient5232);fill-opacity:1;stroke:url(#linearGradient5234);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             inkscape:label="rect3968" /></g><rect
+           transform="matrix(0,1,1,0,0,0)"
+           style="fill:url(#linearGradient4087);fill-opacity:1;stroke:none"
+           id="rect6999"
+           width="1.9999614"
+           height="3.006958"
+           x="1049.5747"
+           y="6.0035219" /><rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5"
+           width="2"
+           height="1.0000386"
+           x="-15.003522"
+           y="-1042.5747"
+           transform="scale(-1,-1)" /><rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5-9"
+           width="2"
+           height="1.0000386"
+           x="-15.003522"
+           y="-1044.5747"
+           transform="scale(-1,-1)" /><rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5-9-5"
+           width="2"
+           height="1.0000386"
+           x="-15.003522"
+           y="-1048.5747"
+           transform="scale(-1,-1)" /><rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5-9-0"
+           width="2"
+           height="1.0000386"
+           x="-12.003522"
+           y="-1048.5747"
+           transform="scale(-1,-1)" /><rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-51"
+           width="5"
+           height="1.0000386"
+           x="-15.003522"
+           y="-1050.5747"
+           transform="scale(-1,-1)" /><rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-3"
+           width="3"
+           height="1.0000386"
+           x="-15.003522"
+           y="-1046.5747"
+           transform="scale(-1,-1)" /><rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4409);fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-51-3"
+           width="4.0000386"
+           height="1.0000386"
+           x="-1052.5747"
+           y="4.0035219"
+           transform="matrix(0,-1,1,0,0,0)" /><rect
+           style="opacity:0.15700001;fill:none;fill-opacity:0.52156863;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:3.70000005;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect7026"
+           width="12"
+           height="13"
+           x="5.0035219"
+           y="1039.5747" /></g></g></g></svg>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.ui.editors/etool16/prev_nav.svg
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.ui.editors/etool16/prev_nav.svg
@@ -1,35 +1,362 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16">
-  <defs>
-    <linearGradient id="d">
-      <stop offset="0" stop-color="#bfb688"/>
-      <stop offset="1" stop-color="#b5b08f"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   sodipodi:docname="prev_nav.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4403">
+      <stop
+         style="stop-color:#bfb688;stop-opacity:1"
+         offset="0"
+         id="stop4405" />
+      <stop
+         style="stop-color:#b5b08f;stop-opacity:1"
+         offset="1"
+         id="stop4407" />
     </linearGradient>
-    <linearGradient id="c">
-      <stop offset="0" stop-color="#286296"/>
-      <stop offset="1" stop-color="#778cb4"/>
+    <linearGradient
+       id="linearGradient4081">
+      <stop
+         style="stop-color:#286296;stop-opacity:1"
+         offset="0"
+         id="stop4083" />
+      <stop
+         style="stop-color:#778cb4;stop-opacity:1"
+         offset="1"
+         id="stop4085" />
     </linearGradient>
-    <linearGradient id="e">
-      <stop offset="0" stop-color="#bcb489"/>
-      <stop offset="1" stop-color="#798da2"/>
+    <linearGradient
+       id="linearGradient4972-6">
+      <stop
+         style="stop-color:#c7e3e7;stop-opacity:1;"
+         offset="0"
+         id="stop4974-71" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-5" />
     </linearGradient>
-    <linearGradient id="b">
-      <stop offset="0" stop-color="#ba7f0d"/>
-      <stop offset="1" stop-color="#a2660b"/>
+    <linearGradient
+       id="linearGradient4972-4-1-2">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-6" />
     </linearGradient>
-    <linearGradient id="a">
-      <stop offset="0" stop-color="#ffe"/>
-      <stop offset="1" stop-color="#fbdd83"/>
+    <linearGradient
+       id="linearGradient6799-4-3-3">
+      <stop
+         style="stop-color:#bcb489;stop-opacity:1"
+         offset="0"
+         id="stop6801-4-0-8" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-5-7-9" />
     </linearGradient>
-    <linearGradient xlink:href="#a" id="g" x1="5.13" x2="13.428" y1="1043.898" y2="1043.898" gradientTransform="translate(.24 .432)" gradientUnits="userSpaceOnUse"/>
-    <linearGradient xlink:href="#b" id="h" x1="5.206" x2="16.247" y1="1044.488" y2="1044.488" gradientTransform="translate(.24 .432)" gradientUnits="userSpaceOnUse"/>
-    <linearGradient xlink:href="#c" id="i" x1="-2.586" x2="-1.767" y1="1045.108" y2="1045.108" gradientTransform="matrix(1.22093 0 0 1.131 -1036.417 -1175.004)" gradientUnits="userSpaceOnUse"/>
-    <linearGradient xlink:href="#d" id="j" x1="-1052.575" x2="-1048.575" y1="4.504" y2="4.504" gradientTransform="matrix(1.24937 0 0 1 2351.63 0)" gradientUnits="userSpaceOnUse"/>
-    <linearGradient xlink:href="#e" id="f" x1="3.004" x2="3.004" y1="1039.575" y2="1052.575" gradientTransform="translate(14 -3)" gradientUnits="userSpaceOnUse"/>
+    <linearGradient
+       id="linearGradient4972-5-7">
+      <stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-5-2-6">
+      <stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-3-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-9-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4741"
+       inkscape:collect="always">
+      <stop
+         id="stop4743"
+         offset="0"
+         style="stop-color:#ba7f0d;stop-opacity:1" />
+      <stop
+         id="stop4745"
+         offset="1"
+         style="stop-color:#a2660b;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4749"
+       inkscape:collect="always">
+      <stop
+         id="stop4751"
+         offset="0"
+         style="stop-color:#ffffee;stop-opacity:1" />
+      <stop
+         id="stop4753"
+         offset="1"
+         style="stop-color:#fbdd83;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient5232"
+       gradientUnits="userSpaceOnUse"
+       x1="5.1299052"
+       y1="1043.8982"
+       x2="13.428"
+       y2="1043.8982"
+       gradientTransform="matrix(0,-0.65104166,0.65104166,0,-674.05214,1052.8412)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient5234"
+       gradientUnits="userSpaceOnUse"
+       x1="5.2061925"
+       y1="1044.488"
+       x2="16.2465"
+       y2="1044.488"
+       gradientTransform="matrix(0,-0.65104166,0.65104166,0,-674.05214,1052.8412)" />
+    <linearGradient
+       id="linearGradient4972-5-7-2">
+      <stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-4-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-3-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-6-5">
+      <stop
+         style="stop-color:#c7e3e7;stop-opacity:1;"
+         offset="0"
+         id="stop4974-71-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-5-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-4-1-2-8">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-4-3" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-6-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4081"
+       id="linearGradient4087"
+       x1="-2.5863335"
+       y1="1045.1082"
+       x2="-1.7672856"
+       y2="1045.1082"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2209298,0,0,1.1309974,-1036.2046,-1177.0077)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4403"
+       id="linearGradient4409"
+       x1="-1052.5747"
+       y1="4.5035412"
+       x2="-1048.5747"
+       y2="4.5035412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2493679,0,0,1,2352.4176,-2.003522)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6799-4-3-3"
+       id="linearGradient7050"
+       x1="3.0035219"
+       y1="1039.5747"
+       x2="3.0035219"
+       y2="1052.5747"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(11.99648,-2.2126746)" />
   </defs>
-  <path fill="none" stroke="url(#f)" stroke-miterlimit="3.7" d="m 16.503522,1036.5747 0,13" transform="translate(-2.004 -1036.575)"/>
-  <path fill="#c1c6d9" d="M-15.004 1048.577H-11.004V1049.577H-15.004z" color="#000" overflow="visible" style="marker:none" transform="matrix(-1 0 0 1 -2.004 -1036.575)"/>
-  <path fill="url(#g)" stroke="url(#h)" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.536" d="m 10.965858,1038.0801 -0.01228,3.072 -7.9948822,0 c -0.6678671,0 -1.2186918,0.109 -1.2186918,0.7769 l 0,4.1465 c 0,0.6678 0.6706328,1.2208 1.3384998,1.2206 l 7.8812162,0 0,3.072 1.012224,0 6.667776,-6.144 -6.667716,-6.144 z" transform="rotate(-90 -328.848 345.484) scale(.65104)"/>
-  <path fill="url(#i)" d="M-1039.575 6.004H-1037.575V9.011H-1039.575z" transform="rotate(-90 -519.29 -517.286)"/>
-  <path fill="#c1c6d9" d="M-15.004 1046.577H-13.004V1047.577H-15.004zM-15.004 1044.577H-13.004V1045.577H-15.004zM-15.004 1040.577H-13.004V1041.577H-15.004zM-12.004 1040.577H-10.004V1041.577H-12.004zM-15.004 1038.577H-10.004V1039.577H-15.004zM-15.004 1042.577H-12.004V1043.577H-15.004z" color="#000" overflow="visible" style="marker:none" transform="matrix(-1 0 0 1 -2.004 -1036.575)"/>
-  <path fill="url(#j)" d="M1036.577 4.004H1041.575V5.004H1036.577z" color="#000" overflow="visible" style="marker:none" transform="matrix(0 1 1 0 -2.004 -1036.575)"/>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#f3f3f3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="35.96875"
+     inkscape:cx="8.0069505"
+     inkscape:cy="8.0069505"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1392"
+     inkscape:window-height="1027"
+     inkscape:window-x="231"
+     inkscape:window-y="34"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4250"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g3"
+       inkscape:label="document">
+      <g
+         id="g2"
+         inkscape:label="border">
+        <path
+           style="display:inline;fill:none;fill-opacity:0.521569;stroke:url(#linearGradient7050);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:3.7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 14.5,1037.3622 v 13"
+           id="rect7028"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc"
+           inkscape:label="rect7028" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4409);fill-opacity:1;stroke:none;stroke-width:0.694276;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-51-3"
+           width="4.99752"
+           height="1.0000386"
+           x="1037.3645"
+           y="2"
+           transform="matrix(0,1,1,0,0,0)"
+           inkscape:label="rect6891-5-7-31-2-51-3" />
+      </g>
+      <g
+         id="g1"
+         inkscape:label="lines">
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.694276;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2"
+           width="4"
+           height="1.0000386"
+           x="-13"
+           y="1048.3622"
+           transform="scale(-1,1)"
+           inkscape:label="rect6891-5-7-31-2" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.694276;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5"
+           width="2"
+           height="1.0000386"
+           x="-13"
+           y="1046.3622"
+           transform="scale(-1,1)" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.694276;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5-9"
+           width="2"
+           height="1.0000386"
+           x="-13"
+           y="1044.3622"
+           transform="scale(-1,1)" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.694276;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5-9-5"
+           width="2"
+           height="1.0000386"
+           x="-13"
+           y="1040.3622"
+           transform="scale(-1,1)" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.694276;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5-9-0"
+           width="2"
+           height="1.0000386"
+           x="-10"
+           y="1040.3622"
+           transform="scale(-1,1)" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:3.7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-51"
+           width="5"
+           height="1.0000386"
+           x="-13"
+           y="1038.3622"
+           transform="scale(-1,1)" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.694276;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-3"
+           width="3"
+           height="1.0000386"
+           x="-13"
+           y="1042.3622"
+           transform="scale(-1,1)" />
+        <rect
+           transform="rotate(-90)"
+           style="display:inline;fill:url(#linearGradient4087);fill-opacity:1;stroke:none"
+           id="rect6999"
+           width="1.9999614"
+           height="3.006958"
+           x="-1039.3622"
+           y="3.9999993"
+           inkscape:label="rect6999" />
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="ccsssscccccc"
+       inkscape:connector-curvature="0"
+       id="rect3968"
+       d="m 1.4999996,1045.8583 2,0.01 v 5.205 c 0,0.4348 0.070964,0.7934 0.5057943,0.7934 h 2.6995442 c 0.4347656,0 0.7947917,-0.4366 0.7946615,-0.8714 v -5.131 h 1.9999997 v -0.659 l -3.9999997,-4.341 -4,4.3409 z"
+       style="fill:url(#linearGradient5232);fill-opacity:1;stroke:url(#linearGradient5234);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:label="arrow" />
+  </g>
 </svg>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/pom.xml
@@ -19,6 +19,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.doc.user</artifactId>
-  <version>3.15.2400-SNAPSHOT</version>
+  <version>3.15.2500-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/images/next_nav.svg
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/images/next_nav.svg
@@ -1,36 +1,285 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16">
-  <defs>
-    <linearGradient id="d">
-      <stop offset="0" stop-color="#8593ae"/>
-      <stop offset="1" stop-color="#979ea3"/>
-    </linearGradient>
-    <linearGradient id="c">
-      <stop offset="0" stop-color="#286296"/>
-      <stop offset="1" stop-color="#778cb4"/>
-    </linearGradient>
-    <linearGradient id="e">
-      <stop offset="0" stop-color="#bcb489"/>
-      <stop offset="1" stop-color="#798da2"/>
-    </linearGradient>
-    <linearGradient id="b">
-      <stop offset="0" stop-color="#ba7f0d"/>
-      <stop offset="1" stop-color="#a2660b"/>
-    </linearGradient>
-    <linearGradient id="a">
-      <stop offset="0" stop-color="#ffe"/>
-      <stop offset="1" stop-color="#fbdd83"/>
-    </linearGradient>
-    <linearGradient xlink:href="#a" id="g" x1="5.13" x2="13.428" y1="1043.898" y2="1043.898" gradientTransform="translate(.24 .432)" gradientUnits="userSpaceOnUse"/>
-    <linearGradient xlink:href="#b" id="h" x1="5.206" x2="16.247" y1="1044.488" y2="1044.488" gradientTransform="translate(.24 .432)" gradientUnits="userSpaceOnUse"/>
-    <linearGradient xlink:href="#c" id="i" x1="-2.586" x2="-1.767" y1="1045.108" y2="1045.108" gradientTransform="matrix(1.22093 0 0 1.131 1052.732 -1175.004)" gradientUnits="userSpaceOnUse"/>
-    <linearGradient xlink:href="#d" id="j" x1="-1052.575" x2="-1048.575" y1="4.504" y2="4.504" gradientUnits="userSpaceOnUse"/>
-    <linearGradient xlink:href="#e" id="f" x1="3.004" x2="3.004" y1="1039.575" y2="1052.575" gradientTransform="translate(14)" gradientUnits="userSpaceOnUse"/>
-  </defs>
-  <path fill="none" stroke="url(#f)" stroke-miterlimit="3.7" d="M16.504 1039.575v13" transform="translate(-2.004 -1036.575)"/>
-  <path fill="#c1c6d9" d="M-15.004-1040.575h4v1h-4z" color="#000" overflow="visible" style="marker:none" transform="rotate(180 -1.002 -518.287)"/>
-  <path fill="url(#g)" stroke="url(#h)" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.536" d="M10.972 1038.08v3.072H2.959c-.668 0-1.219.11-1.219.777v4.146c0 .668.671 1.221 1.34 1.221h7.891v3.072h1.002l6.663-6.054-6.664-6.234z" transform="matrix(0 .65104 .65104 0 -674.333 -.633)"/>
-  <path fill="url(#i)" d="M1049.575 6.004h2v3.007h-2z" transform="matrix(0 1 1 0 -2.004 -1036.575)"/>
-  <path fill="#c1c6d9" d="M-15.004-1042.575h2v1h-2zM-15.004-1044.575h2v1h-2zM-15.004-1048.575h2v1h-2zM-12.004-1048.575h2v1h-2zM-15.004-1050.575h5v1h-5zM-15.004-1046.575h3v1h-3z" color="#000" overflow="visible" style="marker:none" transform="rotate(180 -1.002 -518.287)"/>
-  <path fill="url(#j)" d="M-1052.575 4.004h4v1h-4z" color="#000" overflow="visible" style="marker:none" transform="rotate(-90 -519.29 -517.286)"/>
-  <path fill="none" d="M3 3h12v13H3z" opacity=".157"/>
-</svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   sodipodi:docname="next_nav.svg"
+   xml:space="preserve"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><defs
+     id="defs4"><linearGradient
+       id="linearGradient7038"><stop
+         id="stop7040"
+         offset="0"
+         style="stop-color:#bcb489;stop-opacity:1" /><stop
+         id="stop7042"
+         offset="1"
+         style="stop-color:#798da2;stop-opacity:1" /></linearGradient><linearGradient
+       inkscape:collect="always"
+       id="linearGradient4403"><stop
+         style="stop-color:#8593ae;stop-opacity:1"
+         offset="0"
+         id="stop4405" /><stop
+         style="stop-color:#979ea3;stop-opacity:1"
+         offset="1"
+         id="stop4407" /></linearGradient><linearGradient
+       id="linearGradient4081"><stop
+         style="stop-color:#286296;stop-opacity:1"
+         offset="0"
+         id="stop4083" /><stop
+         style="stop-color:#778cb4;stop-opacity:1"
+         offset="1"
+         id="stop4085" /></linearGradient><linearGradient
+       id="linearGradient4972-6"><stop
+         style="stop-color:#c7e3e7;stop-opacity:1;"
+         offset="0"
+         id="stop4974-71" /><stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-5" /></linearGradient><linearGradient
+       id="linearGradient4972-4-1-2"><stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-4" /><stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-6" /></linearGradient><linearGradient
+       id="linearGradient6799-4-3-3"><stop
+         style="stop-color:#bcb489;stop-opacity:1"
+         offset="0"
+         id="stop6801-4-0-8" /><stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-5-7-9" /></linearGradient><linearGradient
+       id="linearGradient4972-5-7"><stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-4" /><stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-3" /></linearGradient><linearGradient
+       id="linearGradient4972-5-2-6"><stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-3-0" /><stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-9-5" /></linearGradient><linearGradient
+       id="linearGradient4741"
+       inkscape:collect="always"><stop
+         id="stop4743"
+         offset="0"
+         style="stop-color:#ba7f0d;stop-opacity:1" /><stop
+         id="stop4745"
+         offset="1"
+         style="stop-color:#a2660b;stop-opacity:1" /></linearGradient><linearGradient
+       id="linearGradient4749"
+       inkscape:collect="always"><stop
+         id="stop4751"
+         offset="0"
+         style="stop-color:#ffffee;stop-opacity:1" /><stop
+         id="stop4753"
+         offset="1"
+         style="stop-color:#fbdd83;stop-opacity:1" /></linearGradient><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient5232"
+       gradientUnits="userSpaceOnUse"
+       x1="5.1299052"
+       y1="1043.8982"
+       x2="13.428"
+       y2="1043.8982"
+       gradientTransform="matrix(0,0.65104166,0.65104166,0,-672.04862,1036.0982)" /><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient5234"
+       gradientUnits="userSpaceOnUse"
+       x1="5.2061925"
+       y1="1044.488"
+       x2="16.2465"
+       y2="1044.488"
+       gradientTransform="matrix(0,0.65104166,0.65104166,0,-672.04862,1036.0982)" /><linearGradient
+       id="linearGradient4972-5-7-2"><stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-4-9" /><stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-3-7" /></linearGradient><linearGradient
+       id="linearGradient4972-6-5"><stop
+         style="stop-color:#c7e3e7;stop-opacity:1;"
+         offset="0"
+         id="stop4974-71-9" /><stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-5-1" /></linearGradient><linearGradient
+       id="linearGradient4972-4-1-2-8"><stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-4-3" /><stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-6-9" /></linearGradient><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4081"
+       id="linearGradient4087"
+       x1="-2.5863335"
+       y1="1045.1082"
+       x2="-1.7672856"
+       y2="1045.1082"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2209298,0,0,1.1309974,1052.7324,-1175.0041)" /><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4403"
+       id="linearGradient4409"
+       x1="-1052.5747"
+       y1="4.5035412"
+       x2="-1048.5747"
+       y2="4.5035412"
+       gradientUnits="userSpaceOnUse" /><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6799-4-3-3"
+       id="linearGradient7050"
+       x1="3.0035219"
+       y1="1039.5747"
+       x2="3.0035219"
+       y2="1052.5747"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(14,-7.73625e-5)" /></defs><sodipodi:namedview
+     id="base"
+     pagecolor="#efefef"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="30.375011"
+     inkscape:cx="4.8395045"
+     inkscape:cy="10.600819"
+     inkscape:document-units="px"
+     inkscape:current-layer="g5253-5"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     showguides="false"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"><inkscape:grid
+       type="xygrid"
+       id="grid4250"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" /></sodipodi:namedview><metadata
+     id="metadata7"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)"><g
+       id="g5542"
+       transform="translate(-0.94286168,0.40625002)"><g
+         transform="translate(-1.0606602,-0.61871837)"
+         id="g5253-5"
+         style="display:inline"><path
+           style="opacity:1;fill:none;fill-opacity:0.52156863;stroke:url(#linearGradient7050);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:3.70000005;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 16.503522,1039.5747 0,13"
+           id="rect7028"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" /><rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2"
+           width="4"
+           height="1.0000386"
+           x="-15.003522"
+           y="-1040.5747"
+           transform="scale(-1,-1)" /><g
+           id="g1"><path
+             sodipodi:nodetypes="ccsssscccccc"
+             inkscape:connector-curvature="0"
+             id="rect3968"
+             d="m 3.5035215,1043.0851 h 2 v -4.2167 c 0,-0.4348 0.070964,-0.7937 0.5057943,-0.7937 H 8.70886 c 0.4347656,0 0.7946615,0.4374 0.7946615,0.8722 v 4.1378 h 1.9999995 v 0.652 l -3.9413407,4.338 -4.0586588,-4.3385 z"
+             style="fill:url(#linearGradient5232);fill-opacity:1;stroke:url(#linearGradient5234);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             inkscape:label="rect3968" /></g><rect
+           transform="matrix(0,1,1,0,0,0)"
+           style="fill:url(#linearGradient4087);fill-opacity:1;stroke:none"
+           id="rect6999"
+           width="1.9999614"
+           height="3.006958"
+           x="1049.5747"
+           y="6.0035219" /><rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5"
+           width="2"
+           height="1.0000386"
+           x="-15.003522"
+           y="-1042.5747"
+           transform="scale(-1,-1)" /><rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5-9"
+           width="2"
+           height="1.0000386"
+           x="-15.003522"
+           y="-1044.5747"
+           transform="scale(-1,-1)" /><rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5-9-5"
+           width="2"
+           height="1.0000386"
+           x="-15.003522"
+           y="-1048.5747"
+           transform="scale(-1,-1)" /><rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5-9-0"
+           width="2"
+           height="1.0000386"
+           x="-12.003522"
+           y="-1048.5747"
+           transform="scale(-1,-1)" /><rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-51"
+           width="5"
+           height="1.0000386"
+           x="-15.003522"
+           y="-1050.5747"
+           transform="scale(-1,-1)" /><rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-3"
+           width="3"
+           height="1.0000386"
+           x="-15.003522"
+           y="-1046.5747"
+           transform="scale(-1,-1)" /><rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4409);fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-51-3"
+           width="4.0000386"
+           height="1.0000386"
+           x="-1052.5747"
+           y="4.0035219"
+           transform="matrix(0,-1,1,0,0,0)" /><rect
+           style="opacity:0.15700001;fill:none;fill-opacity:0.52156863;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:3.70000005;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect7026"
+           width="12"
+           height="13"
+           x="5.0035219"
+           y="1039.5747" /></g></g></g></svg>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/images/prev_nav.svg
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/images/prev_nav.svg
@@ -1,35 +1,362 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16">
-  <defs>
-    <linearGradient id="d">
-      <stop offset="0" stop-color="#bfb688"/>
-      <stop offset="1" stop-color="#b5b08f"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   sodipodi:docname="prev_nav.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4403">
+      <stop
+         style="stop-color:#bfb688;stop-opacity:1"
+         offset="0"
+         id="stop4405" />
+      <stop
+         style="stop-color:#b5b08f;stop-opacity:1"
+         offset="1"
+         id="stop4407" />
     </linearGradient>
-    <linearGradient id="c">
-      <stop offset="0" stop-color="#286296"/>
-      <stop offset="1" stop-color="#778cb4"/>
+    <linearGradient
+       id="linearGradient4081">
+      <stop
+         style="stop-color:#286296;stop-opacity:1"
+         offset="0"
+         id="stop4083" />
+      <stop
+         style="stop-color:#778cb4;stop-opacity:1"
+         offset="1"
+         id="stop4085" />
     </linearGradient>
-    <linearGradient id="e">
-      <stop offset="0" stop-color="#bcb489"/>
-      <stop offset="1" stop-color="#798da2"/>
+    <linearGradient
+       id="linearGradient4972-6">
+      <stop
+         style="stop-color:#c7e3e7;stop-opacity:1;"
+         offset="0"
+         id="stop4974-71" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-5" />
     </linearGradient>
-    <linearGradient id="b">
-      <stop offset="0" stop-color="#ba7f0d"/>
-      <stop offset="1" stop-color="#a2660b"/>
+    <linearGradient
+       id="linearGradient4972-4-1-2">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-6" />
     </linearGradient>
-    <linearGradient id="a">
-      <stop offset="0" stop-color="#ffe"/>
-      <stop offset="1" stop-color="#fbdd83"/>
+    <linearGradient
+       id="linearGradient6799-4-3-3">
+      <stop
+         style="stop-color:#bcb489;stop-opacity:1"
+         offset="0"
+         id="stop6801-4-0-8" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-5-7-9" />
     </linearGradient>
-    <linearGradient xlink:href="#a" id="g" x1="5.13" x2="13.428" y1="1043.898" y2="1043.898" gradientTransform="translate(.24 .432)" gradientUnits="userSpaceOnUse"/>
-    <linearGradient xlink:href="#b" id="h" x1="5.206" x2="16.247" y1="1044.488" y2="1044.488" gradientTransform="translate(.24 .432)" gradientUnits="userSpaceOnUse"/>
-    <linearGradient xlink:href="#c" id="i" x1="-2.586" x2="-1.767" y1="1045.108" y2="1045.108" gradientTransform="matrix(1.22093 0 0 1.131 -1036.417 -1175.004)" gradientUnits="userSpaceOnUse"/>
-    <linearGradient xlink:href="#d" id="j" x1="-1052.575" x2="-1048.575" y1="4.504" y2="4.504" gradientTransform="matrix(1.24937 0 0 1 2351.63 0)" gradientUnits="userSpaceOnUse"/>
-    <linearGradient xlink:href="#e" id="f" x1="3.004" x2="3.004" y1="1039.575" y2="1052.575" gradientTransform="translate(14 -3)" gradientUnits="userSpaceOnUse"/>
+    <linearGradient
+       id="linearGradient4972-5-7">
+      <stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-5-2-6">
+      <stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-3-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-9-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4741"
+       inkscape:collect="always">
+      <stop
+         id="stop4743"
+         offset="0"
+         style="stop-color:#ba7f0d;stop-opacity:1" />
+      <stop
+         id="stop4745"
+         offset="1"
+         style="stop-color:#a2660b;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4749"
+       inkscape:collect="always">
+      <stop
+         id="stop4751"
+         offset="0"
+         style="stop-color:#ffffee;stop-opacity:1" />
+      <stop
+         id="stop4753"
+         offset="1"
+         style="stop-color:#fbdd83;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient5232"
+       gradientUnits="userSpaceOnUse"
+       x1="5.1299052"
+       y1="1043.8982"
+       x2="13.428"
+       y2="1043.8982"
+       gradientTransform="matrix(0,-0.65104166,0.65104166,0,-674.05214,1052.8412)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient5234"
+       gradientUnits="userSpaceOnUse"
+       x1="5.2061925"
+       y1="1044.488"
+       x2="16.2465"
+       y2="1044.488"
+       gradientTransform="matrix(0,-0.65104166,0.65104166,0,-674.05214,1052.8412)" />
+    <linearGradient
+       id="linearGradient4972-5-7-2">
+      <stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-4-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-3-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-6-5">
+      <stop
+         style="stop-color:#c7e3e7;stop-opacity:1;"
+         offset="0"
+         id="stop4974-71-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-5-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-4-1-2-8">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-4-3" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-6-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4081"
+       id="linearGradient4087"
+       x1="-2.5863335"
+       y1="1045.1082"
+       x2="-1.7672856"
+       y2="1045.1082"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2209298,0,0,1.1309974,-1036.2046,-1177.0077)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4403"
+       id="linearGradient4409"
+       x1="-1052.5747"
+       y1="4.5035412"
+       x2="-1048.5747"
+       y2="4.5035412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2493679,0,0,1,2352.4176,-2.003522)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6799-4-3-3"
+       id="linearGradient7050"
+       x1="3.0035219"
+       y1="1039.5747"
+       x2="3.0035219"
+       y2="1052.5747"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(11.99648,-2.2126746)" />
   </defs>
-  <path fill="none" stroke="url(#f)" stroke-miterlimit="3.7" d="M16.504 1036.575v13" transform="translate(-2.004 -1036.575)"/>
-  <path fill="#c1c6d9" d="M-15.004 1048.577h4v1h-4z" color="#000" overflow="visible" style="marker:none" transform="matrix(-1 0 0 1 -2.004 -1036.575)"/>
-  <path fill="url(#g)" stroke="url(#h)" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.536" d="m10.966 1038.08-.012 3.072H2.959c-.668 0-1.219.11-1.219.777v4.146c0 .668.67 1.221 1.339 1.221h7.88v3.072h1.013l6.668-6.144-6.668-6.144z" transform="rotate(-90 -328.848 345.484) scale(.65104)"/>
-  <path fill="url(#i)" d="M-1039.575 6.004h2v3.007h-2z" transform="rotate(-90 -519.29 -517.286)"/>
-  <path fill="#c1c6d9" d="M-15.004 1046.577h2v1h-2zM-15.004 1044.577h2v1h-2zM-15.004 1040.577h2v1h-2zM-12.004 1040.577h2v1h-2zM-15.004 1038.577h5v1h-5zM-15.004 1042.577h3v1h-3z" color="#000" overflow="visible" style="marker:none" transform="matrix(-1 0 0 1 -2.004 -1036.575)"/>
-  <path fill="url(#j)" d="M1036.577 4.004h4.998v1h-4.998z" color="#000" overflow="visible" style="marker:none" transform="matrix(0 1 1 0 -2.004 -1036.575)"/>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#f3f3f3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="35.96875"
+     inkscape:cx="8.0069505"
+     inkscape:cy="8.0069505"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1392"
+     inkscape:window-height="1027"
+     inkscape:window-x="231"
+     inkscape:window-y="34"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4250"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g3"
+       inkscape:label="document">
+      <g
+         id="g2"
+         inkscape:label="border">
+        <path
+           style="display:inline;fill:none;fill-opacity:0.521569;stroke:url(#linearGradient7050);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:3.7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 14.5,1037.3622 v 13"
+           id="rect7028"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc"
+           inkscape:label="rect7028" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4409);fill-opacity:1;stroke:none;stroke-width:0.694276;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-51-3"
+           width="4.99752"
+           height="1.0000386"
+           x="1037.3645"
+           y="2"
+           transform="matrix(0,1,1,0,0,0)"
+           inkscape:label="rect6891-5-7-31-2-51-3" />
+      </g>
+      <g
+         id="g1"
+         inkscape:label="lines">
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.694276;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2"
+           width="4"
+           height="1.0000386"
+           x="-13"
+           y="1048.3622"
+           transform="scale(-1,1)"
+           inkscape:label="rect6891-5-7-31-2" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.694276;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5"
+           width="2"
+           height="1.0000386"
+           x="-13"
+           y="1046.3622"
+           transform="scale(-1,1)" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.694276;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5-9"
+           width="2"
+           height="1.0000386"
+           x="-13"
+           y="1044.3622"
+           transform="scale(-1,1)" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.694276;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5-9-5"
+           width="2"
+           height="1.0000386"
+           x="-13"
+           y="1040.3622"
+           transform="scale(-1,1)" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.694276;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5-9-0"
+           width="2"
+           height="1.0000386"
+           x="-10"
+           y="1040.3622"
+           transform="scale(-1,1)" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:3.7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-51"
+           width="5"
+           height="1.0000386"
+           x="-13"
+           y="1038.3622"
+           transform="scale(-1,1)" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.694276;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-3"
+           width="3"
+           height="1.0000386"
+           x="-13"
+           y="1042.3622"
+           transform="scale(-1,1)" />
+        <rect
+           transform="rotate(-90)"
+           style="display:inline;fill:url(#linearGradient4087);fill-opacity:1;stroke:none"
+           id="rect6999"
+           width="1.9999614"
+           height="3.006958"
+           x="-1039.3622"
+           y="3.9999993"
+           inkscape:label="rect6999" />
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="ccsssscccccc"
+       inkscape:connector-curvature="0"
+       id="rect3968"
+       d="m 1.4999996,1045.8583 2,0.01 v 5.205 c 0,0.4348 0.070964,0.7934 0.5057943,0.7934 h 2.6995442 c 0.4347656,0 0.7947917,-0.4366 0.7946615,-0.8714 v -5.131 h 1.9999997 v -0.659 l -3.9999997,-4.341 -4,4.3409 z"
+       style="fill:url(#linearGradient5232);fill-opacity:1;stroke:url(#linearGradient5234);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:label="arrow" />
+  </g>
 </svg>


### PR DESCRIPTION
Fix Icons according to Eclipse UI guideline.
Left and top pixel row should stay empty according to the guideline.

Also: make the "document" in the "wordwrap" and the "block_selection_mode" icon the same hight as they are shown next to each other in the toolbar.