### PR TITLE
[Build] Adapt initial testConfigs.php to move of test-builds to Java-21

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/staticDropFiles/testConfigs.php
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/staticDropFiles/testConfigs.php
@@ -10,9 +10,8 @@
 include("buildproperties.php");
 
 $expectedTestConfigs = array();
-$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-macosx-x86_64-java17_macosx.cocoa.x86_64_17";
-$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-macosx-aarch64-java17_macosx.cocoa.aarch64_17";
-$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-win32-x86_64-java17_win32.win32.x86_64_17";
-$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-linux-x86_64-java17_linux.gtk.x86_64_17";
+$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-macosx-x86_64-java21_macosx.cocoa.x86_64_21";
+$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-macosx-aarch64-java21_macosx.cocoa.aarch64_21";
+$expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-win32-x86_64-java21_win32.win32.x86_64_21";
 $expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-linux-x86_64-java21_linux.gtk.x86_64_21";
 $expectedTestConfigs[]="ep$STREAMMajor$STREAMMinor$TESTED_BUILD_TYPE-unit-linux-x86_64-java23_linux.gtk.x86_64_23";


### PR DESCRIPTION
Follow-up on
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2667
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2666
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2670
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2680