### PR TITLE
[Build] Drop execution of smoke-tests with Java-17

### DIFF
--- a/JenkinsJobs/SmokeTests/StartSmokeTests.jenkinsfile
+++ b/JenkinsJobs/SmokeTests/StartSmokeTests.jenkinsfile
@@ -38,7 +38,7 @@ spec:
 					}
 					axis {
 						name 'JAVA_VERSION'
-						values '17', '21', '23'
+						values '21', '23'
 					}
 				}
 				stages {


### PR DESCRIPTION
The Eclipse SDK starts to require Java-21 and all other tests are just executed on at least Java-21