### PR TITLE
[Build] Use default declarative checkout for I/Y-builds

### DIFF
--- a/JenkinsJobs/Builds/FOLDER.groovy
+++ b/JenkinsJobs/Builds/FOLDER.groovy
@@ -5,6 +5,7 @@ folder('Builds') {
 }
 
 for (STREAM in config.Streams){
+	def BRANCH = config.Branches[STREAM]
 
 	pipelineJob('Builds/I-build-' + STREAM){
 		description('Daily Eclipse Integration builds.')
@@ -34,7 +35,7 @@ for (STREAM in config.Streams){
 			cpsScm {
 				lightweight(true)
 				scm {
-					github('eclipse-platform/eclipse.platform.releng.aggregator', 'master')
+					github('eclipse-platform/eclipse.platform.releng.aggregator', BRANCH)
 				}
 				scriptPath('JenkinsJobs/Builds/build.jenkinsfile')
 			}

--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -25,7 +25,7 @@ def BUILD = {
 				mailingList: 'jdt-dev@eclipse.org'            , testJobFolder:'YPBuilds'      , testConfigurations: Y_TEST_CONFIGURATIONS]
 		}
 	}
-	throw new IllegalStateException("Unsupported job: $JOB_BASE_NAME" )
+	error("Unsupported job: $JOB_BASE_NAME" )
 }()
 
 def testConfigurationsExpected = BUILD.testConfigurations.collect{c ->
@@ -37,7 +37,6 @@ pipeline {
 		timeout(time: 360, unit: 'MINUTES')
 		timestamps()
 		buildDiscarder(logRotator(numToKeepStr:'25'))
-		skipDefaultCheckout()
 	}
   agent {
     kubernetes {
@@ -69,20 +68,13 @@ spec:
 		PATCH_OR_BRANCH_LABEL = "${BUILD.branchLabel}"
 
 		MAVEN_OPTS = "-Xmx6G"
-		CJE_ROOT = "${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production"
+		CJE_ROOT = "${WORKSPACE}/cje-production"
 		logDir = "$CJE_ROOT/buildlogs"
 		TEST_CONFIGURATIONS_EXPECTED = "${testConfigurationsExpected}"
 	}
 	stages {
-	  stage('Setup intial configuration'){
-          steps {
-                  sshagent(['github-bot-ssh']) {
-                      dir ('eclipse.platform.releng.aggregator') {
-                        sh '''
-                            git clone -b master git@github.com:eclipse-platform/eclipse.platform.releng.aggregator.git
-                        '''
-                      }
-                    }
+		stage('Setup intial configuration'){
+			steps {
 				dir("${CJE_ROOT}") {
                     sh '''
                         chmod +x mbscripts/*

--- a/JenkinsJobs/JobDSL.json
+++ b/JenkinsJobs/JobDSL.json
@@ -2,4 +2,7 @@
     "Streams": [
         "4.35"
     ],
+	"Branches": {
+		"4.35": "master"
+	}
 }

--- a/JenkinsJobs/YBuilds/FOLDER.groovy
+++ b/JenkinsJobs/YBuilds/FOLDER.groovy
@@ -6,6 +6,7 @@ folder('YPBuilds') {
 }
 
 for (STREAM in config.Streams){
+	def BRANCH = config.Branches[STREAM]
 
 	pipelineJob('YPBuilds/Y-build-' + STREAM){
 		description('Daily Maintenance Builds.')
@@ -32,7 +33,7 @@ for (STREAM in config.Streams){
 			cpsScm {
 				lightweight(true)
 				scm {
-					github('eclipse-platform/eclipse.platform.releng.aggregator', 'master')
+					github('eclipse-platform/eclipse.platform.releng.aggregator', BRANCH)
 				}
 				scriptPath('JenkinsJobs/Builds/build.jenkinsfile')
 			}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -184,8 +184,9 @@ The release is scheduled for 10AM EST. Typically the jobs are scheduled beforeha
 #### **Update Jenkins for the next Release:**
   - Edit the [JobDSL.json](JenkinsJobs/JobDSL.json)
       * Add the next release version to the `Streams` key item.
+      * In the `branches` item update the current release to map to the maintenance branch and add a new key:value pair mapping the next release to master.
   - Run the [Create Jobs](https://ci.eclipse.org/releng/job/Create%20Jobs/) job in Jenkins.  
-    This should create new I-builds for the next release.
+    This should move the current I-builds to run on the maintenance branch and create new I-builds for the next release.
     Performance and Unit tests should also be generated for the new release automatically.
 
 #### **Create new Stream Repos:**


### PR DESCRIPTION
and restore ability to define I/Y-builds jobs for other branches, only through the job definition.
This ability was lost for I-builds in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2709. For maintenance branches the `build.jenkinsfile` would have to be modified directly, like it is done for Y- and P-builds.

Furthermore use the error() step instead of throwing an 'IllegalStateException' because the latter doesn't always seem to be permitted.