### PR TITLE
[Build] Remove unnecessary 'gpg.passphrase' property in master build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,7 +91,6 @@ pipeline {
 						-DskipTests=true \
 						-Dcompare-version-with-baselines.skip=false \
 						-DapiBaselineTargetDirectory=${WORKSPACE} \
-						-Dgpg.passphrase="${KEYRING_PASSPHRASE}" \
 						-Dcbi-ecj-version=99.99 \
 						-U
 				'''


### PR DESCRIPTION
Removing that property definition was forgotten in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2140