### PR TITLE
Update target platform to lucene 10.

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -26,12 +26,12 @@
       <unit id="org.junit" version="4.13.2.v20240929-1000"/>
       <unit id="org.junit.source" version="4.13.2.v20240929-1000"/>
 
-      <unit id="org.apache.lucene.core" version="9.12.0.v20240929-0900"/>
-      <unit id="org.apache.lucene.analysis-smartcn" version="9.12.0.v20240929-0900"/>
-      <unit id="org.apache.lucene.analysis-common" version="9.12.0.v20240929-0900"/>
-      <unit id="org.apache.lucene.core.source" version="9.12.0.v20240929-0900"/>
-      <unit id="org.apache.lucene.analysis-smartcn.source" version="9.12.0.v20240929-0900"/>
-      <unit id="org.apache.lucene.analysis-common.source" version="9.12.0.v20240929-0900"/>
+      <unit id="org.apache.lucene.core" version="10.0.0.v20241213-1200"/>
+      <unit id="org.apache.lucene.analysis-smartcn" version="10.0.0.v20241213-1200"/>
+      <unit id="org.apache.lucene.analysis-common" version="10.0.0.v20241213-1200"/>
+      <unit id="org.apache.lucene.core.source" version="10.0.0.v20241213-1200"/>
+      <unit id="org.apache.lucene.analysis-smartcn.source" version="10.0.0.v20241213-1200"/>
+      <unit id="org.apache.lucene.analysis-common.source" version="10.0.0.v20241213-1200"/>
 
       <!-- Transitive dependency of jxpath, not available as OSGi bundle on Maven Central -->
       <unit id="org.jdom" version="1.1.3.v20230812-1600"/>
@@ -49,7 +49,7 @@
       <unit id="org.commonmark-gfm-tables" version="0.24.0.v20241021-1700"/>
 
       <!-- This is the "normal" Orbit repository is expected to be updated on milestones and releases based on Orbit deliveries. -->
-      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.34.0"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202412161131"/>
     </location>
 
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
@@ -832,5 +832,5 @@
 		  </dependencies>
 	  </location>
   </locations>
-  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 </target>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.product
@@ -9,7 +9,7 @@
    <launcherArgs>
       <programArgs>--launcher.defaultAction openFile --launcher.appendVmargs
       </programArgs>
-      <vmArgs>-Dosgi.requiredJavaVersion=17 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true --add-modules=ALL-SYSTEM -Dorg.slf4j.simpleLogger.defaultLogLevel=off -Djava.security.manager=allow
+      <vmArgs>-Dosgi.requiredJavaVersion=21 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true --add-modules=ALL-SYSTEM -Dorg.slf4j.simpleLogger.defaultLogLevel=off -Djava.security.manager=allow
       </vmArgs>
       <vmArgsMac>-Xdock:icon=../Resources/Eclipse.icns -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>


### PR DESCRIPTION
- Lucene 10 requires Java 21, so the SDK product should indicate it requires Java 21.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2654