### PR TITLE
Skip PR creation if no report was produced

### DIFF
--- a/.github/workflows/checkDependencies.yml
+++ b/.github/workflows/checkDependencies.yml
@@ -93,6 +93,7 @@ jobs:
           mvn -B -ntp ${{ inputs.maven-goals }} -DskipTests -Pdependency-check -Dtycho.dependency.check.apply=true
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
+        if: ${{ hashFiles(${{ matrix.bundles }}/target/versionProblems.md) != '' }} 
         with:
           commit-message: Update version ranges of dependencies for ${{ matrix.bundles }}
           branch: dependency-check/${{ matrix.bundles }}


### PR DESCRIPTION
Currently the job fails for bundles that do not generate a report, as this is not an error, we skip the PR creation if the step did not created any report.