### PR TITLE
[I/Y-Build] Simplify GPG-signing in I/Y-builds

### DIFF
--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -97,24 +97,6 @@ spec:
 				}
 			}
 		}
-	  stage('Load PGP keys'){
-          environment {
-                KEYRING = credentials('secret-subkeys-releng.asc')
-                KEYRING_PASSPHRASE = credentials('secret-subkeys-releng.asc-passphrase')
-          }
-          steps {
-				dir("${CJE_ROOT}/mbscripts") {
-                sh '''
-                    ./mb011_loadPGPKeys.sh 2>&1 | tee $logDir/mb011_loadPGPKeys.sh.log
-                    if [[ ${PIPESTATUS[0]} -ne 0 ]]
-                    then
-                        echo "Failed in Load PGP keys"
-                        exit 1
-                    fi
-                '''
-				}
-			}
-		}
 		stage('Export environment variables stage 1'){
 			steps {
 				script {

--- a/JenkinsJobs/YBuilds/P_build.groovy
+++ b/JenkinsJobs/YBuilds/P_build.groovy
@@ -105,25 +105,6 @@ spec:
                 }
             }
 		}
-	  stage('Load PGP keys'){
-          environment {
-                KEYRING = credentials('secret-subkeys-releng.asc')
-                KEYRING_PASSPHRASE = credentials('secret-subkeys-releng.asc-passphrase')
-          }
-          steps {
-              container('jnlp') {
-                sh \'\'\'
-                    cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
-                    ./mb011_loadPGPKeys.sh 2>&1 | tee $logDir/mb011_loadPGPKeys.sh.log
-                    if [[ ${PIPESTATUS[0]} -ne 0 ]]
-                    then
-                        echo "Failed in Load PGP keys"
-                        exit 1
-                    fi
-                \'\'\'
-                }
-            }
-		}
 	  stage('Export environment variables stage 1'){
           steps {
               container('jnlp') {

--- a/cje-production/P-build/mb220_buildSdkPatch.sh
+++ b/cje-production/P-build/mb220_buildSdkPatch.sh
@@ -39,6 +39,7 @@ mvn -f eclipse.platform.releng.tychoeclipsebuilder/${PATCH_OR_BRANCH_LABEL}/pom.
   -Dtycho.debug.artifactcomparator \
   -Dtycho.localArtifacts=ignore \
   -Dcbi.jarsigner.continueOnFail=true \
+  -Dtycho.pgp.signer=bc -Dtycho.pgp.signer.bc.secretKeys="${KEYRING}" \
   -Djgit.dirtyWorkingTree=error \
   -Dmaven.repo.local=$LOCAL_REPO \
   -Djava.io.tmpdir=$CJE_ROOT/$TMP_DIR \

--- a/cje-production/mbscripts/mb011_loadPGPKeys.sh
+++ b/cje-production/mbscripts/mb011_loadPGPKeys.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-#import gpg keys
-gpg --batch --import "${KEYRING}"
-for fpr in $(gpg --list-keys --with-colons  | awk -F: '/fpr:/ {print $10}' | sort -u);
-do
-  echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${fpr}" trust;
-done

--- a/cje-production/mbscripts/mb220_buildSdkPatch.sh
+++ b/cje-production/mbscripts/mb220_buildSdkPatch.sh
@@ -36,6 +36,7 @@ mvn clean verify -DskipTests=true ${MVN_ARGS} \
   -Dtycho.debug.artifactcomparator \
   -Dtycho.localArtifacts=ignore \
   -Dcbi.jarsigner.continueOnFail=true \
+  -Dtycho.pgp.signer=bc -Dtycho.pgp.signer.bc.secretKeys="${KEYRING}" \
   -Djgit.dirtyWorkingTree=error \
   -Dmaven.repo.local=$LOCAL_REPO \
   -Djava.io.tmpdir=$CJE_ROOT/$TMP_DIR \

--- a/eclipse.platform.releng.tychoeclipsebuilder/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/pom.xml
@@ -42,8 +42,6 @@
 					<artifactId>tycho-gpg-plugin</artifactId>
 					<version>${tycho.version}</version>
 					<configuration>
-						<signer>bc</signer>
-						<keyname>b6d3ab9bcc641282</keyname>
 						<skipIfJarsigned>false</skipIfJarsigned>
 						<skipIfJarsignedAndAnchored>true</skipIfJarsignedAndAnchored>
 						<pgpKeyBehavior>skip</pgpKeyBehavior>


### PR DESCRIPTION
Importing the secret-key is not necessary when signing with the bouncy-castle signer. Therefore just import the key where the `gpg` executable is used (i.e. when signing the list of artifact checksums).
