### PR TITLE
Increase MAVEN_OPTS = '-Xmx3300m' to avoid out-of-memory building war

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
 		jdk 'temurin-jdk21-latest'
 	}
 	environment {
-		MAVEN_OPTS = '-Xmx3G'
+		MAVEN_OPTS = '-Xmx3300m'
 	}
 	stages {
 		stage('Use master') {


### PR DESCRIPTION
- The infocenter war is building in parallel typically with infocenter product assembly and this randomly runs out of heap space, so with a little more heap available we should avoid this problem.