### PR TITLE
Add more bundles for which to not show deprecations

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
@@ -31,3 +31,5 @@ org.eclipse.jetty.server
 org.eclipse.jetty.servlet
 org.eclipse.jetty.util.ajax
 org.eclipse.jetty.util
+org.eclipse.jetty.ee8.server
+org.mortbay.jasper.apache-jsp


### PR DESCRIPTION
Based on content of
https://download.eclipse.org/eclipse/downloads/drops4/I20250403-1800/apitools/deprecation/apideprecation.html , these jetty bundles are not something the project can claim API stability thus excluding from the list.