### PR TITLE
Reduce noise in the build output

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--XX:+PrintFlagsFinal
+


### PR DESCRIPTION
These extra outputs clutter the build output and make it harder to find and analyze problems.
Such options should be enable temporarily when issue is analyzed and removed after that.