### PR TITLE
Exclude JUnit bundles from deprecation report

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
@@ -15,6 +15,9 @@ bcprov
 org.apache.httpcomponents.client5.httpclient5
 org.apache.httpcomponents.core5.httpcore5
 org.apache.httpcomponents.core5.httpcore5-h2
+junit-jupiter-api
+junit-platform-commons
+junit-platform-engine
 
 ## SPECIAL CASE FOR SWT: THE FRAGMENT IS ANALYZED AS PART OF THE HOST
 org.eclipse.swt.win32.win32.x86_64


### PR DESCRIPTION
Cleans irrelevant entries as can be seen at
https://download.eclipse.org/eclipse/downloads/drops4/I20250305-1800/apitools/deprecation/apideprecation.html