### PR TITLE
Install more jvms for the cleancode action

### DIFF
--- a/.github/workflows/cleanCode.yml
+++ b/.github/workflows/cleanCode.yml
@@ -89,7 +89,11 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
         with:
-          java-version: '21'
+          java-version: |
+            8
+            11
+            17
+            21
           distribution: 'temurin'
           cache: maven
       - name: Perform Cleanups on ${{ matrix.bundles }} 


### PR DESCRIPTION
Currently we only have a Java 21 VM for the cleancode action but JDT works best with a real JVM (especially for those without a release option like Java 8), so this one install some more so they are available at the toolchains and can be discovered by Tycho to setup a JDT JRE in the cleanups.