### PR TITLE
[I-Build-Tests] Revert to installed temurin-jdk23-latest for Linux-J23

### DIFF
--- a/JenkinsJobs/AutomatedTests/I_unit_tests.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_tests.groovy
@@ -3,7 +3,7 @@ def STREAMS = config.Streams
 
 def TEST_CONFIGURATIONS = [
 	[os: 'linux' , ws:'gtk'  , arch: 'x86_64' , javaVersion: 21, agentLabel: 'ubuntu-2404'        , javaHome: "tool(type:'jdk', name:'temurin-jdk21-latest')" ],
-	[os: 'linux' , ws:'gtk'  , arch: 'x86_64' , javaVersion: 23, agentLabel: 'ubuntu-2404'        , javaHome: "installTemurinJDK('23', 'linux', 'x86_64', 'ea')" ],
+	[os: 'linux' , ws:'gtk'  , arch: 'x86_64' , javaVersion: 23, agentLabel: 'ubuntu-2404'        , javaHome: "tool(type:'jdk', name:'temurin-jdk23-latest')" ],
 	[os: 'macosx', ws:'cocoa', arch: 'aarch64', javaVersion: 21, agentLabel: 'nc1ht-macos11-arm64', javaHome: "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11-arm64/Contents/Home'" ],
 	[os: 'macosx', ws:'cocoa', arch: 'x86_64' , javaVersion: 21, agentLabel: 'nc1ht-macos11-arm64', javaHome: "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11/Contents/Home'" ],
 	[os: 'win32' , ws:'win32', arch: 'x86_64' , javaVersion: 21, agentLabel: 'qa6xd-win11'        , javaHome: "'C:\\\\Program Files\\\\Eclipse Adoptium\\\\jdk-21.0.5.11-hotspot'" ],


### PR DESCRIPTION
See also https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5603

@jukzi this relates to https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1664 respectively https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2523 doesn't it? 
