### PR TITLE
Do not generate deprecation report for bouncycastle jars

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
@@ -10,6 +10,8 @@ org.apache.commons.commons-io
 biz.aQute.bndlib
 org.apache.lucene.core
 org.apache.commons.commons-beanutils
+bcpg
+bcprov
 
 ## SPECIAL CASE FOR SWT: THE FRAGMENT IS ANALYZED AS PART OF THE HOST
 org.eclipse.swt.win32.win32.x86_64


### PR DESCRIPTION
In latest I-build report there are:
```
bcpg(1.80.0)
DEPRECATED	org.bouncycastle.openpgp.operator.PublicKeyKeyEncryptionMethodGenerator#WILDCARD
DEPRECATED	org.bouncycastle.openpgp.operator.PublicKeyKeyEncryptionMethodGenerator#PublicKeyKeyEncryptionMethodGenerator
setUseWildcardKeyID(boolean)
bcprov(1.80.0)
DEPRECATED	org.bouncycastle.asn1.x509.DeltaCertificateDescriptor#ASN1Sequence
getValidity()
DEPRECATED	org.bouncycastle.asn1.x509.DeltaCertificateDescriptor#DeltaCertificateDescriptor
trimTo(TBSCertificate, Extensions)
DEPRECATED	org.bouncycastle.asn1.x509.ExtensionsGenerator#void
addExtension(Extensions)
DEPRECATED	org.bouncycastle.crypto.digests.AsconDigest
DEPRECATED	org.bouncycastle.crypto.digests.AsconXof
DEPRECATED	org.bouncycastle.crypto.engines.AsconEngine
```
seen at https://download.eclipse.org/eclipse/downloads/drops4/I20250121-1800/apitools/deprecation/apideprecation.html .
Report should be limited to our own bundles.