### PR TITLE
Remove out of date compatibility note

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/topics_Guide.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/topics_Guide.xml
@@ -221,7 +221,7 @@
 		<topic label="Honoring single click support" href="guide/wrkAdv_singleclick.htm" />
 		<topic label="Working sets" href="guide/wrkAdv_workingsets.htm" />
 		<topic label="Filtering large user interfaces" href="guide/workbench_scalability.htm" >
-			<topic label="Activities (Not currently in 4.1)" href="guide/workbench_advext_activities.htm" />
+			<topic label="Activities" href="guide/workbench_advext_activities.htm" />
 			<topic label="Contexts" href="guide/workbench_advext_contexts.htm" />
 		</topic>
 		<topic label="Workbench concurrency support" href="guide/workbench_jobs.htm" />


### PR DESCRIPTION
Many years ago Activites weren't support in e4. That has long since been resolved and when the "not currently in 4.1" note was removed from the main help page in commit 5f66a3ea1ea9e71c32ce4fa63b5148530165bf16 the same update was not made to the table of contents.