### PR TITLE
Add FreeBSD platforms' build.

### DIFF
--- a/cje-production/dockerfiles/alpine/freebsd-cross/Dockerfile
+++ b/cje-production/dockerfiles/alpine/freebsd-cross/Dockerfile
@@ -1,0 +1,137 @@
+# syntax=docker/dockerfile:1
+
+ARG BASE_IMAGE_NAME="alpine"
+ARG BASE_IMAGE_TAG="3.19"
+
+ARG FREEBSD_VERSION_MAJOR="14"
+ARG FREEBSD_VERSION_MINOR="2"
+ARG FREEBSD_TARGET="amd64"
+ARG FREEBSD_TARGET_ARCH="amd64"
+ARG FREEBSD_VERSION="${FREEBSD_VERSION_MAJOR}.${FREEBSD_VERSION_MINOR}-RELEASE"
+ARG FREEBSD_SYSROOT="/freebsd"
+ARG FREEBSD_PKG_VERSION="1.21.3"
+ARG FREEBSD_PKG_ABI="FreeBSD:${FREEBSD_VERSION_MAJOR}:${FREEBSD_TARGET_ARCH}"
+ARG FREEBSD_PKG_JAVA="openjdk21"
+ARG CLANG_TARGET_ARCH="x86_64"
+ARG CLANG_LINKS_TARGET="${CLANG_TARGET_ARCH}-unknown-freebsd${FREEBSD_VERSION_MAJOR}"
+
+FROM ${BASE_IMAGE_NAME}:${BASE_IMAGE_TAG}
+
+# Export the build arguments
+ARG FREEBSD_VERSION_MAJOR
+ARG FREEBSD_VERSION_MINOR
+ARG FREEBSD_TARGET
+ARG FREEBSD_TARGET_ARCH
+ARG FREEBSD_VERSION
+ARG FREEBSD_SYSROOT
+ARG FREEBSD_PKG_VERSION
+ARG FREEBSD_PKG_ABI
+ARG FREEBSD_PKG_JAVA
+ARG CLANG_TARGET_ARCH
+ARG CLANG_LINKS_TARGET
+
+### HOST DEPENDENCIES ###
+
+# Install various build tools and dependencies
+RUN apk add --quiet --no-cache --no-progress \
+      bash \
+      curl \
+      clang \
+      gcc \
+      git \
+      pkgconf \
+      make \
+      autoconf \
+      automake \
+      libtool \
+      musl-dev \
+      xz-dev \
+      bzip2-dev \
+      zlib-dev \
+      zstd-dev \
+      lz4-dev \
+      expat-dev \
+      acl-dev \
+      fts-dev \
+      libbsd-dev \
+      openssl-dev \
+      libarchive-dev \
+      libarchive-tools
+
+### FreeBSD's PKG INSTALLATION on HOST ###
+
+# Download, build and install the FreeBSD `pkg` tool
+RUN mkdir /pkg && \
+    curl -L https://github.com/freebsd/pkg/archive/refs/tags/${FREEBSD_PKG_VERSION}.tar.gz | \
+      bsdtar -xf - -C /pkg
+
+RUN cd /pkg/pkg-* && \
+    ln -sf clang /usr/bin/cc && cc --version && \
+    export CFLAGS="-Wno-cpp -Wno-switch -D__BEGIN_DECLS='' -D__END_DECLS='' -DDEFFILEMODE='S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH' -D__GLIBC__" && \
+    export LDFLAGS="-lfts" && \
+    ./configure --quiet --with-libarchive.pc && \
+    touch /usr/include/sys/unistd.h && \
+    touch /usr/include/sys/sysctl.h && \
+    sed -i'' -e '/#include "pkg.h"/i#include <bsd/stdlib.h>' libpkg/pkg_jobs_conflicts.c && \
+    sed -i'' -e '/#include.*cdefs.h>/i#include <fcntl.h>' libpkg/flags.c && \
+    sed -i'' -e '/#include <stdio.h>/i#include <stdarg.h>' libpkg/xmalloc.h && \
+    make && mkdir -p /usr/local/etc && make install && \
+    cd / && rm -rf /pkg /usr/local/sbin/pkg2ng && \
+    unset CFLAGS LDFLAGS
+
+### FREEBSD BASE INSTALLATION ###
+
+# Download the FreeBSD base and install the libraries, include files and package keys etc.
+RUN mkdir ${FREEBSD_SYSROOT} && \
+    curl -L https://download.freebsd.org/ftp/releases/${FREEBSD_TARGET}/${FREEBSD_TARGET_ARCH}/${FREEBSD_VERSION}/base.txz | \
+	bsdtar -xf - -C ${FREEBSD_SYSROOT} ./lib ./usr/lib ./usr/libdata ./usr/include ./usr/share/keys ./etc
+
+### FreeBSD's PKG CONFIGURATION ###
+
+# Configure and update `pkg`
+# (usage: pkg install ...)
+ENV PKG_ROOTDIR ${FREEBSD_SYSROOT}
+RUN mkdir -p ${FREEBSD_SYSROOT}/usr/local/etc && \
+	  echo "ABI = \"${FREEBSD_PKG_ABI}\"; REPOS_DIR = [\"${FREEBSD_SYSROOT}/etc/pkg\"]; REPO_AUTOUPDATE = NO; RUN_SCRIPTS = NO;" > ${FREEBSD_SYSROOT}/usr/local/etc/pkg.conf
+RUN ln -s ${FREEBSD_SYSROOT}/usr/share/keys /usr/share/keys
+RUN mv /usr/local/sbin/pkg /usr/local/sbin/pkg.real && \
+    echo "#!/bin/sh" > /usr/local/sbin/pkg && \
+    echo "exec pkg.real -r ${PKG_ROOTDIR} \"\$@\"" >> /usr/local/sbin/pkg && \
+    chmod +x /usr/local/sbin/pkg
+RUN pkg update -f
+
+### CLANG on HOST to cross-compile to FreeBSD target ###
+
+# Make clang symlinks to cross-compile
+# NOTE: clang++ should be able to find stdc++ (necessary for meson checks even without building any c++ code)
+ADD scripts/clang-links.sh /tmp/clang-links.sh
+RUN bash /tmp/clang-links.sh ${FREEBSD_SYSROOT} ${CLANG_LINKS_TARGET}
+ENV CLANG=${CLANG_LINKS_TARGET}-clang
+ENV CPPLANG=${CLANG_LINKS_TARGET}-clang++
+
+### PKG-CONFIG ###
+
+# Configure `pkg-config`
+ENV PKG_CONFIG_LIBDIR ${FREEBSD_SYSROOT}/usr/libdata/pkgconfig:${FREEBSD_SYSROOT}/usr/local/libdata/pkgconfig
+ENV PKG_CONFIG_SYSROOT_DIR ${FREEBSD_SYSROOT}
+
+### FreeBSD's JDK INSTALLATION ###
+
+RUN pkg install -y ${FREEBSD_PKG_JAVA}
+ENV FREEBSD_JAVA_HOME=${FREEBSD_SYSROOT}/usr/local/${FREEBSD_PKG_JAVA}
+
+### FreeBSD's GTK3 & GTK4 LIBRARIES' INSTALLATION ###
+
+# Install 'cairo' & 'GLU' dependencies
+RUN pkg install -y cairo libGLU
+
+# Install the GTK3 & GTK4 packages
+RUN pkg install -y gtk3
+RUN pkg install -y gtk4
+
+# Install 'webkit2' dependencies
+RUN pkg install -y webkit2-gtk3 webkit2-gtk4
+
+
+WORKDIR /workdir
+

