### PR TITLE
[Build|GH] Add quick-fix to avoid need for EF-infrastrucutre

### DIFF
--- a/.github/actions/install-maven-parent-action/action.yml
+++ b/.github/actions/install-maven-parent-action/action.yml
@@ -1,0 +1,29 @@
+name: 'Install Maven parent and SDK target'
+description: 'Install the eclipse-parent pom.xml and Eclipse SDK target-platform into the local Maven cache in order to avoid the need for EF-infrastructure (which is currently unavailable).'
+inputs:
+  tycho-version:
+    description: 'The tycho release to use.'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout eclipse.platform.releng.aggregator
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        repository: eclipse-platform/eclipse.platform.releng.aggregator
+        path: eclipse.platform.releng.aggregator
+        sparse-checkout: |
+          eclipse-platform-parent
+          eclipse.platform.releng.prereqs.sdk
+    - name: Install eclipse-parent poms
+      working-directory: eclipse.platform.releng.aggregator
+      shell: bash
+      run: |
+        cd eclipse-platform-parent
+        mvn clean install -B -ntp -Dtycho.version=${{ inputs.tycho-version }}
+        cd ..
+        cd eclipse.platform.releng.prereqs.sdk
+        mvn clean install -B -ntp -Dtycho.version=${{ inputs.tycho-version }}
+    - name: Remove eclipse.platform.releng.aggregator
+      shell: bash
+      run: 'rm -rf eclipse.platform.releng.aggregator'

--- a/.github/workflows/checkVersions.yml
+++ b/.github/workflows/checkVersions.yml
@@ -26,6 +26,11 @@ on:
         type: string
         required: false
         default: '.'
+      without-EF-infra:
+        description: 'Whether to run this build without the need for EF-infrastructure (which is currently unavailable).'
+        type: boolean
+        required: false
+        default: true
 
 permissions: {} # all none
 
@@ -51,6 +56,12 @@ jobs:
       with:
         maven-version: 3.9.9
 
+    - name: Install Maven parent locally
+      uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/actions/install-maven-parent-action@master
+      if : inputs.without-EF-infra
+      with:
+        tycho-version: 4.0.12
+
     - name: Additional setup
       if: inputs.extra-setup-command
       run: |
@@ -66,6 +77,7 @@ jobs:
           mvn verify ${{ inputs.extra-maven-args }} -DskipTests -Dcompare-version-with-baselines.skip=false
           org.eclipse.tycho:tycho-versions-plugin:bump-versions -Dtycho.bump-versions.increment=100
           --threads 1C --fail-at-end --batch-mode --no-transfer-progress --show-version
+          ${{ inputs.without-EF-infra && '-Dtycho.version=4.0.12' || '' }}
 
     - name: Commit version increments, if any
       run: |
@@ -79,7 +91,8 @@ jobs:
           
           # Read 'releaseNumberSDK' property as stream version
           pushd ${{ inputs.working-directory }}
-          mvn help:evaluate -Dexpression=releaseNumberSDK ${{ inputs.extra-maven-args }} --quiet '-Doutput=releaseNumberSDK-value.txt'
+          mvn help:evaluate -Dexpression=releaseNumberSDK ${{ inputs.extra-maven-args }} --quiet '-Doutput=releaseNumberSDK-value.txt' \
+            ${{ inputs.without-EF-infra && '-Dtycho.version=4.0.12' || '' }}
           streamVersion=$(<releaseNumberSDK-value.txt)
           rm -f releaseNumberSDK-value.txt
           popd

--- a/.github/workflows/codeQLworkflow.yml
+++ b/.github/workflows/codeQLworkflow.yml
@@ -20,6 +20,11 @@ on:
         type: string
         required: false
         default: '3.9.9'
+      without-EF-infra:
+        description: 'Whether to run this build without the need for EF-infrastructure (which is currently unavailable).'
+        type: boolean
+        required: false
+        default: true
 
 jobs:
   analyze:
@@ -77,11 +82,19 @@ jobs:
       uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
       with:
         maven-version: ${{ inputs.mavenVersion }}
+
+    - name: Install Maven parent locally
+      uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/actions/install-maven-parent-action@master
+      if : inputs.without-EF-infra
+      with:
+        tycho-version: 4.0.12
+
     - name: Build with Maven
       uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
       with:
        run: >- 
         mvn --batch-mode -V -U
+        ${{ inputs.without-EF-infra && '-Dtycho.version=4.0.12' || '' }}
         -ntp
         -Dcompare-version-with-baselines.skip=true
         -Pbree-libs

--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -15,11 +15,16 @@ on:
         type: string
         required: false
         default: 'false'
-      mavenVersion: 
+      mavenVersion:
         description: 'The version of Maven set up'
         type: string
         required: false
         default: '3.9.9'
+      without-EF-infra:
+        description: 'Whether to run this build without the need for EF-infrastructure (which is currently unavailable).'
+        type: boolean
+        required: false
+        default: true
 
 permissions: {}
 
@@ -68,6 +73,13 @@ jobs:
       uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
       with:
         maven-version: ${{ inputs.mavenVersion }}
+
+    - name: Install Maven parent locally
+      uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/actions/install-maven-parent-action@master
+      if : inputs.without-EF-infra
+      with:
+        tycho-version: 4.0.12
+
     - name: Download the API Tools matcher
       uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9 # v1.6.0
       id: api-tools-matcher
@@ -80,6 +92,7 @@ jobs:
       with:
        run: >- 
         mvn --batch-mode -V -U -e
+        ${{ inputs.without-EF-infra && '-Dtycho.version=4.0.12' || '' }}
         -ntp
         -Dcompare-version-with-baselines.skip=false
         -Pbree-libs


### PR DESCRIPTION
In order to mitigate the current outage of the EF-hosted storage, which will probably continue to block builds for at least a few days (https://www.eclipse.org/lists/eclipse.org-committers/msg01493.html) this implements a quick-fix to avoid the need for said EF infrastructure for the shared GitHub workflows. This is achieved by the following actions:
- Obtain the eclipse-parent pom.xml and the sdk.target project from the GH repository and install it within the build into the local Maven cache
- Revert Tycho to use it's latest release 4.0.12, which is available from Maven-Central

Especially the latter could cause problems for builds that rely on the new features only available in Tycho 4.0.13-SNAPSHOT. Therefore this is currently designed as opt-in feature.  But looking at https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2870#issue-2892484622, only SWT currently needs the snapshot but doesn't use the shared workflow.
After some more testing we could also enable this by default.