### PR TITLE
Use 4.0.11-SNAPSHOT in the build

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -70,7 +70,7 @@
     <releaseNumberSDK>${releaseVersion}</releaseNumberSDK>
     <releaseNumberPlatform>${releaseVersion}</releaseNumberPlatform>
 
-    <tycho.version>4.0.10</tycho.version>
+    <tycho.version>4.0.11-SNAPSHOT</tycho.version>
 
     <cbi-plugins.version>1.5.1</cbi-plugins.version>
     <surefire.version>3.5.2</surefire.version>


### PR DESCRIPTION
Especially for
- https://github.com/eclipse-tycho/tycho/pull/4561

this will hopefully fix or make it less likely that API analysis fails in verification builds. Beside that there are some pending changes that could have an impact to platform builds so it would be better to make sure everything works until the next release.