### PR TITLE
Adjust jenkins scripts for Java 21

### DIFF
--- a/JenkinsJobs/AutomatedTests/I_unit_win32.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_win32.groovy
@@ -5,7 +5,7 @@ for (STREAM in STREAMS){
   def MAJOR = STREAM.split('\\.')[0]
   def MINOR = STREAM.split('\\.')[1]
 
-  pipelineJob('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-win32-x86_64-java17'){
+  pipelineJob('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-win32-x86_64-java21'){
     description('Run Eclipse SDK Tests for the platform implied by this job\'s name')
     parameters { // Define parameters in job configuration to make them available from the very first build onwards
       stringParam('buildId', null, 'Build Id to test (such as I20240611-1800, N20120716-0800).')

--- a/JenkinsJobs/Builds/I_build.groovy
+++ b/JenkinsJobs/Builds/I_build.groovy
@@ -417,12 +417,11 @@ spec:
 	  stage('Trigger tests'){
           steps {
             container('jnlp') {
-              build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-linux-x86_64-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
               build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-linux-x86_64-java21', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
               build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-linux-x86_64-java23', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
               build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-macosx-aarch64-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
               build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-macosx-x86_64-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
-              build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-win32-x86_64-java17', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
+              build job: 'AutomatedTests/ep''' + MAJOR + MINOR + '''I-unit-win32-x86_64-java21', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
               build job: 'SmokeTests/Start-smoke-tests', parameters: [string(name: 'buildId', value: "${env.BUILD_IID.trim()}")], wait: false
             }
           }

--- a/cje-production/scripts/publish.xml
+++ b/cje-production/scripts/publish.xml
@@ -185,8 +185,7 @@
     <resources id="testsConfigExpected">
       <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-macosx-x86_64-java17_macosx.cocoa.x86_64_17</string>
       <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-macosx-aarch64-java17_macosx.cocoa.aarch64_17</string>
-      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-win32-x86_64-java17_win32.win32.x86_64_17</string>
-      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-linux-x86_64-java17_linux.gtk.x86_64_17</string>
+      <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-win32-x86_64-java21_win32.win32.x86_64_21</string>
       <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-linux-x86_64-java21_linux.gtk.x86_64_21</string>
       <string>ep${eclipseStreamMajor}${eclipseStreamMinor}${buildType}-unit-linux-x86_64-java23_linux.gtk.x86_64_23</string>
     </resources>


### PR DESCRIPTION
* Do not start Linux Java 17 tests
* Rename Windows tests to Java 21 to match version used
* Publish correct test results