### PR TITLE
[Build] Remove unused 'partial-build' Maven profile

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -883,21 +883,6 @@
       </build>
     </profile>
     <profile>
-      <id>partial-build</id>
-      <activation>
-        <property>
-          <name>eclipse-sdk-repo.url</name>
-        </property>
-      </activation>
-      <repositories>
-        <repository>
-          <id>eclipse-sdk-repo</id>
-          <url>${eclipse-sdk-repo.url}</url>
-          <layout>p2</layout>
-        </repository>
-      </repositories>
-    </profile>
-    <profile>
        <id>dependency-check</id>
         <build>
             <plugins>


### PR DESCRIPTION
Nowadays the 'build-individual-bundles' profile seems to be used for partial builds in sub-projects.
And there are no references to the removed profile nor the property referenced in it within the Eclipse SDK.