### PR TITLE
Add documentation for the added eclipse.appName System Property

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/runtime-options.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/runtime-options.html
@@ -317,6 +317,9 @@ in <a href="#eclipsevm">eclipse.vm</a>.</dd>
   <dd>Controls registration of application descriptor services for all installed applications.  The default value is
   &quot;false&quot;.  If set to &quot;false&quot; only the default application will have an application descriptor service
   registered.  If set to &quot;true&quot; then all installed applications will have an application descriptor service registered.</dd>
+  <dt><a name="eclipseappname"  id="eclipseappname"></a>eclipse.appName</dt>
+  <dd>allows to set the application name with which Eclipse is regsitered at the operating system. This option is helpful to
+	distinguish and group Eclipse instances.</dd>
   <dt><a name="eclipsecommands" id="eclipsecommands"></a>eclipse.commands</dt>
   <dd>a new-line separated list of all command-line arguments passed in when launching
     Eclipse </dd>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/runtime-options.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/runtime-options.html
@@ -318,7 +318,7 @@ in <a href="#eclipsevm">eclipse.vm</a>.</dd>
   &quot;false&quot;.  If set to &quot;false&quot; only the default application will have an application descriptor service
   registered.  If set to &quot;true&quot; then all installed applications will have an application descriptor service registered.</dd>
   <dt><a name="eclipseappname"  id="eclipseappname"></a>eclipse.appName</dt>
-  <dd>allows to set the application name with which Eclipse is regsitered at the operating system. This option is helpful to
+  <dd>allows to set the application name with which Eclipse is registered in the operating system. This option is helpful to
 	distinguish and group Eclipse instances.</dd>
   <dt><a name="eclipsecommands" id="eclipsecommands"></a>eclipse.commands</dt>
   <dd>a new-line separated list of all command-line arguments passed in when launching

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/runtime-options.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/runtime-options.html
@@ -318,7 +318,7 @@ in <a href="#eclipsevm">eclipse.vm</a>.</dd>
   &quot;false&quot;.  If set to &quot;false&quot; only the default application will have an application descriptor service
   registered.  If set to &quot;true&quot; then all installed applications will have an application descriptor service registered.</dd>
   <dt><a name="eclipseappname"  id="eclipseappname"></a>eclipse.appName</dt>
-  <dd>allows to set the application name with which Eclipse is registered in the operating system. This option is helpful to
+  <dd>Allows to set the application name with which Eclipse is registered in the operating system. This option is helpful to
 	distinguish and group Eclipse instances.</dd>
   <dt><a name="eclipsecommands" id="eclipsecommands"></a>eclipse.commands</dt>
   <dd>a new-line separated list of all command-line arguments passed in when launching


### PR DESCRIPTION
The eclipse.appName sytem property allows users to specify on the command line the appName to be used for a specific Eclipse instance. The appName Display property is used by window managers and desktop environments for identification and grouping. This is helpful to distinguish Eclipse instances (e.g., JDT vs CDT) as per default these all are using the same identifier.

Eclipse UI PR:
https://github.com/eclipse-platform/eclipse.platform.ui/pull/2631 
Root Issue: eclipse-packaging/packages#253