### PR TITLE
Split releaseYear in its own property in parent

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -44,6 +44,8 @@
     <buildId>${buildType}${buildTimestamp}</buildId>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+	<!-- releaseYear is used in copyright statements, etc.-->
+    <releaseYear>2025</releaseYear>
      <!--
       releaseName should match the yearly "release train" name.
       For example, "Mars", "Mars.1", "Luna SR2", etc.
@@ -51,7 +53,7 @@
       such as Version: Mars (4.5), for main features.
       See bug 328139.
     -->
-    <releaseName>2025-06</releaseName>
+    <releaseName>${releaseYear}-06</releaseName>
     <releaseVersion>4.36</releaseVersion>
     <!--
       The releaseNumbers below, for SDK and Platform, might be


### PR DESCRIPTION
Needed in order to reduce hard coded years (e.g. in generated javadoc).