### PR TITLE
Exclude commons-beanutils from deprecation report

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
@@ -9,6 +9,7 @@ org.objectweb.asm
 org.apache.commons.commons-io
 biz.aQute.bndlib
 org.apache.lucene.core
+org.apache.commons.commons-beanutils
 
 ## SPECIAL CASE FOR SWT: THE FRAGMENT IS ANALYZED AS PART OF THE HOST
 org.eclipse.swt.win32.win32.x86_64


### PR DESCRIPTION
We should not report 3rd party deprecations as there is no API promise for them.
Fixes commons-beanutils appearing in the report after https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/commit/d9a1570180e013c7b4fe208a9ccc035cd27cf3e6