### PR TITLE
Add new profile dependency-check to verify dependency ranges

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -890,6 +890,26 @@
       </repositories>
     </profile>
     <profile>
+       <id>dependency-check</id>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>tycho-baseline-plugin</artifactId>
+                    <version>${tycho.version}</version>
+                    <executions>
+                        <execution>
+                            <id>check-dependencies</id>
+                            <goals>
+                                <goal>check-dependencies</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </build>
+    </profile>
+    <profile>
        <id>api-check</id>
        <activation>
          <activeByDefault>false</activeByDefault>


### PR DESCRIPTION
Tycho has a [new mojo to check dependency ranges](https://github.com/eclipse-tycho/tycho/blob/main/RELEASE_NOTES.md#new-check-dependencies-mojo) this adds a new profile `dependency-check` to activate / execute this mojo, currently this is just the plugin execution itself but we maybe later add more options when things evolve.