### PR TITLE
[Build] Remove configuration of deprecated tycho-apitools-plugin options

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -953,8 +953,6 @@
                              </apiToolsRepository>
                              <skip>${skipAPIAnalysis}</skip>
                              <skipIfReplaced>false</skipIfReplaced>
-                             <logDirectory>${compileLogDir}</logDirectory>
-                             <enhanceLogs>true</enhanceLogs>
                              <printProblems>${printApiMessages}</printProblems>
                              <runAsJob>false</runAsJob>
                         </configuration>


### PR DESCRIPTION
They are not used nowadays anyways as the generated api-tools 'report' is used instead by the Jenkins quality-gates.
See also
- https://github.com/eclipse-tycho/tycho/pull/4897
- https://github.com/eclipse-tycho/tycho/pull/4908
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/1932

Currently using these options produces warnings in the build logs.
