### PR TITLE
Use current i build API tools

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -906,6 +906,9 @@
                                      <url>${previous-release.baseline}</url>
                                  </repository>
                              </baselines>
+                             <apiToolsRepository>
+                                <url>https://download.eclipse.org/eclipse/updates/4.35-I-builds/</url>>
+                             </apiToolsRepository>
                              <skip>${skipAPIAnalysis}</skip>
                              <skipIfReplaced>false</skipIfReplaced>
                              <logDirectory>${compileLogDir}</logDirectory>


### PR DESCRIPTION
Since a while we have new API Tools check in the IDE and there where no complains, so it seems time to enable this in the verification builds as well to capture potential problems before the final release.