### PR TITLE
Add generic editor extension points to docs

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/extension-points/index.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/extension-points/index.html
@@ -160,9 +160,15 @@
       <li>
         <a href="org_eclipse_ui_genericeditor_contentAssistProcessors.html">org.eclipse.ui.genericeditor.contentAssistProcessors</a>
       </li>
+	  <li>
+	    <a href="org_eclipse_ui_genericeditor_foldingReconcilers.html">org.eclipse.ui.genericeditor.foldingReconcilers</a>
+	  </li>
       <li>
         <a href="org_eclipse_ui_genericeditor_highlightReconcilers.html">org.eclipse.ui.genericeditor.highlightReconcilers</a>
       </li>
+	  <li>
+		<a href="org_eclipse_ui_genericeditor_hoverProviders.html">org.eclipse.ui.genericeditor.hoverProviders</a>
+	  </li>
       <li>
         <a href="org_eclipse_ui_genericeditor_icons.html">org.eclipse.ui.genericeditor.icons</a>
       </li>
@@ -172,6 +178,12 @@
       <li>
         <a href="org_eclipse_ui_genericeditor_reconcilers.html">org.eclipse.ui.genericeditor.reconcilers</a>
       </li>
+	  <li>
+	    <a href="org_eclipse_ui_genericeditor_quickAssistProcessors.html">org.eclipse.ui.genericeditor.quickAssistProcessors</a>
+	  </li>
+	  <li>
+	  	<a href="org_eclipse_ui_genericeditor_textDoubleClickStrategies.html">org.eclipse.ui.genericeditor.textDoubleClickStrategies</a>
+	  </li>
       <li>
         <a href=
         "org_eclipse_ui_workbench_texteditor_codeMiningProviders.html">org.eclipse.ui.workbench.texteditor.codeMiningProviders</a>


### PR DESCRIPTION
They have been missed to be added to the docs when added.