### PR TITLE
[Build] Remove definition PLUGIN_PATH system-property for I-build tests

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse-junit-tests/src/main/scripts/library.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse-junit-tests/src/main/scripts/library.xml
@@ -66,8 +66,6 @@
 
             test-output   - overrides default output file produced from test run. [May not currently override default?]
 
-            plugin-path   - path to root of plug-in
-
             useEclipseExe - property setting forces test to launch via eclipse executable. [Not fully supported. See bug 387638.]
 
             junit-report-output - output directory for junit reports produced for specified classname.
@@ -149,9 +147,6 @@
             value="" />
         <property
             name="extraVMargs"
-            value="" />
-        <property
-            name="plugin-path"
             value="" />
 
       <property
@@ -271,9 +266,6 @@
             <arg value="-junitReportOutput" />
             <arg path="${junit-report-output}" />
             <jvmarg line="${frameworkvmargs} ${loglocation} ${vmargs} ${extraVMargs} ${frameworkperfargs}" />
-            <sysproperty
-                key="PLUGIN_PATH"
-                value="${plugin-path}" />
             <env
                 key="ECLIPSE_I_BUILD_TEST"
                 value="true"/>
@@ -339,7 +331,7 @@
             <arg line="-nosplash" />
             <arg line="--launcher.suppressErrors" />
             <arg line="${consolelog}" />
-            <arg line="-vmargs ${frameworkvmargs} ${loglocation} ${vmargs} ${extraVMargs} -DPLUGIN_PATH=${plugin-path}" />
+            <arg line="-vmargs ${frameworkvmargs} ${loglocation} ${vmargs} ${extraVMargs}" />
         </exec>
         <antcall target="collect-results" />
     </target>

--- a/eclipse.platform.releng/bundles/org.eclipse.releng.tests/META-INF/MANIFEST.MF
+++ b/eclipse.platform.releng/bundles/org.eclipse.releng.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.releng.tests;singleton:=true
-Bundle-Version: 3.6.600.qualifier
+Bundle-Version: 3.6.700.qualifier
 Eclipse-BundleShape: dir
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/eclipse.platform.releng/bundles/org.eclipse.releng.tests/pom.xml
+++ b/eclipse.platform.releng/bundles/org.eclipse.releng.tests/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.releng.tests</artifactId>
-  <version>3.6.600-SNAPSHOT</version>
+  <version>3.6.700-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <testSuite>${project.artifactId}</testSuite>

--- a/eclipse.platform.releng/bundles/org.eclipse.releng.tests/test.xml
+++ b/eclipse.platform.releng/bundles/org.eclipse.releng.tests/test.xml
@@ -227,10 +227,6 @@
         name="classname"
         value="org.eclipse.releng.tests.BuildTests" />
       <property
-        name="plugin-path"
-        value="${eclipse-home}/plugins/${org.eclipse.releng.tests}" />
-      
-      <property
         name="vmargs"
         value="-DdownloadHost=${downloadHost} -DbuildId=${buildId}"  />
     </ant>


### PR DESCRIPTION
All usages of the `PLUGIN_PATH` system-property have been removed and that property and it's definition ANT property `plugin-path` can be removed.

This is the completion of the following PRs that have made the final removals of remaining usages of the `PLUGIN_PATH` system-property:
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2024
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2039
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/2931
