### PR TITLE
Include org.eclipse.equinox.slf4j in the repository

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
@@ -45,4 +45,5 @@
    <bundle id="org.eclipse.unittest.ui.source"/>
    <bundle id="jakarta.annotation-api" version="1.3.5"/>
    <bundle id="jakarta.inject.jakarta.inject-api" version="1.0.5"/>
+   <bundle id="org.eclipse.equinox.slf4j"/>
 </site>


### PR DESCRIPTION
... but not in the product ...

This way it can be installed from the site but is not available by default.