### PR TITLE
Exclude deprecations in lucene.core from reporting

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
@@ -8,6 +8,7 @@ org.apache.commons.codec
 org.objectweb.asm
 org.apache.commons.commons-io
 biz.aQute.bndlib
+org.apache.lucene.core
 
 ## SPECIAL CASE FOR SWT: THE FRAGMENT IS ANALYZED AS PART OF THE HOST
 org.eclipse.swt.win32.win32.x86_64


### PR DESCRIPTION
Fixes the
org.apache.lucene.core(10.1.0)
DEPRECATED	org.apache.lucene.search.TopFieldCollectorManager#TopFieldCollectorManager(Sort, int, FieldDoc, int, boolean)
DEPRECATED	org.apache.lucene.search.TopScoreDocCollectorManager#TopScoreDocCollectorManager(int, ScoreDoc, int, boolean)
DEPRECATED	org.apache.lucene.util.Version#LUCENE_9_12_0 in e.g. https://download.eclipse.org/eclipse/downloads/drops4/I20250108-0430/apitools/deprecation/apideprecation.html