### PR TITLE
Switch javadoc source to 21

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -567,7 +567,7 @@
             <artifactId>maven-javadoc-plugin</artifactId>
             <version>3.11.2</version>
             <configuration>
-                <source>17</source>
+                <source>21</source>
                 <legacyMode>true</legacyMode>
                 <doclint>reference,html,syntax</doclint>
                 <splitindex>true</splitindex>


### PR DESCRIPTION
Now that there is Java 21 content this would allow such code to be accepted.
Additionally, maven-javadoc-plugin uses that to decide which Java version to link javadoc to aka with this change String will link to Java 21 and not Java 17.