### PR TITLE
[Build] Apply best practices to Maven artifact singing and use BC-signer

### DIFF
--- a/JenkinsJobs/Releng/publishToMaven.jenkinsfile
+++ b/JenkinsJobs/Releng/publishToMaven.jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
 		PATH = "${installMavenDaemon('1.0.2')}/bin:${PATH}"
 		// Folder ~/.m2 is not writable for builds, ensure mvnd metadata are written within the workspace.
 		// prevent jline warning about inability to create a system terminal and increase keep-alive timeouts to increase stability in concurrent usage
-		MVND = "mvnd -Dmvnd.daemonStorage=${WORKSPACE}/tools/mvnd -Dorg.jline.terminal.type=dumb -Dmvnd.keepAlive=1000 -Dmvnd.maxLostKeepAlive=100"
+		MVND = "mvnd -Dmvnd.daemonStorage=${WORKSPACE}/tools/mvnd -Dorg.jline.terminal.type=dumb -Dmvnd.keepAlive=1000 -Dmvnd.maxLostKeepAlive=600"
 		ECLIPSE = "${installLatestEclipse()}"
 		URL_AGG_UPDATES = 'https://download.eclipse.org/cbi/updates/p2-aggregator/products/nightly/latest'
 	}
@@ -174,15 +174,11 @@ pipeline {
 							// The location of the temporarily file that contains the secret file content
 							// (see https://www.jenkins.io/doc/book/pipeline/syntax/#supported-credentials-type):
 							KEYRING = credentials("secret-subkeys-${PROJECT == 'platform' ? 'releng': PROJECT}.asc")
+							MAVEN_GPG_PASSPHRASE = credentials("secret-subkeys-${PROJECT == 'platform' ? 'releng': PROJECT}.asc-passphrase")
 						}
 						steps {
 							dir("publish-${PROJECT}"){
 								sh '''#!/bin/sh -xe
-									gpg --batch --import "${KEYRING}"
-									for fpr in $(gpg --list-keys --with-colons  | awk -F: '/fpr:/ {print $10}' | sort -u); do
-										echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key ${fpr} trust
-									done
-									
 									# Copy configuration pom into clean directory to stop maven from finding the .mvn folder of this git-repository
 									cp "${WORKSPACE}/git-repo/eclipse-platform-parent/pom.xml" eclipse-parent-pom.xml
 									
@@ -240,6 +236,7 @@ pipeline {
 									
 										${MVND} -f eclipse-parent-pom.xml -s ${SETTINGS} \\
 											gpg:sign-and-deploy-file -DretryFailedDeploymentCount=5 \\
+											-Dgpg.signer=bc -Dgpg.keyFilePath=${KEYRING} \\
 											-Durl=${URL} -DrepositoryId=${REPO_ID} \\
 											-DpomFile=${pomFile} -Dfile=${file} \\
 											${SOURCES_ARG} ${JAVADOC_ARG}

--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -714,6 +714,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>
           <version>3.2.7</version>
+          <configuration>
+            <bestPractices>true</bestPractices>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Passing the 'MAVEN_GPG_PASSPHRASE' as environment variable fixes many build warnings:
'''
 [WARNING] Do not store passphrase in any file (disk or SCM repository),
 [WARNING] instead rely on GnuPG agent or provide passphrase in
 [WARNING] MAVEN_GPG_PASSPHRASE environment variable for batch mode.
'''
Additionally using the Bouncy Castle (BC) signer is not only faster but also simplifies the setup as it can use the keyring in armored form and thus avoids the import step.