### PR TITLE
Add support for supply extra maven args

### DIFF
--- a/.github/workflows/checkVersions.yml
+++ b/.github/workflows/checkVersions.yml
@@ -11,6 +11,11 @@ on:
         description: The name of the bot that adds the necessary version increment changes
         type: string
         required: true
+      extra-maven-args:
+        description: Additional arguments to the maven call
+        type: string
+        required: false
+        default: ''
 
 permissions: {} # all none
 
@@ -42,7 +47,7 @@ jobs:
         attempt_delay: 200
         attempt_limit: 10
         command: >
-          mvn verify -DskipTests -Dcompare-version-with-baselines.skip=false
+          mvn verify ${{ inputs.extra-maven-args }} -DskipTests -Dcompare-version-with-baselines.skip=false
           org.eclipse.tycho:tycho-versions-plugin:bump-versions -Dtycho.bump-versions.increment=100
           --threads 1C --fail-at-end --batch-mode --no-transfer-progress --show-version
 


### PR DESCRIPTION
That way it should be possible to use it for equinox by using:

`extra-maven-args: '-f bundles'`

then at laest it will already work for the bundles (that don't seem to need the binary repo), also useful for other use cases (e.g. enable extra checks or similar)