### PR TITLE
[Build] Fix signing of the artifact-checksums list on download page

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/extras/produceChecksum.sh
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/extras/produceChecksum.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -13,115 +13,39 @@
 #     David Williams - initial API and implementation
 #*******************************************************************************
 #
-# this localBuildProperties.shsource file is to ease local builds to
-# override some variables.
-# It should not be used for production builds.
-source localBuildProperties.shsource 2>/dev/null
-
 echo "[DEBUG] Producing checksums starting"
 echo "[DEBUG] current directory: ${PWD}"
-if [[ -z "${SCRIPT_PATH}" ]]
-then
-  echo -e "\n\tWARNING: SCRIPT_PATH not defined in ${0##*/}"
-else
-  source "${SCRIPT_PATH}/bashUtilities.shsource"
-  checkSumStart="$(date +%s )"
-fi
-
-# This checkSums script is called twice, once while publishing Eclipse DL site, again
-# when publishing Equinox DL site. We use a simple heuristic to
-# make use of "eclipse" or "equinox".
-# TODO: better design to require it to be passed in?
-currentDirectory="${PWD}"
-equinoxPattern="^.*equinox.*$"
-eclipsePattern="^.*eclipse.*$"
-if [[ "${currentDirectory}" =~ $equinoxPattern ]]
-then
-  client="equinox"
-elif [[ "${currentDirectory}" =~ $eclipsePattern ]]
-then
-  client="eclipse"
-else
-  echo -e "\n\t[ERROR]: Unknown client: ${client} in ${0##*/}\n"
-  exit 1
-fi
 
 allCheckSumsSHA512=checksum/${client}-${BUILD_ID}-SUMSSHA512
+fileExtensionsToHash='zip dmg gz tar.xz jar'
 
 #  Remove the "all" files, here at beginning if they all ready exist,
 #  so that subsequent calls can all use append (i.e. ">>")
 
-rm ${allCheckSumsSHA512}
+rm -f ${allCheckSumsSHA512}
 
-#array of zipfiles
-zipfiles=`ls *.zip`
-
-for zipfile in ${zipfiles}
-do
-  # There is one zip file to not list, eclipse.platform.releng.aggregator-<hash>.zip, which is merely
-  # a collected utility scripts used to run unit tests.
-  aggrPattern="^eclipse.platform.releng.aggregator.*.zip$"
-  if [[ ! "${zipfile}" =~ $aggrPattern ]]
-  then
-    echo [sha512] ${zipfile}
-    sha512sum -b ${zipfile} | tee checksum/${zipfile}.sha512  >>${allCheckSumsSHA512}
-  fi
-done
-
-#array of dmgfiles
-dmgfiles=`ls *.dmg`
-
-for dmgfile in ${dmgfiles}
-do
-  echo [sha512] ${dmgfile}
-  sha512sum -b ${dmgfile} | tee checksum/${dmgfile}.sha512  >>${allCheckSumsSHA512}
-done
-
-#array of tar.gzip files
-gzipfiles=`ls *.gz`
-
-for gzipfile in ${gzipfiles}
-do
-  echo [sha512] ${gzipfile}
-  sha512sum -b ${gzipfile} | tee checksum/${gzipfile}.sha512 >>${allCheckSumsSHA512}
-done
-
-#array of tar.xz files
-xzfiles=`ls *.tar.xz`
-
-for xzfile in ${xzfiles}
-do
-  echo [sha512] ${xzfile}
-  sha512sum -b ${xzfile} | tee checksum/${xzfile}.sha512 >>${allCheckSumsSHA512}
-done
-
-
-#array of .jar files
-jarfiles=`ls *.jar`
-
-for jarfile in ${jarfiles}
-do
-  echo [sha512] ${jarfile}
-  sha512sum -b ${jarfile} | tee checksum/${jarfile}.sha512 >>${allCheckSumsSHA512}
+for extension in ${fileExtensionsToHash}; do
+  files=$(ls *.${extension})
+  for file in ${files}; do
+    # There is one zip file to not list, eclipse.platform.releng.aggregator-<hash>.zip, which is merely
+    # a collected utility scripts used to run unit tests.
+    aggrPattern="^eclipse.platform.releng.aggregator.*.zip$"
+    if [[ ! "${file}" =~ $aggrPattern ]]; then
+      echo [sha512] ${file}
+      sha512sum -b ${file} | tee checksum/${file}.sha512 >>${allCheckSumsSHA512}
+    fi
+  done
 done
 
 # We'll always try to sign checksum files, if passphrase file exists
 echo "[DEBUG] Producing GPG signatures starting."
