### PR TITLE
[Build] Always run Eclipse at the storage-server with Java-21

### DIFF
--- a/JenkinsJobs/Builds/markBuild.groovy
+++ b/JenkinsJobs/Builds/markBuild.groovy
@@ -69,7 +69,7 @@ pipeline {
 						
 						#triggering ant runner
 						baseBuilderDir=${workspace}/eclipse
-						javaCMD=/opt/public/common/java/openjdk/jdk-17_x64-latest/bin/java
+						javaCMD=/opt/public/common/java/openjdk/jdk-21_x64-latest/bin/java
 						
 						launcherJar=$(ssh genie.releng@projects-storage.eclipse.org find ${baseBuilderDir}/. -name "org.eclipse.equinox.launcher_*.jar" | sort | head -1 )
 						

--- a/cje-production/mbscripts/mb620_promoteUpdateSite.sh
+++ b/cje-production/mbscripts/mb620_promoteUpdateSite.sh
@@ -25,7 +25,7 @@ source $1
 epUpdateDir=/home/data/httpd/download.eclipse.org/eclipse/updates
 dropsPath=${epUpdateDir}/${STREAMMajor}.${STREAMMinor}-${BUILD_TYPE}-builds
 latestRelDir=/home/data/httpd/download.eclipse.org/eclipse/downloads/drops4
-java_home=/opt/public/common/java/openjdk/jdk-17_x64-latest/bin
+java_home=/opt/public/common/java/openjdk/jdk-21_x64-latest/bin
 
 pushd $CJE_ROOT/$UPDATES_DIR
 scp -r ${BUILD_ID} genie.releng@projects-storage.eclipse.org:${dropsPath}/.

--- a/cje-production/promotion/makeVisible.sh
+++ b/cje-production/promotion/makeVisible.sh
@@ -181,7 +181,7 @@ then
 
   #triggering ant runner
   baseBuilderDir=${workspace}/eclipse
-  javaCMD=/opt/public/common/java/openjdk/jdk-17_x64-latest/bin/java
+  javaCMD=/opt/public/common/java/openjdk/jdk-21_x64-latest/bin/java
 
   launcherJar=$(ssh genie.releng@projects-storage.eclipse.org find ${baseBuilderDir}/. -name "org.eclipse.equinox.launcher_*.jar" | sort | head -1 )
 

--- a/production/testScripts/updateTestResultsPages.sh
+++ b/production/testScripts/updateTestResultsPages.sh
@@ -101,10 +101,6 @@ then
   exit 1
 fi
 
-JAVA_11_HOME=${JAVA_11_HOME:-/opt/public/common/java/openjdk/jdk-11_x64-latest}
-
-export JAVA_HOME=${JAVA_HOME:-${JAVA_11_HOME}}
-
 devJRE=$JAVA_HOME/jre/bin/java
 
 if [[ ! -n ${devJRE} && -x ${devJRE} ]]


### PR DESCRIPTION
Adding a new I-build to the I-build composite seems to not work at the moment and running Eclipse to perform the addition with Java-17 although the Eclipse-SDK/Platform products now require Java-21 could be a cause.

A Java-21 JDK was installed via
- https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5780

I'm not entirely sure the addition started to fail with the latest I-build, but after running the [Mark Stable](https://ci.eclipse.org/releng/job/Builds/job/markStable/) job, modified to use Java-21, it worked. Running it explicitly previously with Java-17 didn't add the build to the composite.
Maybe this was also just a caching issue at the storage-server, but still this change should be applied.