### PR TITLE
Exclude Apache Httpclient 4 from deprecation reports

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
@@ -12,6 +12,9 @@ org.apache.lucene.core
 org.apache.commons.commons-beanutils
 bcpg
 bcprov
+org.apache.httpcomponents.client5.httpclient5
+org.apache.httpcomponents.core5.httpcore5
+org.apache.httpcomponents.core5.httpcore5-h2
 
 ## SPECIAL CASE FOR SWT: THE FRAGMENT IS ANALYZED AS PART OF THE HOST
 org.eclipse.swt.win32.win32.x86_64


### PR DESCRIPTION
Cleans up the report which is today
(https://download.eclipse.org/eclipse/downloads/drops4/I20250123-1800/apitools/deprecation/apideprecation.html ) mostly deprecations from this project.
Report should contain only bundles developed by the project.