### PR TITLE
Add jsvg 1.7.0 to eclipse-sdk target

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -94,6 +94,12 @@
 	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="error" type="Maven">
 		  <dependencies>
 			  <dependency>
+				  <groupId>com.github.weisj</groupId>
+				  <artifactId>jsvg</artifactId>
+				  <version>1.7.0</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
 				  <groupId>com.google.code.gson</groupId>
 				  <artifactId>gson</artifactId>
 				  <version>2.12.1</version>


### PR DESCRIPTION
Required for
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/1638

Contributes to
- https://github.com/eclipse-platform/eclipse.platform.swt/issues/1438