### PR TITLE
Fix checkCompositesValidity

### DIFF
--- a/JenkinsJobs/Releng/checkCompositesValidity.groovy
+++ b/JenkinsJobs/Releng/checkCompositesValidity.groovy
@@ -6,7 +6,7 @@ job('Releng/checkCompositesValidity'){
     daysToKeep(15)
   }
 
-  jdk('adoptopenjdk-hotspot-jdk11-latest')
+  jdk('temurin-jdk21-latest')
 
   label('basic')
 
@@ -31,7 +31,7 @@ job('Releng/checkCompositesValidity'){
 
   publishers {
     extendedEmail {
-      recipientList("sravankumarl@in.ibm.com")
+      recipientList("platform-releng-dev@eclipse.org")
     }
   }
   


### PR DESCRIPTION
Has been failing since "June 12, 2024" but went unnoticed as it was sending mails to Sravan only.
Problem was it tried to run with Java 11 but now Java 21 and during the whole period Java 17 was needed.