### PR TITLE
Make Update target a shared workflow and move configuration into pom

### DIFF
--- a/.github/workflows/README.MD
+++ b/.github/workflows/README.MD
@@ -41,3 +41,35 @@ It checks all artifacts that match the provided range and suggest a lower bound 
 Workflow that could be used as a timed action to check if any automatic code cleanup can be performed.
 Actions to perform must be defined in the configuration of the [quickfix-and-cleanup-mojo](https://github.com/eclipse-tycho/tycho/blob/main/RELEASE_NOTES.md#new-quickfix-and-cleanup-mojo)
 that is called by this action. For this purpose it uses the follwoing execution ids `cleanups` and `quickfixes`
+
+## updateTarget.yml
+
+A Workflow that automatically checks a target file for updates of its dependencies.
+
+It has the follwoing inputs:
+- author - desired commit author / email 
+- token - token to use to create the PR while this action can work with the default github token, it is recommended to use a PAT if used as a timed action because otherwhise PR checks can't run, see [here](https://github.com/marketplace/actions/create-pull-request#token) for details.
+- path - path to a project that contains the target to update
+
+and exspect that the pom configures an execution named `update-target` for its configuration, or otherwhise is running with the defaults. 
+An example might look like this:
+
+```
+<plugin>
+  <groupId>org.eclipse.tycho.extras</groupId>
+  <artifactId>tycho-version-bump-plugin</artifactId>
+  <version>${tycho.version}</version>
+  <executions>
+    <execution>
+        <id>update-target</id>
+        <configuration>
+            <allowMajorUpdates>false</allowMajorUpdates>
+            <updateSiteDiscovery>parent</updateSiteDiscovery>
+            <mavenRulesUri>${project.basedir}/update-rules.xml</mavenRulesUri>
+        </configuration>
+    </execution>
+  </executions>
+</plugin>
+```
+
+See the [tycho-version-bump:update-target](https://tycho.eclipseprojects.io/doc/latest/tycho-extras/tycho-version-bump-plugin/update-target-mojo.html) for further details.

--- a/.github/workflows/callUpdateTarget.yml
+++ b/.github/workflows/callUpdateTarget.yml
@@ -1,0 +1,25 @@
+name: Check for Target Platform updates
+
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 */2 * * *'
+  push:
+    branches:
+      - master
+    paths:
+      - '**.target'
+
+
+jobs:
+  update:
+    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/updateTarget.yml@master
+    with:
+      author: Eclipse Releng Bot <releng-bot@eclipse.org>
+      path: 'eclipse.platform.releng.prereqs.sdk'
+    secrets:
+      token: ${{ secrets.RELENG_BOT_PAT }}

--- a/.github/workflows/updateTarget.yml
+++ b/.github/workflows/updateTarget.yml
@@ -1,18 +1,21 @@
 name: Update Target Platform
 
-concurrency: 
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
-
 on:
-  workflow_dispatch:
-  schedule:
-    - cron:  '0 0 * * *'
-  push:
-    branches:
-      - master
-    paths:
-      - '**.target'
+  workflow_call:
+    inputs:
+      author:
+        description: Defines the committer / author that should be used for the commit
+        required: false
+        type: string
+        default: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+      path:
+        description: Defines the committer / author that should be used for the commit
+        required: true
+        type: string
+    secrets:
+      token:
+        description: Personal Access Token to use for creating pull-requests
+        required: true
 jobs:
   update:
     runs-on: ubuntu-latest
@@ -33,11 +36,8 @@ jobs:
         cache: maven
     - name: Update Target Platform
       run: >-
-          mvn -ntp -f eclipse.platform.releng.prereqs.sdk 
-          org.eclipse.tycho.extras:tycho-version-bump-plugin:4.0.9:update-target
-          -DallowMajorUpdates=false
-          -Ddiscovery=parent
-          -Dmaven.version.rules=update-rules.xml
+          mvn -ntp -f ${{ inputs.path }} 
+          tycho-version-bump:update-target@update-target
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
       with:
@@ -47,8 +47,8 @@ jobs:
         body: Please review the changes and merge if appropriate, or cherry pick individual updates.
         delete-branch: true
         draft: false
-        token: ${{ secrets.RELENG_BOT_PAT }}
-        committer: Eclipse Releng Bot <releng-bot@eclipse.org>
-        author: Eclipse Releng Bot <releng-bot@eclipse.org>
+        token: ${{ secrets.token }}
+        committer: ${{ inputs.author }}
+        author: ${{ inputs.author }}
         add-paths: |
             **/*.target

--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -533,6 +533,24 @@
           <version>${tycho.version}</version>
         </plugin>
         <plugin>
+          <groupId>org.eclipse.tycho.extras</groupId>
+          <artifactId>tycho-version-bump-plugin</artifactId>
+          <version>${tycho.version}</version>
+          <executions>
+            <execution>
+                <id>update-target</id>
+                <configuration>
+                    <allowMajorUpdates>false</allowMajorUpdates>
+                    <mavenRulesUri>${project.basedir}/update-rules.xml</mavenRulesUri>
+                    <updateSiteDiscovery>
+                        <strategy>parent</strategy>
+                        <strategy>versionPattern:ecf/(\d+)\.(\d+).(\d+)/site.p2/(.*$)</strategy>
+                    </updateSiteDiscovery>
+                </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-cleancode-plugin</artifactId>
           <version>${tycho.version}</version>


### PR DESCRIPTION
The workflow to update the target file is quite convenient and proven to work well.

This now moves the configuration into the pom and makes the workflow a shared one so it can be used in other projects easily.