### PR TITLE
[Build] Don't fail shared GH-workflow on test-failures

### DIFF
--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -84,7 +84,7 @@ jobs:
         -Dcompare-version-with-baselines.skip=false
         -Pbree-libs
         -Papi-check
-        --fail-at-end
+        --fail-at-end -Dmaven.test.failure.ignore=true
         ${{ inputs.maven-goals }}
     - name: Upload Test Results for ${{ matrix.config.name }}
       if: always()


### PR DESCRIPTION
Don't fail the build on test-failures because the the additional test-result check fails in case of test-failures. This simplifies the distinction between 'hard' failures, like compile-errors and test-failures.