### PR TITLE
Add Docker image to build natives with older dependencies

### DIFF
--- a/JenkinsJobs/Builds/DockerImagesBuild.jenkinsfile
+++ b/JenkinsJobs/Builds/DockerImagesBuild.jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
 					dir('eclipse.platform.releng.aggregator/cje-production/dockerfiles') {
 						parallel(
 							'debian-swtnative': { buildAndPushImage('debian/swtnativebuild', 'eclipse/platformreleng-debian-swtnativebuild:12') },
+							'debian-swtgtk3native': { buildAndPushImage('debian/swtgtk3nativebuild', 'eclipse/platformreleng-debian-swtgtk3nativebuild:10') },
 							'centos9-gtk4': { buildAndPushImage('centos-gtk4-mutter/9-gtk4', 'eclipse/platformreleng-centos-gtk4-mutter:9') },
 							'opensuse-gtk3': { buildAndPushImage('opensuse-gtk3-metacity/15-gtk3', 'eclipse/platformreleng-opensuse-gtk3-metacity:15') },
 						failFast: false)

--- a/cje-production/dockerfiles/debian/swtgtk3nativebuild/Dockerfile
+++ b/cje-production/dockerfiles/debian/swtgtk3nativebuild/Dockerfile
@@ -1,0 +1,37 @@
+FROM debian:10
+
+### user name recognition at runtime w/ an arbitrary uid - for OpenShift deployments
+COPY scripts/uid_entrypoint /usr/local/bin/uid_entrypoint
+RUN chmod u+x /usr/local/bin/uid_entrypoint && \
+    chgrp 0 /usr/local/bin/uid_entrypoint && \
+    chmod g=u /usr/local/bin/uid_entrypoint /etc/passwd
+### end
+
+ENV LANG=en_US.UTF-8
+RUN apt-get update -qq && apt-get install -qq -y \
+      locales \
+      build-essential \
+      procps \
+      git \
+      libgtk-3-dev \
+      freeglut3-dev \
+      webkit2gtk-driver
+
+# There is purposefully no JDK in this image. If a particular build needs JDK it installs
+# it in the Jenkinsfile.
+
+ENV HOME=/home/swtbuild
+ENV DISPLAY :0
+RUN useradd -u 10001 -d ${HOME} testuser
+
+RUN mkdir -p /var/lib/dbus && dbus-uuidgen > /var/lib/dbus/machine-id \
+  && mkdir -p /var/run/dbus
+
+# Make $HOME open to the 'root' group (so Jenkins/OpenShift user can write there)
+WORKDIR $HOME
+RUN chgrp -R 0 ${HOME} && chmod -R g=u ${HOME}
+
+RUN localedef -i en_US -f UTF-8 en_US.UTF-8
+ENV LANG=en_US.UTF-8
+
+USER 10001

--- a/cje-production/dockerfiles/debian/swtgtk3nativebuild/scripts/uid_entrypoint
+++ b/cje-production/dockerfiles/debian/swtgtk3nativebuild/scripts/uid_entrypoint
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+if ! whoami > /dev/null 2>&1; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
+  fi
+fi
+exec "$@"


### PR DESCRIPTION
To verify locally that this built a suitable eclipse/eclise*.so:

1. Add `USER 1000` to end of Dockerfile
2. in dir of Dockerfile `docker build --pull -t swtgtk3nativebuild .`
3. `EQUINOX=/scratch/eclipse/oomph/swt-master/git/equinox`
4. `LIBRARY_GTK=$EQUINOX/features/org.eclipse.equinox.executable.feature/library/gtk`
5. `docker run --rm -it -v$EQUINOX:$EQUINOX -w$LIBRARY_GTK swtgtk3nativebuild make -f make_linux.mak`
6. `make -f make_linux.mak install EXE_OUTPUT_DIR=#### LIB_OUTPUT_DIR=####`
8. Test eclipse works
7. run `objdump -R` on the exe and so to ensure no new glibc symbols

I don't know how to verify this on the build machine. Do we just merge it so that new images are available

Prerequisite of https://github.com/eclipse-equinox/equinox/issues/830