### PR TITLE
Add SWT SVG fragment to SDK tests feature

### DIFF
--- a/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
@@ -387,4 +387,8 @@
          id="org.eclipse.update.configurator.tests"
          version="0.0.0"/>
 
+   <plugin
+         id="org.eclipse.swt.svg"
+         version="0.0.0"/>
+
 </feature>


### PR DESCRIPTION
The SVG fragment needs to be available in SDK tests product as SWT tests require that fragment and the SDK does not currently not include it.