### PR TITLE
[Build] Use latest commit of branch specified in .gitmodules file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,37 +1,48 @@
-# Touched, for Bug 398016 - [CBI] How to coordinate (or not) submodules with Git and EGit
 [submodule "eclipse.jdt"]
   path = eclipse.jdt
   url = https://github.com/eclipse-jdt/eclipse.jdt.git
+  branch = master
 [submodule "eclipse.jdt.core"]
   path = eclipse.jdt.core
   url = https://github.com/eclipse-jdt/eclipse.jdt.core.git
+  branch = master
 [submodule "eclipse.jdt.core.binaries"]
   path = eclipse.jdt.core.binaries
   url = https://github.com/eclipse-jdt/eclipse.jdt.core.binaries.git
+  branch = master
 [submodule "eclipse.jdt.debug"]
   path = eclipse.jdt.debug
   url = https://github.com/eclipse-jdt/eclipse.jdt.debug.git
+  branch = master
 [submodule "eclipse.jdt.ui"]
   path = eclipse.jdt.ui
   url = https://github.com/eclipse-jdt/eclipse.jdt.ui.git
+  branch = master
 [submodule "eclipse.pde"]
   path = eclipse.pde
   url = https://github.com/eclipse-pde/eclipse.pde.git
+  branch = master
 [submodule "eclipse.platform"]
   path = eclipse.platform
   url = https://github.com/eclipse-platform/eclipse.platform.git
+  branch = master
 [submodule "eclipse.platform.swt"]
   path = eclipse.platform.swt
   url = https://github.com/eclipse-platform/eclipse.platform.swt.git
+  branch = master
 [submodule "eclipse.platform.ui"]
   path = eclipse.platform.ui
   url = https://github.com/eclipse-platform/eclipse.platform.ui.git
+  branch = master
 [submodule "equinox.binaries"]
   path = equinox.binaries
   url = https://github.com/eclipse-equinox/equinox.binaries.git
+  branch = master
 [submodule "equinox"]
   path = equinox
   url = https://github.com/eclipse-equinox/equinox.git
+  branch = master
 [submodule "equinox.p2"]
   path = equinox.p2
   url = https://github.com/eclipse-equinox/p2.git
+  branch = master

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,11 +16,6 @@ pipeline {
 		MAVEN_OPTS = '-Xmx3800m'
 	}
 	stages {
-		stage('Use master') {
-			steps {
-				sh 'git submodule foreach "git fetch origin master; git checkout FETCH_HEAD"'
-			}
-		}
 		stage('Deploy parent-pom and SDK-target') {
 			when {
 				anyOf {
@@ -105,6 +100,7 @@ pipeline {
 						*/tests/target/work/data/.metadata/.*log,\
 						apiAnalyzer-workspace/.metadata/.*log,\
 						eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/target/repository/*'
+					// To archive the built products, add to above's list: eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/target/products/*
 				}
 			}
 		}


### PR DESCRIPTION
This simplifies trying out changes in a submodule and their effect on the entire Eclipse-SDK in advance. Instead of always fetching the latest commit from the master branch of the specified remote, fetch the latest commit of the branch specified in `.gitmodules` from each submodule's remote (also specified in `.gitmodules`).

In order to try out a change with the entire Eclipse-SDK, now one just has to update the affected submodules in the `.gitmodules` file to point to the git-repository and the branch providing the change(s).

Before, one either had to push changes to the 'master' branch of the alternative repository providing a change or had to disable the fetch in this Jenkins pipeline and record the change's commit in this aggregator repository along with changing the of the remote in `.gitmodules`. Of course all of this had to be known.

Additionally add a comment explaining how to archive the just built product with a Jenkins build.

@HeikoKlare IIRC you recently had difficulties to try out a change from a fork in the Eclipse-SDK. This should make it much simpler.