### PR TITLE
Set copyright year to release year in javadoc

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/META-INF/MANIFEST.MF
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.doc.isv; singleton:=true
-Bundle-Version: 3.14.2700.qualifier
+Bundle-Version: 3.14.2800.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.2.0,4.0.0)"

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.doc.isv</artifactId>
-  <version>3.14.2700-SNAPSHOT</version>
+  <version>3.14.2800-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <profiles>
@@ -174,7 +174,7 @@
                         <windowtitle>Eclipse JDT API Specification</windowtitle>
                         <doctitle>Eclipse JDT API Specification</doctitle>
                         <header><![CDATA[<span style='font-size:small'><b>Eclipse JDT</b><br>${releaseName} (${releaseNumberSDK})</span>]]></header>
-                        <bottom><![CDATA[<br><span style='font-size:small;float:right'>Copyright (c) 2000, 2023 Eclipse Contributors and others. All rights reserved.</span><span style='font-size:small'><a href='{@docRoot}/../misc/api-usage-rules.html'>Guidelines for using Eclipse APIs.</a></span>]]></bottom>
+                        <bottom><![CDATA[<br><span style='font-size:small;float:right'>Copyright (c) 2000, ${releaseYear} Eclipse Contributors and others. All rights reserved.</span><span style='font-size:small'><a href='{@docRoot}/../misc/api-usage-rules.html'>Guidelines for using Eclipse APIs.</a></span>]]></bottom>
                         <sourcepath>${eclipse.jdt.core}/org.eclipse.jdt.annotation/src
                                     ;${eclipse.jdt.core}/org.eclipse.jdt.core.compiler.batch/src
                                     ;${eclipse.jdt.core}/org.eclipse.jdt.apt.core/src

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
@@ -472,7 +472,7 @@
                         <windowtitle>Eclipse Platform API Specification</windowtitle>
                         <doctitle>Eclipse Platform API Specification</doctitle>
                         <header><![CDATA[<span style='font-size:small'><b>Eclipse Platform</b><br>${releaseName} (${releaseNumberSDK})</span>]]></header>
-                        <bottom><![CDATA[<br><span style='font-size:small;float:right'>Copyright (c) 2000, 2023 Eclipse Contributors and others. All rights reserved.</span><span style='font-size:small'><a href='{@docRoot}/../misc/api-usage-rules.html'>Guidelines for using Eclipse APIs.</a></span>]]></bottom>
+                        <bottom><![CDATA[<br><span style='font-size:small;float:right'>Copyright (c) 2000, ${releaseYear} Eclipse Contributors and others. All rights reserved.</span><span style='font-size:small'><a href='{@docRoot}/../misc/api-usage-rules.html'>Guidelines for using Eclipse APIs.</a></span>]]></bottom>
                         <sourcepath>;${eclipse.platform.ui.bundles}/org.eclipse.ltk.core.refactoring/src
                                 ;${eclipse.platform.ui.bundles}/org.eclipse.ltk.ui.refactoring/src
                                 ;${eclipse.pde}/org.eclipse.pde/src


### PR DESCRIPTION
Using https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2897 it will remove the need to update it (which has been forgotten during the whole 2024 - it's still 2023 in our 2025-03 release).