### PR TITLE
Revert "Add java security properties for surefire"

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -139,8 +139,6 @@
     <surefire.platformSystemProperties></surefire.platformSystemProperties>
     <!-- properties related to Java modules on Java 9+ -->
     <surefire.moduleProperties></surefire.moduleProperties>
-    <!-- properties related to Java security -->
-    <surefire.securityProperties></surefire.securityProperties>
     <!-- system specific JVM args; if needed provided by system properties to the build command -->
     <surefire.systemProperties></surefire.systemProperties>
     <java.version>17</java.version>
@@ -478,7 +476,7 @@
           <version>${tycho.version}</version>
           <configuration>
             <enableAssertions>true</enableAssertions>
-            <argLine>${surefire.testArgLine} ${surefire.platformSystemProperties} ${surefire.systemProperties} ${surefire.moduleProperties} ${surefire.securityProperties}</argLine>
+            <argLine>${surefire.testArgLine} ${surefire.platformSystemProperties} ${surefire.systemProperties} ${surefire.moduleProperties}</argLine>
             <quiet>true</quiet>
           </configuration>
         </plugin>
@@ -1115,15 +1113,6 @@
       </activation>
       <properties>
         <surefire.moduleProperties>--add-modules=ALL-SYSTEM</surefire.moduleProperties>
-      </properties>
-    </profile>
-    <profile>
-      <id>jdk18-or-newer</id>
-      <activation>
-        <jdk>[18,)</jdk>
-      </activation>
-      <properties>
-        <surefire.securityProperties>-Djava.security.manager=allow</surefire.securityProperties>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
Now that all tests can handle a disabled SecurityManger it doesn't have to be enabled by default anymore.

This reverts https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1941