### PR TITLE
[Build] Fix and unify invocations of 'update-download-index' job

### DIFF
--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -298,7 +298,7 @@ spec:
                         ./mb600_promoteEclipse.sh $CJE_ROOT/buildproperties.shsource
                       '''
                   }
-                build job: 'eclipse.releng.updateIndex', wait: false
+                build job: 'Releng/updateIndex', wait: false
 				}
 			}
 		}

--- a/JenkinsJobs/Builds/markStable.groovy
+++ b/JenkinsJobs/Builds/markStable.groovy
@@ -86,7 +86,7 @@ job('Builds/markStable'){
 
   publishers {
     downstreamParameterized {
-      trigger('updateIndex') {
+      trigger('Releng/updateIndex') {
         condition('SUCCESS')
         triggerWithNoParameters(true)
       }

--- a/JenkinsJobs/Builds/markUnstable.groovy
+++ b/JenkinsJobs/Builds/markUnstable.groovy
@@ -93,7 +93,7 @@ job('Builds/markUnstable'){
 
   publishers {
     downstreamParameterized {
-      trigger('updateIndex') {
+      trigger('Releng/updateIndex') {
         condition('SUCCESS')
         triggerWithNoParameters(true)
       }

--- a/JenkinsJobs/Releng/makeVisible.groovy
+++ b/JenkinsJobs/Releng/makeVisible.groovy
@@ -52,7 +52,7 @@ ${WORKSPACE}/makeVisible.sh
 
   publishers {
     downstreamParameterized {
-      trigger('updateIndex') {
+      trigger('Releng/updateIndex') {
         triggerWithNoParameters(true)
       }
     }


### PR DESCRIPTION
Update or fix all invocations of a 'update-download-index' job to invoke `Releng/updateIndex`, because its definition is under version-control. The other previously referenced jobs are either manually defined/maintained (with equal definition) or don't exist.

This fixes the index-update for the `Mark (Un)Stable` and `Make Visible` job and allows to delete the manually defined `eclipse.releng.updateIndex` job:
- https://ci.eclipse.org/releng/job/eclipse.releng.updateIndex/