### PR TITLE
[Build] Launch EnrichPom.java as source program in Maven publication

### DIFF
--- a/JenkinsJobs/Releng/publishToMaven.jenkinsfile
+++ b/JenkinsJobs/Releng/publishToMaven.jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
 		label 'basic'
 	}
 	tools {
-		jdk 'temurin-jdk21-latest'
+		jdk 'temurin-jdk23-latest'
 		maven 'apache-maven-latest'
 	}
 	environment {
@@ -71,20 +71,9 @@ pipeline {
 					#   - organization
 					#   - issue management
 					
-					ENRICH_POMS_JAR=${WORKSPACE}/work/EnrichPoms.jar
-					ENRICH_POMS_PACKAGE=org.eclipse.platform.releng.maven.pom
-					
-					#TODO: Just launch as multi-file source-code program as soon as Java-22 or later is used: https://openjdk.org/jeps/458
-					# build the jar:
-					mkdir -p ${WORKSPACE}/work/bin
-					javac -d "${WORKSPACE}/work/bin" $(find "${MAVEN_PUBLISH_BASE}/src" -name \\*.java)
-					pushd "${WORKSPACE}/work/bin"
-					jar --create --verbose --main-class=${ENRICH_POMS_PACKAGE}.EnrichPoms --file=${ENRICH_POMS_JAR} $(find * -name \\*.class)
-					popd
-					ls -l ${ENRICH_POMS_JAR}
-					
+					enrichPomsSourceFile="${MAVEN_PUBLISH_BASE}/src/org/eclipse/platform/releng/maven/pom/EnrichPoms.java"
 					set -x
-					java -jar ${ENRICH_POMS_JAR} ${REPO}/org/eclipse/{platform,jdt,pde}
+					java ${enrichPomsSourceFile} ${REPO}/org/eclipse/{platform,jdt,pde}
 					set +x
 					
 					echo "==== Add Javadoc stubs ===="


### PR DESCRIPTION
This leverages the ability to launch multi-file source-code programs add in Java-22 via JEP-458:
- https://openjdk.org/jeps/458

Technically it's not a problem to use JDK-23 or 24 (as soon as it's released) in this internal part of the build, yet I still hesitate with this because I worry a bit that it might be forgotten to update the JDK tool as soon as the non-LTS releases are out of maintenance since we usually don't use them anywhere else and it's therefore not on our TODO-list.