### PR TITLE
Use buildtools snapshots

### DIFF
--- a/cje-production/buildproperties.txt
+++ b/cje-production/buildproperties.txt
@@ -45,7 +45,7 @@ BASEBUILD_ID="R-4.35-202502280140"
 #release id for downloading eclipse
 PREVIOUS_RELEASE_ID="R-4.35-202502280140"
 
-BUILDTOOLS_REPO="https://download.eclipse.org/eclipse/updates/buildtools/"
+BUILDTOOLS_REPO="https://download.eclipse.org/eclipse/updates/buildtools/snapshots"
 WEBTOOLS_REPO="https://download.eclipse.org/webtools/downloads/drops/R3.36.0/R-3.36.0-20241110095156/repositoryunittests/"
 BASEBUILDER_DIR="tmp/org.eclipse.releng.basebuilder"
 ECLIPSE_RUN_REPO="https://download.eclipse.org/eclipse/updates/4.36-I-builds/"


### PR DESCRIPTION
With https://github.com/eclipse-platform/eclipse.platform.releng.buildtools/pull/83 latest build of buildtools is deployed to
https://download.eclipse.org/eclipse/updates/buildtools/snapshots/ . At https://download.eclipse.org/eclipse/updates/buildtools/ there is composite repo but maintenance of it broke with missing Java 21 on downloads as scripts run serverside.
This is the simplest and fastest way to put us back in the game.