### PR TITLE
[Build] Disallow Java security-manager in all I-/Y-/Smoke-tests

### DIFF
--- a/JenkinsJobs/AutomatedTests/I_unit_linux.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_linux.groovy
@@ -40,7 +40,7 @@ pipeline {
               JAVA_HOME = ''' + BUILD_CONFIG.javaHome + '''
               ANT_HOME = tool(type:'ant', name:'apache-ant-latest')
               PATH = "${JAVA_HOME}/bin:${ANT_HOME}/bin:${PATH}"
-              ANT_OPTS = "-Djava.io.tmpdir=${WORKSPACE}/tmp -Djava.security.manager=allow"
+              ANT_OPTS = "-Djava.io.tmpdir=${WORKSPACE}/tmp"
           }
           steps {
               xvnc(useXauthority: true) {

--- a/JenkinsJobs/AutomatedTests/I_unit_mac.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_mac.groovy
@@ -37,7 +37,7 @@ pipeline {
               JAVA_HOME = \'''' + ARCHS_JAVA_HOME[ARCH] + ''''
               ANT_HOME = tool(type:'ant', name:'apache-ant-latest')
               PATH = "${JAVA_HOME}/bin:${ANT_HOME}/bin:${PATH}"
-              ANT_OPTS = "-Djava.io.tmpdir=${WORKSPACE}/tmp -Djava.security.manager=allow"
+              ANT_OPTS = "-Djava.io.tmpdir=${WORKSPACE}/tmp"
           }
           steps {
               cleanWs() // workspace not cleaned by default

--- a/JenkinsJobs/AutomatedTests/I_unit_win32.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_win32.groovy
@@ -32,7 +32,7 @@ pipeline {
               JAVA_HOME = 'C:\\\\Program Files\\\\Eclipse Adoptium\\\\jdk-17.0.11+9'
               ANT_HOME = tool(type:'ant', name:'apache-ant-latest')
               PATH = "${JAVA_HOME}\\\\bin;${ANT_HOME}\\\\bin;${PATH}"
-              ANT_OPTS = "-Djava.io.tmpdir=${WORKSPACE}\\\\tmp -Djava.security.manager=allow"
+              ANT_OPTS = "-Djava.io.tmpdir=${WORKSPACE}\\\\tmp"
           }
           steps {
               cleanWs() // workspace not cleaned by default

--- a/JenkinsJobs/SmokeTests/StartSmokeTests.jenkinsfile
+++ b/JenkinsJobs/SmokeTests/StartSmokeTests.jenkinsfile
@@ -108,7 +108,7 @@ def runSmokeTest(Closure executorAgent, String agentId, String os, String arch, 
 			withEnv([
 				"JAVA_HOME=${javaHome}", "ANT_HOME=${ antHome }",
 				"WORKSPACE=${pwd()}", "PATH=${javaHome}/bin:${antHome}/bin:${PATH}",
-				"ANT_OPTS=-Djava.io.tmpdir=${pwd()}/tmp -Djava.security.manager=allow"
+				"ANT_OPTS=-Djava.io.tmpdir=${pwd()}/tmp"
 			]) {
 				xvnc(useXauthority: true) {
 					if (os =='linux') {

--- a/JenkinsJobs/YBuilds/Y_unit_linux.groovy
+++ b/JenkinsJobs/YBuilds/Y_unit_linux.groovy
@@ -37,7 +37,7 @@ pipeline {
               JAVA_HOME = ''' + BUILD_CONFIG.javaHome + '''
               ANT_HOME = tool(type:'ant', name:'apache-ant-latest')
               PATH = "${JAVA_HOME}/bin:${ANT_HOME}/bin:${PATH}"
-              ANT_OPTS = "-Djava.io.tmpdir=${WORKSPACE}/tmp -Djava.security.manager=allow"
+              ANT_OPTS = "-Djava.io.tmpdir=${WORKSPACE}/tmp"
           }
           steps {
               xvnc(useXauthority: true) {

--- a/JenkinsJobs/YBuilds/Y_unit_mac.groovy
+++ b/JenkinsJobs/YBuilds/Y_unit_mac.groovy
@@ -36,7 +36,7 @@ pipeline {
               JAVA_HOME = \'''' + BUILD_CONFIG.javaHome + ''''
               ANT_HOME = tool(type:'ant', name:'apache-ant-latest')
               PATH = "${JAVA_HOME}/bin:${ANT_HOME}/bin:${PATH}"
-              ANT_OPTS = "-Djava.io.tmpdir=${WORKSPACE}/tmp -Djava.security.manager=allow"
+              ANT_OPTS = "-Djava.io.tmpdir=${WORKSPACE}/tmp"
           }
           steps {
               cleanWs() // workspace not cleaned by default

--- a/JenkinsJobs/YBuilds/Y_unit_win32.groovy
+++ b/JenkinsJobs/YBuilds/Y_unit_win32.groovy
@@ -30,7 +30,7 @@ pipeline {
               JAVA_HOME = 'C:\\\\Program Files\\\\Eclipse Adoptium\\\\jdk-17.0.11+9'
               ANT_HOME = tool(type:'ant', name:'apache-ant-latest')
               PATH = "${JAVA_HOME}\\\\bin;${ANT_HOME}\\\\bin;${PATH}"
-              ANT_OPTS = "-Djava.io.tmpdir=${WORKSPACE}\\\\tmp -Djava.security.manager=allow"
+              ANT_OPTS = "-Djava.io.tmpdir=${WORKSPACE}\\\\tmp"
           }
           steps {
               cleanWs() // workspace not cleaned by default


### PR DESCRIPTION
Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2623

@merks do you think we should explicitly disallow the security-manager or just remove the argument to explicitly enable it?
Since Java-18 the default value of the `java.security.manager` property is  `disallow` as part of [JEP-411](https://openjdk.org/jeps/411):
- https://bugs.openjdk.org/browse/JDK-8270380

In order to make the builds a bit simpler I would be in favor to just remove the `java.security.manager` argument. With that only the Java-17 tests would run with enabled security-manager and all others would have it disabled. And Java-17 will probably not last long any-ways.

Btw. I have replayed a I-build test with explicit disallowed security-manager in order to test in advance if everything falls apart or not (you can see it in the diff):
- https://ci.eclipse.org/releng/job/AutomatedTests/job/ep435I-unit-linux-x86_64-java21/25/