### PR TITLE
Install git and `procps` package in all docker-images

### DIFF
--- a/JenkinsJobs/Builds/DockerImagesBuild.jenkinsfile
+++ b/JenkinsJobs/Builds/DockerImagesBuild.jenkinsfile
@@ -14,8 +14,8 @@ pipeline {
 			steps {
 				cleanWs()
 				sh '''
-					git clone -b master https://github.com/eclipse-platform/eclipse.platform.releng.aggregator.git
-					git clone -b master https://github.com/eclipse-jdt/eclipse.jdt.core
+					git clone --depth=1 -b master https://github.com/eclipse-platform/eclipse.platform.releng.aggregator.git
+					git clone --depth=1 -b master https://github.com/eclipse-jdt/eclipse.jdt.core
 				'''
 			}
 		}

--- a/cje-production/dockerfiles/centos-gtk4-mutter/9-gtk4/Dockerfile
+++ b/cje-production/dockerfiles/centos-gtk4-mutter/9-gtk4/Dockerfile
@@ -17,6 +17,7 @@ RUN dnf -y update && dnf -y install \
       tigervnc \
       mutter \
       xorg-x11-server-utils \
+      procps-ng \
       mesa-libGL \
       xorg-x11-fonts-misc \
       xorg-x11-fonts-75dpi \

--- a/cje-production/dockerfiles/centos-gtk4-mutter/9-gtk4/Dockerfile
+++ b/cje-production/dockerfiles/centos-gtk4-mutter/9-gtk4/Dockerfile
@@ -27,6 +27,7 @@ RUN dnf -y update && dnf -y install \
       lsof \
       wget \
       curl-minimal \
+      git \
       dbus \
       webkit2gtk3 \
       glibc-locale-source \

--- a/cje-production/dockerfiles/debian/swtnativebuild/Dockerfile
+++ b/cje-production/dockerfiles/debian/swtnativebuild/Dockerfile
@@ -8,7 +8,15 @@ RUN chmod u+x /usr/local/bin/uid_entrypoint && \
 ### end
 
 ENV LANG=en_US.UTF-8
-RUN apt-get update -qq && apt-get install -qq -y locales libgtk-3-dev libgtk-4-dev freeglut3-dev webkit2gtk-driver build-essential default-jdk
+RUN apt-get update -qq && apt-get install -qq -y \
+      locales \
+      build-essential \
+      git \
+      libgtk-3-dev \
+      libgtk-4-dev \
+      freeglut3-dev \
+      webkit2gtk-driver \
+      default-jdk
 
 ENV HOME=/home/swtbuild
 ENV DISPLAY :0

--- a/cje-production/dockerfiles/debian/swtnativebuild/Dockerfile
+++ b/cje-production/dockerfiles/debian/swtnativebuild/Dockerfile
@@ -11,6 +11,7 @@ ENV LANG=en_US.UTF-8
 RUN apt-get update -qq && apt-get install -qq -y \
       locales \
       build-essential \
+      procps \
       git \
       libgtk-3-dev \
       libgtk-4-dev \

--- a/cje-production/dockerfiles/opensuse-gtk3-metacity/15-gtk3/Dockerfile
+++ b/cje-production/dockerfiles/opensuse-gtk3-metacity/15-gtk3/Dockerfile
@@ -11,6 +11,7 @@ RUN zypper --non-interactive update && zypper --non-interactive install \
       libgtk-3-0 \
       xorg-x11-Xvnc \
       tigervnc \
+      procps \
       metacity \
       xorg-x11-fonts \
       dejavu-fonts \

--- a/cje-production/dockerfiles/opensuse-gtk3-metacity/15-gtk3/Dockerfile
+++ b/cje-production/dockerfiles/opensuse-gtk3-metacity/15-gtk3/Dockerfile
@@ -21,6 +21,7 @@ RUN zypper --non-interactive update && zypper --non-interactive install \
       wget \
       curl \
       unzip \
+      git-core \
       vim \
       tar \
       gzip


### PR DESCRIPTION
Install git on all docker-images, which is a prerequisite for
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2609

Install `procps` package in all docker-images for smoke-tests. The 'procps'-package contains the pkill command which is currently
missing according to the smoke-tests logs. Part of
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2642
