### PR TITLE
[Build] Fix Y-Build test result collection

### DIFF
--- a/JenkinsJobs/YBuilds/collectYbuildResults.groovy
+++ b/JenkinsJobs/YBuilds/collectYbuildResults.groovy
@@ -26,9 +26,6 @@ job('YPBuilds/ep-collectYbuildResults'){
     timeout {
       absolute(30)
     }
-    xvnc {
-      useXauthority()
-    }
     withAnt {
       installation('apache-ant-latest')
       jdk('openjdk-jdk17-latest')
@@ -78,7 +75,7 @@ ssh genie.releng@projects-storage.eclipse.org rm -rf ${workspace}/eclipse
 
 #get requisite tools
 ssh genie.releng@projects-storage.eclipse.org wget -O ${workspace}/collectTestResults.xml https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.releng.aggregator/master/cje-production/scripts/collectTestResults.xml
-ssh genie.releng@projects-storage.eclipse.org wget -O ${workspace}/publish.xml https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.releng.aggregator/master/cje-production/Y-build/publish.xml
+ssh genie.releng@projects-storage.eclipse.org wget -O ${workspace}/publish.xml https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.releng.aggregator/master/cje-production/scripts/publish.xml
 
 cd ${WORKSPACE}
 git clone https://github.com/eclipse-platform/eclipse.platform.releng.aggregator.git


### PR DESCRIPTION
Don't use xvnc, which is not available on the 'basic' agent and also not necessary (for a headless build task) [1].
Use The unified  'cje-production/scripts/publish.xml' ANT script. The script customized for Y-builds is not necessary anymore since [2].
Follow-up for
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2611 [1]
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2693 [2]