### PR TITLE
Publish 4.35 to maven central

### DIFF
--- a/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr
+++ b/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr
@@ -2,10 +2,10 @@
 <aggregator:Aggregation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="SDK4Mvn" packedStrategy="UNPACK_AS_SIBLING" type="R" mavenResult="true" versionFormat="MavenRelease" includeSources="true">
   <validationSets label="main">
     <contributions label="sdk">
-      <repositories enabled="false" location="/home/data/httpd/download.eclipse.org/eclipse/updates/4.36-I-builds"/>
+      <repositories enabled="false" location="/home/data/httpd/download.eclipse.org/eclipse/updates/4.35/R-4.35-202502280140"/>
     </contributions>
     <contributions label="sdk_http">
-      <repositories location="https://download.eclipse.org/eclipse/updates/4.36-I-builds"/>
+      <repositories location="https://download.eclipse.org/eclipse/updates/4.35/R-4.35-202502280140"/>
     </contributions>
   </validationSets>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="aarch64"/>


### PR DESCRIPTION
Publish to Maven central 4.35

Update SDK4Mvn.aggr file (`properties.sh` file was removed in a previous commit related to updating maven job https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/commit/a999440157c01973facfce4e69c48d19fe0d3961)

Refs: https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2889

cc/ @MohananRahul @merks 
