### PR TITLE
Stop trying to copy chkpii files

### DIFF
--- a/production/testScripts/configuration/sdk.tests/testScripts/test.xml
+++ b/production/testScripts/configuration/sdk.tests/testScripts/test.xml
@@ -1441,16 +1441,6 @@
     name="relEng"
     depends="init">
     <runTests testPlugin="org.eclipse.releng.tests" />
-    <move
-      todir="${results}/chkpii"
-      includeEmptyDirs="no"
-      failonerror="false">
-      <fileset dir="${results}/chkpii" />
-      <mapper
-        type="glob"
-        from="*"
-        to="${testedPlatform}_*" />
-    </move>
   </target>
 
  <target


### PR DESCRIPTION
These have not been generated for years (since builds not running internally at IBM).