### PR TITLE
[I/Y/P-Build] Various minos clean-ups of I/Y/P-Builds

### DIFF
--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -142,7 +142,7 @@ spec:
 	  stage('Clone Repositories'){
           steps {
 				dir("${CJE_ROOT}/mbscripts") {
-                  sshagent(['git.eclipse.org-bot-ssh', 'github-bot-ssh']) {
+                  sshagent(['github-bot-ssh']) {
                     sh '''
                         git config --global user.email "eclipse-releng-bot@eclipse.org"
                         git config --global user.name "Eclipse Releng Bot"
@@ -163,7 +163,7 @@ spec:
           }
           steps {
 				dir("${CJE_ROOT}/mbscripts") {
-                  sshagent (['git.eclipse.org-bot-ssh', 'github-bot-ssh', 'projects-storage.eclipse.org-bot-ssh']) {
+                  sshagent (['github-bot-ssh', 'projects-storage.eclipse.org-bot-ssh']) {
                     sh '''
                         bash -x ./mb110_tagBuildInputs.sh $CJE_ROOT/buildproperties.shsource 2>&1 | tee $logDir/mb110_tagBuildInputs.sh.log
                         if [[ ${PIPESTATUS[0]} -ne 0 ]]

--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -196,8 +196,6 @@ spec:
           steps {
 				dir("${CJE_ROOT}/mbscripts") {
                     sh '''
-                        unset JAVA_TOOL_OPTIONS 
-                        unset _JAVA_OPTIONS
                         ./mb220_buildSdkPatch.sh $CJE_ROOT/buildproperties.shsource 2>&1 | tee $logDir/mb220_buildSdkPatch.sh.log
                         if [[ ${PIPESTATUS[0]} -ne 0 ]]
                         then
@@ -248,8 +246,6 @@ spec:
           steps {
 				dir("${CJE_ROOT}/mbscripts") {
                       sh '''
-                        unset JAVA_TOOL_OPTIONS 
-                        unset _JAVA_OPTIONS
                         ./mb500_createRepoReports.sh $CJE_ROOT/buildproperties.shsource 2>&1 | tee $logDir/mb500_createRepoReports.sh.log
                         if [[ ${PIPESTATUS[0]} -ne 0 ]]
                         then
@@ -264,8 +260,6 @@ spec:
           steps {
 				dir("${CJE_ROOT}/mbscripts") {
                       sh '''
-                        unset JAVA_TOOL_OPTIONS 
-                        unset _JAVA_OPTIONS
                         ./mb510_createApiToolsReports.sh $CJE_ROOT/buildproperties.shsource 2>&1 | tee $logDir/mb510_createApiToolsReports.sh.log
                         if [[ ${PIPESTATUS[0]} -ne 0 ]]
                         then

--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -284,15 +284,10 @@ spec:
                 sh '''
                     source $CJE_ROOT/buildproperties.shsource
                     cp -r $logDir/* $CJE_ROOT/$DROP_DIR/$BUILD_ID/buildlogs
-                    rm -rf $logDir
                     rm -rf $CJE_ROOT/$DROP_DIR/$BUILD_ID/apitoolingreference
-                    cp $CJE_ROOT/buildproperties.txt $CJE_ROOT/$DROP_DIR/$BUILD_ID
-                    cp $CJE_ROOT/buildproperties.php $CJE_ROOT/$DROP_DIR/$BUILD_ID
-                    cp $CJE_ROOT/buildproperties.properties $CJE_ROOT/$DROP_DIR/$BUILD_ID
-                    cp $CJE_ROOT/buildproperties.shsource $CJE_ROOT/$DROP_DIR/$BUILD_ID
+                    cp $CJE_ROOT/buildproperties.* $CJE_ROOT/$DROP_DIR/$BUILD_ID
                     cp $CJE_ROOT/$DROP_DIR/$BUILD_ID/buildproperties.* $CJE_ROOT/$EQUINOX_DROP_DIR/$BUILD_ID
                 '''
-              archiveArtifacts '**/siteDir/**'
             }
 		}
 	  stage('Promote Eclipse platform'){
@@ -354,11 +349,13 @@ spec:
 		}
 	}
 	post {
+		always {
+			archiveArtifacts 'cje-production/siteDir/**'
+		}
 		failure {
 			emailext subject: "${RELEASE_VER} ${BUILD_TYPE}-Build: ${BUILD_IID} - BUILD FAILED",
 				body: "Please go to ${BUILD_URL}console and check the build failure.", mimeType: 'text/plain',
 				to: "${BUILD.mailingList}", from:'genie.releng@eclipse.org'
-			archiveArtifacts "${CJE_ROOT}/siteDir/eclipse/downloads/drops4/${BUILD_IID}/gitLog.html, $CJE_ROOT/gitCache/eclipse.platform.releng.aggregator"
 		}
 		success {
 			emailext subject: "${RELEASE_VER} ${BUILD_TYPE}-Build: ${BUILD_IID} ${COMPARATOR_ERRORS_SUBJECT}",

--- a/JenkinsJobs/YBuilds/P_build.groovy
+++ b/JenkinsJobs/YBuilds/P_build.groovy
@@ -171,8 +171,6 @@ spec:
               container('jnlp') {
                     sh \'\'\'
                         cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
-                        unset JAVA_TOOL_OPTIONS 
-                        unset _JAVA_OPTIONS
                         ./mb220_buildSdkPatch.sh $CJE_ROOT/buildproperties.shsource 2>&1 | tee $logDir/mb220_buildSdkPatch.sh.log
                         if [[ ${PIPESTATUS[0]} -ne 0 ]]
                         then

--- a/JenkinsJobs/YBuilds/P_build.groovy
+++ b/JenkinsJobs/YBuilds/P_build.groovy
@@ -208,11 +208,6 @@ spec:
                 }
             }
         }
-	  stage('Archive artifacts'){
-          steps {
-              archiveArtifacts '**/siteDir/**'
-            }
-		}
 	  stage('Promote Update Site'){
           steps {
               container('jnlp') {
@@ -227,6 +222,9 @@ spec:
 		}
 	}
 	post {
+		always {
+			archiveArtifacts 'cje-production/siteDir/**'
+		}
         failure {
             emailext body: "Please go to <a href='${BUILD_URL}console'>${BUILD_URL}console</a> and check the build failure.<br><br>",
             subject: "${env.RELEASE_VER.trim()} P-Build: ${env.BUILD_IID.trim()} - BUILD FAILED", 

--- a/JenkinsJobs/YBuilds/P_build.groovy
+++ b/JenkinsJobs/YBuilds/P_build.groovy
@@ -118,7 +118,7 @@ spec:
 	  stage('Clone Repositories'){
           steps {
               container('jnlp') {
-                  sshagent(['git.eclipse.org-bot-ssh', 'github-bot-ssh']) {
+                  sshagent(['github-bot-ssh']) {
                     sh \'\'\'
                         git config --global user.email "eclipse-releng-bot@eclipse.org"
                         git config --global user.name "Eclipse Releng Bot"
@@ -137,7 +137,7 @@ spec:
 	  stage('Tag Build Inputs'){
           steps {
               container('jnlp') {
-                  sshagent (['git.eclipse.org-bot-ssh', 'github-bot-ssh', 'projects-storage.eclipse.org-bot-ssh']) {
+                  sshagent (['github-bot-ssh', 'projects-storage.eclipse.org-bot-ssh']) {
                     sh \'\'\'
                         cd ${WORKSPACE}/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/mbscripts
                         bash -x ./mb110_tagBuildInputs.sh $CJE_ROOT/buildproperties.shsource 2>&1 | tee $logDir/mb110_tagBuildInputs.sh.log


### PR DESCRIPTION
1. Remove unnecessary 'unset' of empty environment variables
2. Remove use of obsolete SSH-agent for git.eclipse.org
3. Unify and fix artifact archiving and make it more specific
  The archiving step in case of build-failures resulted in no artifacts being archived.