### PR TITLE
Modify ECF setup to eliminate API errors

### DIFF
--- a/oomph/Platform.setup
+++ b/oomph/Platform.setup
@@ -539,16 +539,6 @@
         </workingSet>
       </setupTask>
       <setupTask
-          xsi:type="setup:TextModifyTask"
-          excludedTriggers="BOOTSTRAP"
-          url="${github.clone.ecf.location|uri}/framework/bundles/org.eclipse.ecf.ssl/META-INF/MANIFEST.MF"
-          encoding="ISO-8859-1">
-        <modification
-            pattern="(Bundle-Version: 1.3.100.qualifier)">
-          <substitution>Bundle-Version: 1.4.0.qualifier</substitution>
-        </modification>
-      </setupTask>
-      <setupTask
           xsi:type="setup:ResourceCreationTask"
           excludedTriggers="BOOTSTRAP"
           targetURL="${github.clone.ecf.location|uri}/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclientjava/.settings/.api_filters"
@@ -595,6 +585,16 @@
           &lt;/component>
 
         </content>
+      </setupTask>
+      <setupTask
+          xsi:type="setup:TextModifyTask"
+          excludedTriggers="BOOTSTRAP"
+          url="${github.clone.ecf.location|uri}/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclientjava/META-INF/MANIFEST.MF"
+          encoding="ISO-8859-1">
+        <modification
+            pattern="(org.eclipse.ecf.internal.provider.filetransfer.httpclientjava;version=&quot;1\.0\.0&quot;)">
+          <substitution>org.eclipse.ecf.internal.provider.filetransfer.httpclientjava;version=&quot;1.1.0&quot;</substitution>
+        </modification>
       </setupTask>
       <stream
           name="master"


### PR DESCRIPTION
- Remove the ssl text modification because the ssl projects are no longer imported.