### PR TITLE
[Build] Fix condition of maven-snapshot publication step

### DIFF
--- a/JenkinsJobs/Builds/I_build.groovy
+++ b/JenkinsJobs/Builds/I_build.groovy
@@ -368,7 +368,7 @@ spec:
 		}
 		stage('Trigger publication to Maven snapshots repo') {
 			when {
-				environment name: 'COMPARATOR_ERRORS_SUBJECT', value: ''
+				expression { env.COMPARATOR_ERRORS_SUBJECT.trim().isEmpty() }
 				// On comparator-erros, skip the deployment of snapshot version to the 'eclipse-snapshots' maven repository to prevent that ECJ snapshot
 				// from being used in verification builds. Similar to how the p2-repository is not added to the I-build composite in that case.
 			}


### PR DESCRIPTION
Current the 'COMPARATOR_ERRORS_SUBJECT' environment variable always contains a line-break, even if otherwise 'empty' (indicating no comparator-error). Trimming the value in the condition removes any leading/trailing white-space.

Follow-up on:
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2538


@merks, @akurtakov IIRC we had issues due to not deployed Maven-snapshots (of ECJ)? This was probably the cause because since the changed mentioned above snapshots were not published anymore.