### PR TITLE
[Y-Build] Use latest Y-build repository as baseline for comparison

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -817,6 +817,19 @@
       </repositories>
     </profile>
     <profile>
+      <id>jdt-y-build</id>
+      <activation>
+        <property>
+          <name>env.BUILD_TYPE</name>
+          <value>Y</value>
+        </property>
+      </activation>
+      <properties>
+        <!-- Use latest Y-build instead of I-build repo as comparator-baseline for Y-builds -->
+        <comparator.repo>https://download.eclipse.org/eclipse/updates/${releaseVersion}-Y-builds</comparator.repo>
+      </properties>
+    </profile>
+    <profile>
       <id>eclipse-sign</id>
       <build>
         <plugins>


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2793