### PR TITLE
Remove -Djava.security.manager=allow from the products

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.p2.inf
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.p2.inf
@@ -1,5 +1,6 @@
 instructions.configure=\
-  mkdir(path:${installFolder}/dropins);
+  mkdir(path:${installFolder}/dropins);\
+  removeJvmArg(jvmArg:-Djava.security.manager=allow);
 
 # Restrict range so we are not an automatic update for 3.x.
 update.id = org.eclipse.platform.ide

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.product
@@ -9,7 +9,7 @@
    <launcherArgs>
       <programArgs>--launcher.defaultAction openFile --launcher.appendVmargs
       </programArgs>
-      <vmArgs>-Dosgi.requiredJavaVersion=17 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true --add-modules=ALL-SYSTEM -Dorg.slf4j.simpleLogger.defaultLogLevel=off -Djava.security.manager=allow
+      <vmArgs>-Dosgi.requiredJavaVersion=21 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true --add-modules=ALL-SYSTEM -Dorg.slf4j.simpleLogger.defaultLogLevel=off
       </vmArgs>
       <vmArgsMac>-Xdock:icon=../Resources/Eclipse.icns -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.p2.inf
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.p2.inf
@@ -1,5 +1,6 @@
 instructions.configure=\
-  mkdir(path:${installFolder}/dropins);
+  mkdir(path:${installFolder}/dropins);\
+  removeJvmArg(jvmArg:-Djava.security.manager=allow);
 
 # Restrict range so we are not an automatic update for 3.x.
 update.id= org.eclipse.sdk.ide
@@ -13,4 +14,3 @@ properties.1.value = 4.35 Release of the Eclipse SDK.
 
 properties.2.name = org.eclipse.equinox.p2.provider
 properties.2.value = Eclipse.org
-

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.product
@@ -9,7 +9,7 @@
    <launcherArgs>
       <programArgs>--launcher.defaultAction openFile --launcher.appendVmargs
       </programArgs>
-      <vmArgs>-Dosgi.requiredJavaVersion=21 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true --add-modules=ALL-SYSTEM -Dorg.slf4j.simpleLogger.defaultLogLevel=off -Djava.security.manager=allow
+      <vmArgs>-Dosgi.requiredJavaVersion=21 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true --add-modules=ALL-SYSTEM -Dorg.slf4j.simpleLogger.defaultLogLevel=off
       </vmArgs>
       <vmArgsMac>-Xdock:icon=../Resources/Eclipse.icns -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>


### PR DESCRIPTION
- Define an unconfigure touchpoint to remove -Djava.security.manager=allow from the eclipse.ini which is done to ensure that updates will leave installations in a state that can run with Java 24.
- Do the above for both products and ensure that both products specify -Dosgi.requiredJavaVersion=21

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2623