### PR TITLE
[Build] Send Y-build results to jdt-dev mailing-list

### DIFF
--- a/JenkinsJobs/YBuilds/Y_build.groovy
+++ b/JenkinsJobs/YBuilds/Y_build.groovy
@@ -441,13 +441,13 @@ spec:
         failure {
             emailext body: "Please go to <a href='${BUILD_URL}console'>${BUILD_URL}console</a> and check the build failure.<br><br>",
             subject: "${env.BUILD_VERSION} Y-Build: ${env.BUILD_IID.trim()} - BUILD FAILED", 
-            to: "rahul.mohanan@ibm.com jarthana@in.ibm.com alshama.m.s@ibm.com elsa.zacharia@ibm.com suby.surendran@ibm.com gpunathi@in.ibm.com sravankumarl@in.ibm.com manoj.palat@in.ibm.com noopur_gupta@in.ibm.com akurtakov@gmail.com",
+            to: 'jdt-dev@eclipse.org',
             from:"genie.releng@eclipse.org"
         }
         success {
             emailext body: "Eclipse downloads:<br>    <a href='https://download.eclipse.org/eclipse/downloads/drops4/${env.BUILD_IID.trim()}'>https://download.eclipse.org/eclipse/downloads/drops4/${env.BUILD_IID.trim()}</a><br><br> Build logs and/or test results (eventually):<br>    <a href='https://download.eclipse.org/eclipse/downloads/drops4/${env.BUILD_IID.trim()}/testResults.php'>https://download.eclipse.org/eclipse/downloads/drops4/${env.BUILD_IID.trim()}/testResults.php</a><br><br>${env.POM_UPDATES_BODY.trim()}${env.COMPARATOR_ERRORS_BODY.trim()}Software site repository:<br>    <a href='https://download.eclipse.org/eclipse/updates/${env.RELEASE_VER.trim()}-Y-builds'>https://download.eclipse.org/eclipse/updates/${env.RELEASE_VER.trim()}-Y-builds</a><br><br>Specific (simple) site repository:<br>    <a href='https://download.eclipse.org/eclipse/updates/${env.RELEASE_VER.trim()}-Y-builds/${env.BUILD_IID.trim()}'>https://download.eclipse.org/eclipse/updates/${env.RELEASE_VER.trim()}-Y-builds/${env.BUILD_IID.trim()}</a><br><br>Equinox downloads:<br>     <a href='https://download.eclipse.org/equinox/drops/${env.BUILD_IID.trim()}'>https://download.eclipse.org/equinox/drops/${env.BUILD_IID.trim()}</a><br><br>", 
             subject: "${env.BUILD_VERSION} Y-Build: ${env.BUILD_IID.trim()} ${env.POM_UPDATES_SUBJECT.trim()} ${env.COMPARATOR_ERRORS_SUBJECT.trim()}", 
-            to: "rahul.mohanan@ibm.com jarthana@in.ibm.com alshama.m.s@ibm.com elsa.zacharia@ibm.com suby.surendran@ibm.com gpunathi@in.ibm.com sravankumarl@in.ibm.com manoj.palat@in.ibm.com noopur_gupta@in.ibm.com akurtakov@gmail.com",
+            to: 'jdt-dev@eclipse.org',
             from:"genie.releng@eclipse.org"
         }
 	}


### PR DESCRIPTION
instead of to a fixed lists of interested people.
As people and their interest may come and go it's simpler to not have a fixed list of people to which notifications are send.

@jarthana, @mpalat or @stephan-herrmann, what do you think?