### PR TITLE
Remove jacoco profile

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -1020,37 +1020,6 @@
     </profile>
 
     <profile>
-      <id>coverage</id>
-      <properties>
-        <!-- Since we append output of various tests, write to a common folder besides tests -->
-        <!-- it's recommended to override that to an absolute value in specific Hudson configurations
-          and Sonar integration -->
-        <jacoco.destFile>${project.basedir}/../target/jacoco.exec</jacoco.destFile>
-        <sonar.jacoco.reportPath>${jacoco.destFile}</sonar.jacoco.reportPath>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.12</version>
-            <executions>
-              <execution>
-                <id>jacoco-agent</id>
-                <goals>
-                  <goal>prepare-agent</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <append>true</append>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
       <id>checkstyle</id>
       <build>
         <plugins>


### PR DESCRIPTION
It's not used and only generates churn in the repo to keep jacoco plugin uptodate (as in
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2965 )