### PR TITLE
[Build|GH] Unify Maven arguments and replace use of coactions/setup-xvfb

### DIFF
--- a/.github/workflows/codeQLworkflow.yml
+++ b/.github/workflows/codeQLworkflow.yml
@@ -90,9 +90,8 @@ jobs:
         tycho-version: 4.0.12
 
     - name: Build with Maven
-      uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
-      with:
-       run: >- 
+      run: >-
+        ${{ runner.os == 'Linux' && 'xvfb-run' || '' }}
         mvn --batch-mode --no-transfer-progress --show-version --update-snapshots --errors
         ${{ inputs.without-EF-infra && '-Dtycho.version=4.0.12' || '' }}
         -Dcompare-version-with-baselines.skip=true

--- a/.github/workflows/codeQLworkflow.yml
+++ b/.github/workflows/codeQLworkflow.yml
@@ -93,9 +93,8 @@ jobs:
       uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
       with:
        run: >- 
-        mvn --batch-mode -V -U
+        mvn --batch-mode --no-transfer-progress --show-version --update-snapshots --errors
         ${{ inputs.without-EF-infra && '-Dtycho.version=4.0.12' || '' }}
-        -ntp
         -Dcompare-version-with-baselines.skip=true
         -Pbree-libs
         -DskipTests=true

--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -91,9 +91,8 @@ jobs:
       uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
       with:
        run: >- 
-        mvn --batch-mode -V -U -e
+        mvn --batch-mode --no-transfer-progress --show-version --update-snapshots --errors
         ${{ inputs.without-EF-infra && '-Dtycho.version=4.0.12' || '' }}
-        -ntp
         -Dcompare-version-with-baselines.skip=false
         -Pbree-libs
         -Papi-check

--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -47,6 +47,10 @@ jobs:
           - { name: Linux,   os: ubuntu-latest  }
           - { name: Windows, os: windows-latest }
           - { name: MacOS,   os: macos-13   }
+    defaults:
+      run: # Run always on bash, because powershell (the Windows default) interprets dots in arguments differently
+        shell: bash
+
     name: Verify ${{ matrix.config.name }}
     steps:
     - name: Checkout
@@ -88,9 +92,8 @@ jobs:
         target: .github/matcher
     - run: echo "::add-matcher::.github/matcher/${{ steps.api-tools-matcher.outputs.filename }}"
     - name: Build with Maven
-      uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
-      with:
-       run: >- 
+      run: >-
+        ${{ runner.os == 'Linux' && 'xvfb-run' || '' }}
         mvn --batch-mode --no-transfer-progress --show-version --update-snapshots --errors
         ${{ inputs.without-EF-infra && '-Dtycho.version=4.0.12' || '' }}
         -Dcompare-version-with-baselines.skip=false

--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -85,12 +85,10 @@ jobs:
         tycho-version: 4.0.12
 
     - name: Download the API Tools matcher
-      uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9 # v1.6.0
-      id: api-tools-matcher
-      with:
-        url: "https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.releng.aggregator/master/.github/matcher/api-tools.json"
-        target: .github/matcher
-    - run: echo "::add-matcher::.github/matcher/${{ steps.api-tools-matcher.outputs.filename }}"
+      run: |
+        mkdir .github/matcher
+        curl -o .github/matcher/api-tools.json https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.releng.aggregator/master/.github/matcher/api-tools.json
+        echo "::add-matcher::.github/matcher/api-tools.json"
     - name: Build with Maven
       run: >-
         ${{ runner.os == 'Linux' && 'xvfb-run' || '' }}


### PR DESCRIPTION
In the shared GH workflows use long option names to be more readable.
Also don't fail the build on test-failures because the the additional test-result check fails in case of test-failures. This simplifies the distinction between 'hard' failures, like compile-errors and test-failures.

Similar to
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/1492
- https://github.com/eclipse-equinox/equinox/pull/677