### PR TITLE
Add JSVG bundle to SDK tests feature

### DIFF
--- a/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
@@ -391,4 +391,8 @@
          id="org.eclipse.swt.svg"
          version="0.0.0"/>
 
+   <plugin
+         id="com.github.weisj.jsvg"
+         version="0.0.0"/>
+
 </feature>


### PR DESCRIPTION
The SVG fragment needs to be available in SDK tests product as SWT tests require that fragment and the SDK does not currently not include it. The transitive dependency to the JSVG bundle has been missing and is added by this change.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/1944