### PR TITLE
[Build] Define max heap size for Maven only via environment variables

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,2 +1,1 @@
 -XX:+PrintFlagsFinal
--Xmx3G

--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -49,10 +49,10 @@ spec:
   - name: "jnlp"
     resources:
       limits:
-        memory: "10Gi"
+        memory: "8Gi"
         cpu: "4000m"
       requests:
-        memory: "6144Mi"
+        memory: "6Gi"
         cpu: "2000m"
 """
     }
@@ -67,7 +67,7 @@ spec:
 		BUILD_TYPE_NAME = "${BUILD.typeName}"
 		PATCH_OR_BRANCH_LABEL = "${BUILD.branchLabel}"
 
-		MAVEN_OPTS = "-Xmx6G"
+		MAVEN_OPTS = '-Xmx4G'
 		CJE_ROOT = "${WORKSPACE}/cje-production"
 		logDir = "$CJE_ROOT/buildlogs"
 		TEST_CONFIGURATIONS_EXPECTED = "${testConfigurationsExpected}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,9 @@ pipeline {
 		maven 'apache-maven-latest'
 		jdk 'temurin-jdk21-latest'
 	}
+	environment {
+		MAVEN_OPTS = '-Xmx3G'
+	}
 	stages {
 		stage('Use master') {
 			steps {

--- a/cje-production/buildproperties.txt
+++ b/cje-production/buildproperties.txt
@@ -51,5 +51,4 @@ BASEBUILDER_DIR="tmp/org.eclipse.releng.basebuilder"
 ECLIPSE_RUN_REPO="https://download.eclipse.org/eclipse/updates/4.35-I-builds/"
 
 #Maven parameters
-MAVEN_OPTS="-Xmx6G"
 JAVA_DOC_TOOL="-Declipse.javadoc=/opt/tools/java/openjdk/jdk-17/latest/bin/javadoc"


### PR DESCRIPTION
This avoids confusion which value is actually used and allows to reduce the memory demand of the container used for I-builds.
Defining it in the corresponding pipeline allows fine-tuning for the circumstances of the corresponding build and it's settings.

I'll have to verify in an experiment that we can really reduce the memory-limit of the container used for I-builds.