### PR TITLE
Revert "Run licensecheck with Java 21"

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -21,7 +21,6 @@ jobs:
     uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
     with:
       projectId: eclipse.platform
-      javaVersion: 21
       submodules: recursive
     secrets:
       gitlabAPIToken: ${{ secrets.ECLIPSE_GITLAB_API_TOKEN }}


### PR DESCRIPTION
Reverts eclipse-platform/eclipse.platform.releng.aggregator#2674

Now that https://github.com/eclipse-dash/dash-licenses/pull/423 is submitted, this should not be necessary anymore.