### PR TITLE
[Build] Fix export of 'TEST_CONFIGURATIONS_EXPECTED' in SSH execution

### DIFF
--- a/JenkinsJobs/Builds/I_build.groovy
+++ b/JenkinsJobs/Builds/I_build.groovy
@@ -88,7 +88,7 @@ spec:
       MAVEN_OPTS = "-Xmx6G"
       CJE_ROOT = "${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production"
       logDir = "$CJE_ROOT/buildlogs"
-      TESTS_CONFIGURATIONS_EXPECTED = \'''' + TEST_CONFIGURATIONS.collect{c ->
+      TEST_CONFIGURATIONS_EXPECTED = \'''' + TEST_CONFIGURATIONS.collect{c ->
         'ep' + MAJOR + MINOR + 'I-unit-' + c.os + '-' + c.arch + '-java' + c.javaVersion + '_' + c.os + '.' + c.ws + '.' + c.arch + '_'  + c.javaVersion
       }.join(',') + ''''
     }

--- a/JenkinsJobs/Releng/collectPerfResults.groovy
+++ b/JenkinsJobs/Releng/collectPerfResults.groovy
@@ -124,6 +124,7 @@ ssh genie.releng@projects-storage.eclipse.org  ${javaCMD} -jar ${launcherJar} -n
   -Djob=${triggeringJob} \\
   -DbuildID=${buildID} \\
   -DeclipseStream=${STREAM} \\
+  "-DtestsConfigExpected=${TEST_CONFIGURATIONS_EXPECTED}" \\
   -DEBuilderDir=${workspace}
 
 #Delete Workspace

--- a/JenkinsJobs/Releng/collectResults.groovy
+++ b/JenkinsJobs/Releng/collectResults.groovy
@@ -110,6 +110,7 @@ ssh genie.releng@projects-storage.eclipse.org  ${javaCMD} -jar ${launcherJar} -n
   -Djob=${triggeringJob} \\
   -DbuildID=${buildID} \\
   -DeclipseStream=${STREAM} \\
+  "-DtestsConfigExpected=${TEST_CONFIGURATIONS_EXPECTED}" \\
   -DEBuilderDir=${workspace}
 
 

--- a/JenkinsJobs/YBuilds/Y_build.groovy
+++ b/JenkinsJobs/YBuilds/Y_build.groovy
@@ -84,7 +84,7 @@ spec:
       MAVEN_OPTS = "-Xmx6G"
       CJE_ROOT = "${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production"
       logDir = "$CJE_ROOT/buildlogs"
-      TESTS_CONFIGURATIONS_EXPECTED = \'''' + TEST_CONFIGURATIONS.collect{c ->
+      TEST_CONFIGURATIONS_EXPECTED = \'''' + TEST_CONFIGURATIONS.collect{c ->
         'ep' + MAJOR + MINOR + 'Y-unit-' + c.os + '-' + c.arch + '-java' + c.javaVersion + '_' + c.os + '.' + c.ws + '.' + c.arch + '_'  + c.javaVersion
       }.join(',') + ''''
     }

--- a/JenkinsJobs/YBuilds/collectYbuildResults.groovy
+++ b/JenkinsJobs/YBuilds/collectYbuildResults.groovy
@@ -111,6 +111,7 @@ ssh genie.releng@projects-storage.eclipse.org  ${javaCMD} -jar ${launcherJar} -n
   -Djob=${triggeringJob} \\
   -DbuildID=${buildID} \\
   -DeclipseStream=${STREAM} \\
+  "-DtestsConfigExpected=${TEST_CONFIGURATIONS_EXPECTED}" \\
   -DEBuilderDir=${workspace}
 
 #Delete Workspace

--- a/cje-production/mbscripts/mb010_createEnvfiles.sh
+++ b/cje-production/mbscripts/mb010_createEnvfiles.sh
@@ -78,4 +78,4 @@ fn-addToPropFiles ECLIPSE_BUILDER_DIR "\"$CJE_ROOT/$AGG_DIR/eclipse.platform.rel
 fn-addToPropFiles PLATFORM_PRODUCTS_DIR "\"$CJE_ROOT/$AGG_DIR/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/target/products\""
 fn-addToPropFiles PLATFORM_REPO_DIR "\"$CJE_ROOT/$AGG_DIR/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/target/repository\""
 fn-addToPropFiles PLATFORM_TARGET_DIR "\"$CJE_ROOT/$AGG_DIR/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/target\""
-fn-addToPropFiles TESTS_CONFIGURATIONS_EXPECTED "\"${TESTS_CONFIGURATIONS_EXPECTED}\""
+fn-addToPropFiles TEST_CONFIGURATIONS_EXPECTED "\"${TEST_CONFIGURATIONS_EXPECTED}\""

--- a/cje-production/scripts/publish.xml
+++ b/cje-production/scripts/publish.xml
@@ -182,7 +182,7 @@
         substring="-perf-" />
     </condition>
     <!-- else normal unit tests configs -->
-    <property name="testsConfigExpected" value="${env.TESTS_CONFIGURATIONS_EXPECTED}"/>
+    <property name="testsConfigExpected" value="${env.TEST_CONFIGURATIONS_EXPECTED}"/>
 
     <condition
       property="expectedConfigFilename"
@@ -257,7 +257,7 @@
     </loadresource>
     <echo message="eclipseStreamService: ${eclipseStreamService}"/>
 
-    <property environment="env" />
+    <property environment="env"/>
 
   </target>
 


### PR DESCRIPTION
Because in the 'Collect Result' jobs the publish.xml ANT script is executed remotely on the download-server via SSH the environment variables defined in the shell on the build-server are not available. As a workaround, define the 'testsConfigExpected' property explicitly as command-line argument.

Also rename 'TESTS_CONFIGURATIONS_EXPECTED' to
'TEST_CONFIGURATIONS_EXPECTED' to avoid a double-plural.

Follow-up to
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2693