--- a/cje-production/dockerfiles/alpine/freebsd-cross/README.md
+++ b/cje-production/dockerfiles/alpine/freebsd-cross/README.md
@@ -1,0 +1,120 @@
+# ***freebsd-cross*** Docker image
+
+***This Docker container is taken from [docker-freebsd-cross](https://github.com/chirontt/docker-freebsd-cross), with the removal of `meson` support.***
+
+An Alpine-based Docker image for cross-compiling to any version of FreeBSD (amd64/arm64) using `clang`.
+
+- Supports building images for `aarch64` & `x86_64` platforms
+- C/C++ cross-compilers are available via the `CLANG` and `CPPLANG` env variables
+- Allows FreeBSD's `pkg` dependency installation
+- Configures `pkgconf` (`pkg-config`)
+- GTK3 & GTK4 libraries for FreeBSD are installed in the image
+- OpenJDK 21 for FreeBSD is also installed in the image, and is available via the `FREEBSD_JAVA_HOME` env variable.
+
+# Usage
+
+## FreeBSD cross builds for default `x86_64` architecture
+
+### Build Docker image for `x86_64` on Linux/x86_64
+
+First, build the image for default `x86_64` architecture, on a Linux/x86_64 box:
+
+```
+> docker build -t "freebsd-cross-x86_64" .
+```
+
+### FreeBSD/x86_64 cross build for Eclipse SWT natives
+
+Then, at the root of [eclipse.platform.swt](https://github.com/eclipse-platform/eclipse.platform.swt) 's working directory,
+execute the following commands:
+
+```
+> cd bundles/org.eclipse.swt
+> java -Dws=gtk -Darch=x86_64 build-scripts/CollectSources.java -nativeSources \
+    ../../binaries/org.eclipse.swt.gtk.freebsd.x86_64/target/natives-build-temp
+> cd ../../binaries/org.eclipse.swt.gtk.freebsd.x86_64
+> docker run --rm --volume $(pwd):/workdir -it "freebsd-cross-x86_64" /bin/sh -c \
+    'cd target/natives-build-temp && \
+    export OS=FreeBSD MODEL=x86_64 SWT_JAVA_HOME=$FREEBSD_JAVA_HOME OUTPUT_DIR=../.. CC=$CLANG && \
+    ./build.sh install'
+```
+
+### FreeBSD/x86_64 cross build for Eclipse Equinox's launcher natives
+
+At the root of [equinox](https://github.com/eclipse-equinox/equinox) 's working directory,
+execute the following command:
+
+```
+> docker run --rm --volume $(pwd)/features/org.eclipse.equinox.executable.feature/library:/workdir \
+    --volume $(pwd)/../equinox.binaries:/output -it "freebsd-cross-x86_64" /bin/sh -c \
+    'cd gtk && \
+    export JAVA_HOME=$FREEBSD_JAVA_HOME BINARIES_DIR=/output CC=$CLANG && \
+    ./build.sh install -ws gtk -os freebsd -arch x86_64 -java $FREEBSD_JAVA_HOME'
+```
+
+### FreeBSD/x86_64 cross build for Eclipse Plaform's file system natives
+
+At the root of [eclipse.platform](https://github.com/eclipse-platform/eclipse.platform) 's working directory,
+execute the following command:
+
+```
+> docker run --rm --volume $(pwd):/workdir -it "freebsd-cross-x86_64" /bin/sh -c \
+    'cd resources/bundles/org.eclipse.core.filesystem/natives/unix/freebsd && \
+    export OS_ARCH=x86_64 JAVA_HOME=$FREEBSD_JAVA_HOME OUTPUT_DIR=../.. CC=$CLANG && \
+    make install'
+```
+
+## FreeBSD cross builds for `aarch64` architecture
+
+### Build Docker image for `aarch64` on Linux/aarch64
+
+First, build the image for `aarch64` architecture, on a Linux/aarch64 box:
+
+```
+> docker build -t "freebsd-cross-aarch64" \
+    --build-arg FREEBSD_TARGET=arm64 \
+    --build-arg FREEBSD_TARGET_ARCH=aarch64 \
+    --build-arg CLANG_TARGET_ARCH=aarch64 .
+```
+
+### FreeBSD/aarch64 cross build for Eclipse SWT natives
+
+Then, at the root of [eclipse.platform.swt](https://github.com/eclipse-platform/eclipse.platform.swt) 's working directory,
+execute the following commands:
+
+```
+> cd bundles/org.eclipse.swt
+> java -Dws=gtk -Darch=aarch64 build-scripts/CollectSources.java -nativeSources \
+    ../../binaries/org.eclipse.swt.gtk.freebsd.aarch64/target/natives-build-temp
+> cd ../../binaries/org.eclipse.swt.gtk.freebsd.aarch64
+> docker run --rm --volume $(pwd):/workdir -it "freebsd-cross-aarch64" /bin/sh -c \
+    'cd target/natives-build-temp && \
+    export OS=FreeBSD MODEL=aarch64 SWT_JAVA_HOME=$FREEBSD_JAVA_HOME OUTPUT_DIR=../.. CC=$CLANG && \
+    ./build.sh install'
+```
+
+### FreeBSD/aarch64 cross build for Eclipse Equinox's launcher natives
+
+At the root of [equinox](https://github.com/eclipse-equinox/equinox) 's working directory,
+execute the following command:
+
+```
+> docker run --rm --volume $(pwd)/features/org.eclipse.equinox.executable.feature/library:/workdir \
+    --volume $(pwd)/../equinox.binaries:/output -it "freebsd-cross-aarch64" /bin/sh -c \
+    'cd gtk && \
+    export JAVA_HOME=$FREEBSD_JAVA_HOME BINARIES_DIR=/output CC=$CLANG && \
+    ./build.sh install -ws gtk -os freebsd -arch aarch64 -java $FREEBSD_JAVA_HOME'
+```
+
+### FreeBSD/aarch64 cross build for Eclipse Plaform's file system natives
+
+At the root of [eclipse.platform](https://github.com/eclipse-platform/eclipse.platform) 's working directory,
+execute the following command:
+
+```
+> docker run --rm --volume $(pwd):/workdir -it "freebsd-cross-aarch64" /bin/sh -c \
+    'cd resources/bundles/org.eclipse.core.filesystem/natives/unix/freebsd && \
+    export OS_ARCH=aarch64 JAVA_HOME=$FREEBSD_JAVA_HOME OUTPUT_DIR=../.. CC=$CLANG && \
+    make install'
+```
+

--- a/cje-production/dockerfiles/alpine/freebsd-cross/scripts/clang-links.sh
+++ b/cje-production/dockerfiles/alpine/freebsd-cross/scripts/clang-links.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+sysroot=${1:-/freebsd}
+triple=${2:-x86_64-unknown-freebsd13}
+
+# Based on Rust's script
+# https://github.com/rust-lang/rust/blob/master/src/ci/docker/scripts/freebsd-toolchain.sh
+for tool in clang clang++; do
+  tool_path=/usr/local/bin/${triple}-${tool}
+  cat > "${tool_path}" <<EOF
+#!/bin/sh
+exec ${tool} --sysroot=${sysroot} "\$@" --target=${triple}
+EOF
+  chmod +x "${tool_path}"
+done

--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2012, 2022 Eclipse Foundation and others.
+  Copyright (c) 2012, 2025 Eclipse Foundation and others.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@
   Thanh Ha - improvements and maintenance
   David Williams - improvements and maintenance
   Lars Vogel - Bug 442042
+  Tue Ton - support for FreeBSD
 -->
 <project
   xmlns="http://maven.apache.org/POM/4.0.0"
@@ -213,6 +214,16 @@
             </artifact>
           </target>
           <environments>
+            <environment>
+              <os>freebsd</os>
+              <ws>gtk</ws>
+              <arch>x86_64</arch>
+            </environment>
+            <environment>
+              <os>freebsd</os>
+              <ws>gtk</ws>
+              <arch>aarch64</arch>
+            </environment>
             <environment>
               <os>linux</os>
               <ws>gtk</ws>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse-junit-tests/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse-junit-tests/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2012, 2014 Eclipse Foundation.
+  Copyright (c) 2012, 2025 Eclipse Foundation.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
   Contributors:
      Igor Fedorenko - initial implementation
      David Williams - improvements and maintenance
+     Tue Ton - support for FreeBSD
 -->
 <project
   xmlns="http://maven.apache.org/POM/4.0.0"
@@ -71,6 +72,11 @@
           <environments>
             <environment>
               <os>linux</os>
+              <ws>gtk</ws>
+              <arch>x86_64</arch>
+            </environment>
+            <environment>
+              <os>freebsd</os>
               <ws>gtk</ws>
               <arch>x86_64</arch>
             </environment>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/platform.product
@@ -21,6 +21,7 @@
       location="org.eclipse.platform" />
    <launcher name="eclipse">
       <linux icon="icons/icon.xpm"/>
+      <freebsd icon="icons/icon.xpm"/>
       <macosx icon="icons/Eclipse.icns">
          <bundleUrlTypes>
             <bundleUrlType scheme="eclipse+command" name="Eclipse Command"/>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2012, 2014 Eclipse Foundation.
+  Copyright (c) 2012, 2025 Eclipse Foundation.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
   Contributors:
      Igor Fedorenko - initial implementation
      David Williams - improvements and maintenance
+     Tue Ton - support for FreeBSD
 -->
 <project
   xmlns="http://maven.apache.org/POM/4.0.0"
@@ -396,6 +397,7 @@ UNmHBQdtflW5G1L5fQggWG7V
               <formats>
                 <win32>zip</win32>
                 <linux>tar.gz</linux>
+                <freebsd>tar.gz</freebsd>
                 <macosx>tar.gz</macosx>
               </formats>
             </configuration>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.product
@@ -21,6 +21,7 @@
       location="org.eclipse.platform" />
    <launcher name="eclipse">
       <linux icon="icons/icon.xpm"/>
+      <freebsd icon="icons/icon.xpm"/>
       <macosx icon="icons/Eclipse.icns"/>
       <win useIco="false">
          <bmp/>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/testManifest.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/testManifest.xml
@@ -18,6 +18,14 @@
         name="Windows (ARM 64-bit)"
         fileName="eclipse-SDK-${BUILD_ID}-win32-aarch64.zip"></platform>
       <platform
+        id="SFG264"
+        name="FreeBSD (x86 64-bit)"
+        fileName="eclipse-SDK-${BUILD_ID}-freebsd-gtk-x86_64.tar.gz"></platform>
+      <platform
+        id="SFG2AARCH64"
+        name="FreeBSD (ARM 64-bit)"
+        fileName="eclipse-SDK-${BUILD_ID}-freebsd-gtk-aarch64.tar.gz"></platform>
+      <platform
         id="SLG264"
         name="Linux (x86 64-bit)"
         fileName="eclipse-SDK-${BUILD_ID}-linux-gtk-x86_64.tar.gz"></platform>
@@ -66,6 +74,14 @@
         id="PWAARCH64"
         name="Windows (ARM 64-bit)"
         fileName="eclipse-platform-${BUILD_ID}-win32-aarch64.zip"></platform>
+      <platform
+        id="PFG264"
+        name="FreeBSD (x86 64-bit)"
+        fileName="eclipse-platform-${BUILD_ID}-freebsd-gtk-x86_64.tar.gz"></platform>
+      <platform
+        id="PFG2AARCH64"
+        name="FreeBSD (ARM 64-bit)"
+        fileName="eclipse-platform-${BUILD_ID}-freebsd-gtk-aarch64.tar.gz"></platform>
       <platform
         id="PLG264"
         name="Linux (x86 64-bit)"
@@ -116,6 +132,14 @@
         id="SWTWAARCH64"
         name="Windows (ARM 64-bit)"
         fileName="swt-${BUILD_ID}-win32-win32-aarch64.zip"></platform>
+      <platform
+        id="SWTFG64"
+        name="FreeBSD (x86 64-bit)"
+        fileName="swt-${BUILD_ID}-gtk-freebsd-x86_64.zip"></platform>
+      <platform
+        id="SWTFG2AARCH64"
+        name="FreeBSD (ARM 64-bit)"
+        fileName="swt-${BUILD_ID}-gtk-freebsd-aarch64.zip"></platform>
       <platform
         id="SWTLG64"
         name="Linux (x86 64-bit)"

--- a/eclipse.platform.releng.tychoeclipsebuilder/equinox.starterkit.product/EclipseRTOSGiStarterKit.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/equinox.starterkit.product/EclipseRTOSGiStarterKit.product
@@ -19,6 +19,7 @@
 
    <launcher name="rt">
       <linux icon="icon.xpm"/>
+      <freebsd icon="icon.xpm"/>
       <macosx icon="rt.icns"/>
       <win useIco="true">
          <ico path="rt.ico"/>

--- a/eclipse.platform.releng.tychoeclipsebuilder/equinox.starterkit.product/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/equinox.starterkit.product/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2012, 2020 Eclipse Foundation.
+  Copyright (c) 2012, 2025 Eclipse Foundation.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
   Contributors:
   Igor Fedorenko - initial implementation
   David Williams - improvements and maintenance
+  Tue Ton - support for FreeBSD
 -->
 <project
   xmlns="http://maven.apache.org/POM/4.0.0"
@@ -42,6 +43,11 @@
           <environments>
             <environment>
               <os>linux</os>
+              <ws>gtk</ws>
+              <arch>x86_64</arch>
+            </environment>
+            <environment>
+              <os>freebsd</os>
               <ws>gtk</ws>
               <arch>x86_64</arch>
             </environment>
@@ -96,6 +102,7 @@
               <formats>
                 <win32>zip</win32>
                 <linux>tar.gz</linux>
+                <freebsd>tar.gz</freebsd>
                 <macosx>tar.gz</macosx>
               </formats>
             </configuration>

--- a/eclipse.platform.releng.tychoeclipsebuilder/equinox/buildConfigs/equinox-launchers/build.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/equinox/buildConfigs/equinox-launchers/build.xml
@@ -19,6 +19,8 @@
     <buildRepos os="linux" ws="gtk" arch="ppc64le" archiveName="${archiveRoot}-linux.gtk.ppc64le.${buildId}.tar.gz" />
     <buildRepos os="linux" ws="gtk" arch="riscv64" archiveName="${archiveRoot}-linux.gtk.riscv64.${buildId}.tar.gz" />
     <buildRepos os="linux" ws="gtk" arch="aarch64" archiveName="${archiveRoot}-linux.gtk.aarch64.${buildId}.tar.gz" />
+    <buildRepos os="freebsd" ws="gtk" arch="x86_64" archiveName="${archiveRoot}-freebsd.gtk.x86_64.${buildId}.tar.gz" />
+    <buildRepos os="freebsd" ws="gtk" arch="aarch64" archiveName="${archiveRoot}-freebsd.gtk.aarch64.${buildId}.tar.gz" />
     <buildRepos os="macosx" ws="cocoa" arch="x86_64" archiveName="${archiveRoot}-macosx.cocoa.x86_64.${buildId}.tar.gz" />
     <buildRepos os="macosx" ws="cocoa" arch="aarch64" archiveName="${archiveRoot}-macosx.cocoa.aarch64.${buildId}.tar.gz" />
   </target>

--- a/eclipse.platform.releng.tychoeclipsebuilder/equinox/publishingFiles/testManifest.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/equinox/publishingFiles/testManifest.xml
@@ -248,6 +248,16 @@
         fileName="launchers-win32.win32.x86_64.${BUILD_ID}.zip" />
       <platform
         format="equinox"
+        id="SFG264"
+        name="FreeBSD (x86_64/GTK+)"
+        fileName="launchers-freebsd.gtk.x86_64.${BUILD_ID}.tar.gz" />
+      <platform
+        format="equinox"
+        id="SFG2AARCH64"
+        name="FreeBSD (AARCH64/GTK+)"
+        fileName="launchers-freebsd.gtk.aarch64.${BUILD_ID}.tar.gz" />
+      <platform
+        format="equinox"
         id="SLG264"
         name="Linux (x86_64/GTK+)"
         fileName="launchers-linux.gtk.x86_64.${BUILD_ID}.tar.gz" />
@@ -284,6 +294,11 @@
         id="ESW64"
         name="Windows (x86_64)"
         fileName="EclipseRT-OSGi-StarterKit-${BUILD_ID}-win32-win32-x86_64.zip" />
+      <platform
+        format="equinox"
+        id="ESFG264"
+        name="FreeBSD (x86_64/GTK+)"
+        fileName="EclipseRT-OSGi-StarterKit-${BUILD_ID}-freebsd-gtk-x86_64.tar.gz" />
       <platform
         format="equinox"
         id="ESLG264"

--- a/eclipse.platform.releng/bundles/org.eclipse.rcp/pom.xml
+++ b/eclipse.platform.releng/bundles/org.eclipse.rcp/pom.xml
@@ -17,7 +17,7 @@
     <version>4.36.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
-  <groupId>org.eclipse.platfrom</groupId>
+  <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.rcp</artifactId>
   <packaging>eclipse-plugin</packaging>
   <build>

--- a/eclipse.platform.releng/features/org.eclipse.platform-feature/build.properties
+++ b/eclipse.platform.releng/features/org.eclipse.platform-feature/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-#  Copyright (c) 2000, 2013 IBM Corporation and others.
+#  Copyright (c) 2000, 2025 IBM Corporation and others.
 #
 #  This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License 2.0
@@ -10,8 +10,12 @@
 # 
 #  Contributors:
 #     IBM Corporation - initial API and implementation
+#     Tue Ton - support for FreeBSD
 ###############################################################################
 bin.includes = feature.xml,\
 			   feature.properties
 
 root=rootfiles
+# workaround for missing icon files in FreeBSD builds
+root.freebsd.gtk.aarch64 = file:../../../eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/icons/icon.xpm
+root.freebsd.gtk.x86_64 = file:../../../eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/icons/icon.xpm

--- a/eclipse.platform.releng/features/org.eclipse.platform-feature/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.platform-feature/feature.xml
@@ -207,6 +207,18 @@
          version="0.0.0"/>
 
    <plugin
+         id="org.eclipse.core.filesystem.freebsd.aarch64"
+         os="freebsd"
+         arch="aarch64"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.core.filesystem.freebsd.x86_64"
+         os="freebsd"
+         arch="x86_64"
+         version="0.0.0"/>
+
+   <plugin
          id="org.eclipse.core.filesystem.linux.x86_64"
          os="linux"
          arch="x86_64"
@@ -262,6 +274,11 @@
    <plugin
          id="org.eclipse.equinox.security.linux"
          os="linux"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.equinox.security.freebsd"
+         os="freebsd"
          version="0.0.0"/>
 
    <plugin

--- a/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr
+++ b/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr
@@ -12,6 +12,8 @@
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="ppc64le"/>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="x86_64"/>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="riscv64"/>
+  <configurations operatingSystem="freebsd" windowSystem="gtk" architecture="aarch64"/>
+  <configurations operatingSystem="freebsd" windowSystem="gtk" architecture="x86_64"/>
   <configurations operatingSystem="macosx" windowSystem="cocoa" architecture="x86_64"/>
   <configurations operatingSystem="macosx" windowSystem="cocoa" architecture="aarch64"/>
   <configurations architecture="x86_64"/>


### PR DESCRIPTION
- part of #2959
- add environment triplets for FreeBSD `aarch64` and/or `x86_64`.