### PR TITLE
[Build] Fix invocation of 'PublishToMaven' job from I-build job

### DIFF
--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -373,7 +373,7 @@ spec:
 				}
 			}
 			steps {
-				build job: 'Releng/PublishToMaven', parameters: [choice(name: 'snapshotOrRelease', value: 'snapshot')], wait: false
+				build job: 'Releng/PublishToMaven', parameters: [string(name: 'snapshotOrRelease', value: '-snapshot')], wait: false
 			}
 		}
 	}

--- a/JenkinsJobs/Releng/publishToMaven.jenkinsfile
+++ b/JenkinsJobs/Releng/publishToMaven.jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
 	environment {
 		REPO = "${WORKSPACE}/repo-${BUILD_NUMBER}"
 	}
+	// parameters declared in the definition of the invoking job
 	stages {
 		stage('Aggregate Maven repository') {
 			steps {


### PR DESCRIPTION
Restore the previous (correct) definition of the 'snapshotOrRelease' parameter.

Follow-up on
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2718