### PR TITLE
Stop quering gtk version using rpm

### DIFF
--- a/production/testScripts/configuration/sdk.tests/testScripts/runtests.sh
+++ b/production/testScripts/configuration/sdk.tests/testScripts/runtests.sh
@@ -27,12 +27,9 @@ then
   echo "ERROR: No JVM define, or the defined one was found to not be executable"
   exit 1
 fi
-#Extract GTK Version and host name
-gtkVersion=$(rpm -q gtk3|cut -d- -f2)
 
 echo "Jvm        : ${jvm}"
 echo "Host       : $(hostname)"
-echo "GTK Version: ${gtkVersion}"
 
 stableEclipseInstallLocation=${stableEclipseInstallLocation:-${WORKSPACE}/workarea/${buildId}/eclipse-testing/platformLocation/}
 # Note: test.xml will "reinstall" fresh install of what we are testing,


### PR DESCRIPTION
Tests no longer run on rpm distribution so this effectively removes "rpm: command not found" and empty "GTK Version: " output from tests consolelog (e.g.
https://download.eclipse.org/eclipse/downloads/drops4/I20250409-1800/testresults/consolelogs/ep436I-unit-linux-x86_64-java24_linux.gtk.x86_64_24_consolelog.txt ).
As nobody probably knew about this output I am not looking into converting it to dpkg command but remove the output altogether. It is simpler to run the command (commands as one may need also glib, webkitgtk, glibc, pango, etc. versions) in dedicated Jenkins job to figure out whatever info is needed.