-# We make double use of the "client". One to simplify signing script. Second to identify times in timefile.
-# remember, this "WORKSPACE" is for genie.releng for production builds.
+set -e
 if [ ! -z "${KEYRING_PASSPHRASE}" ]
 then
-    signature_file512=${allCheckSumsSHA512}.asc
-    gpg --detach-sign --armor --output ${signature_file512} --batch --yes --passphrase-fd 0 ${allCheckSumsSHA512} <<< "${KEYRING_PASSPHRASE}"
+    gpg --detach-sign --armor --output ${allCheckSumsSHA512}.asc --batch --pinentry-mode loopback --passphrase-fd 0 ${allCheckSumsSHA512} <<< "${KEYRING_PASSPHRASE}"
 else
     # We don't treat as ERROR since would be normal in a "local build".
     # But, would be an ERROR in production build so could be improved.
     echo -e "\n\t[WARNING] The key_passphrase_file did not exist or was not readable.\n"
-fi
-# if SCRIPT_PATH not defined, we can not call elapsed time
-if [[ -n "${SCRIPT_PATH}" ]]
-then
-  checkSumEnd="$(date +%s )"
-  elapsedTime $checkSumStart $checkSumEnd "${client} Elapsed Time computing checksums"
 fi
 echo "[DEBUG] Producing checksums ended normally"

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/helper.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/helper.xml
@@ -30,6 +30,7 @@
       executable="/bin/bash"
       dir="${buildDirectory}">
       <arg line="${EBuilderDir}/eclipse/extras/produceChecksum.sh" />
+      <env key="client" value="eclipse"/>
     </exec>
 
     <!--get static files required in the buildLabel directory -->

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/templateFiles/buildproperties.phpHoldForLocalTests
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/templateFiles/buildproperties.phpHoldForLocalTests
@@ -31,7 +31,6 @@ $REPO_AND_ACCESS = "file:///gitroot";
 $MAVEN_BREE = "-Pbree-libs";
 $GIT_PUSH = "echo no git push done since Nightly";
 $LOCAL_REPO = "/shared/eclipse/builds/4N/localMavenRepo";
-$SCRIPT_PATH = "/shared/eclipse/builds/4N/production";
 $STREAMS_PATH = "/shared/eclipse/builds/4N/gitCache/eclipse.platform.releng.aggregator/streams";
 $CBI_JDT_REPO_URL = "";
 $CBI_JDT_REPO_URL_ARG = "";

--- a/eclipse.platform.releng.tychoeclipsebuilder/equinox/helper.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/equinox/helper.xml
@@ -90,6 +90,7 @@
       executable="/bin/bash"
       dir="${equinoxPostingDirectory}/${buildDir}">
       <arg line="${EBuilderDir}/eclipse/extras/produceChecksum.sh" />
+      <env key="client" value="equinox"/>
     </exec>
 
 

--- a/eclipse.platform.releng.tychoeclipsebuilder/equinox/publishingFiles/templateFiles/index.template.php
+++ b/eclipse.platform.releng.tychoeclipsebuilder/equinox/publishingFiles/templateFiles/index.template.php
@@ -22,8 +22,11 @@
   $generateChecksumLinks = 'generateChecksumLinks';
   $buildlabel = "$EQ_BUILD_DIR_SEG";
   $sums512file = "checksum/equinox-$BUILD_ID-SUMSSHA512";
-  if (file_exists($sums512file)) {
+  $sums512file_asc = $sums512file.".asc";
+  if ((file_exists($sums512file)) && (file_exists($sums512file_asc))) {
       $gpgchecksumline = "<p style=\"text-indent: 3em;\"><a href=\"$sums512file\">SHA512 Checksums for $BUILD_ID</a>&nbsp;(<a href=\"$sums512file.asc\">GPG</a>)</p>";
+  } else if (file_exists($sums512file)) {
+      $gpgchecksumline = "<p style=\"text-indent: 3em;\"><a href=\"$sums512file\">SHA512 Checksums for $BUILD_ID</a>";
   }
   $html = <<<EOHTML
 


### PR DESCRIPTION
The checksum signature is gone since:
https://archive.eclipse.org/eclipse/downloads/drops4/R-4.16-202006040540/

This is caused by a failure in the signing process because recent versions of GPG ask for the passphrase via a dialog by default. In order obtain it through a environment variable one has disable pinentry using: --pinentry-mode loopback

- Remove unnecessary specification of '--yes' option.
- Remove attempt to read 'bashUtilities.shsource' as it seems to have been gone in general.
- specify the 'client' through a environment variable in the caller