### PR TITLE
Update the setup website management

### DIFF
--- a/oomph/Platform.setup
+++ b/oomph/Platform.setup
@@ -278,7 +278,7 @@
           <operand
               xsi:type="predicates:RepositoryPredicate"
               project="org.eclipse.platform"
-              relativePathPattern="platform/.*|releng/.*"/>
+              relativePathPattern="platform/.*|releng/.*|docs"/>
         </predicate>
       </workingSet>
       <workingSet
@@ -978,6 +978,8 @@
           name="Platform Website">
         <requirement
             name="*"/>
+        <requirement
+            name="org.eclipse.oomph.util"/>
         <sourceLocator
             rootFolder="${github.clone.platform.website.location}"/>
       </targlet>
@@ -990,8 +992,14 @@
         <predicate
             xsi:type="predicates:AndPredicate">
           <operand
-              xsi:type="predicates:RepositoryPredicate"
-              project="eclipse"/>
+              xsi:type="predicates:OrPredicate">
+            <operand
+                xsi:type="predicates:NamePredicate"
+                pattern="org\.eclipse\..*\.docs"/>
+            <operand
+                xsi:type="predicates:RepositoryPredicate"
+                project="eclipse"/>
+          </operand>
         </predicate>
       </workingSet>
     </setupTask>
@@ -1003,6 +1011,56 @@
           optional="true"/>
       <repository
           url="https://download.eclipse.org/wildwebdeveloper/releases/latest"/>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:ResourceCreationTask"
+        targetURL="${workspace.location|uri}/.metadata/.plugins/org.eclipse.debug.core/.launches/HTTPServer.launch">
+      <content>
+        &lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?>
+        &lt;launchConfiguration type=&quot;org.eclipse.pde.ui.RuntimeWorkbench&quot;>
+            &lt;setAttribute key=&quot;additional_plugins&quot;/>
+            &lt;booleanAttribute key=&quot;append.args&quot; value=&quot;true&quot;/>
+            &lt;stringAttribute key=&quot;application&quot; value=&quot;org.eclipse.oomph.util.HTTPServer&quot;/>
+            &lt;booleanAttribute key=&quot;askclear&quot; value=&quot;true&quot;/>
+            &lt;booleanAttribute key=&quot;automaticAdd&quot; value=&quot;false&quot;/>
+            &lt;booleanAttribute key=&quot;automaticIncludeRequirements&quot; value=&quot;true&quot;/>
+            &lt;booleanAttribute key=&quot;automaticValidate&quot; value=&quot;true&quot;/>
+            &lt;stringAttribute key=&quot;bootstrap&quot; value=&quot;&quot;/>
+            &lt;stringAttribute key=&quot;checked&quot; value=&quot;[NONE]&quot;/>
+            &lt;booleanAttribute key=&quot;clearConfig&quot; value=&quot;true&quot;/>
+            &lt;booleanAttribute key=&quot;clearws&quot; value=&quot;false&quot;/>
+            &lt;booleanAttribute key=&quot;clearwslog&quot; value=&quot;false&quot;/>
+            &lt;stringAttribute key=&quot;configLocation&quot; value=&quot;$${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/HTTPServer&quot;/>
+            &lt;booleanAttribute key=&quot;default&quot; value=&quot;false&quot;/>
+            &lt;setAttribute key=&quot;deselected_workspace_bundles&quot;/>
+            &lt;stringAttribute key=&quot;featureDefaultLocation&quot; value=&quot;workspace&quot;/>
+            &lt;stringAttribute key=&quot;featurePluginResolution&quot; value=&quot;workspace&quot;/>
+            &lt;booleanAttribute key=&quot;includeOptional&quot; value=&quot;false&quot;/>
+            &lt;stringAttribute key=&quot;location&quot; value=&quot;@none&quot;/>
+            &lt;booleanAttribute key=&quot;org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING&quot; value=&quot;false&quot;/>
+            &lt;booleanAttribute key=&quot;org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE&quot; value=&quot;false&quot;/>
+            &lt;booleanAttribute key=&quot;org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES&quot; value=&quot;true&quot;/>
+            &lt;booleanAttribute key=&quot;org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD&quot; value=&quot;true&quot;/>
+            &lt;stringAttribute key=&quot;org.eclipse.jdt.launching.JRE_CONTAINER&quot; value=&quot;org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21&quot;/>
+            &lt;stringAttribute key=&quot;org.eclipse.jdt.launching.PROGRAM_ARGUMENTS&quot; value=&quot;-os $${target.os} -ws $${target.ws} -arch $${target.arch} -nl $${target.nl} -consoleLog&amp;#13;&amp;#10;&amp;#13;&amp;#10;-alias &amp;#13;&amp;#10;/eclipse-&amp;gt;$${project_loc:/eclipse}&amp;#13;&amp;#10;/eclipse-platform/eclipse.platform/master-&amp;gt;$${project_loc:/eclipse}/../eclipse.platform&amp;#13;&amp;#10;/eclipse-platform/eclipse.platform.ui/master-&amp;gt;$${project_loc:/eclipse}/../eclipse.platform.ui&amp;#13;&amp;#10;/eclipse-pde/eclipse.pde/master-&amp;gt;$${project_loc:/eclipse}/../eclipse.pde&amp;#13;&amp;#10;/eclipse-equinox/p2/master-&amp;gt;$${project_loc:/eclipse}/../p2&quot;/>
+            &lt;stringAttribute key=&quot;org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER&quot; value=&quot;org.eclipse.pde.ui.workbenchClasspathProvider&quot;/>
+            &lt;stringAttribute key=&quot;org.eclipse.jdt.launching.VM_ARGUMENTS&quot; value=&quot;-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true&amp;#13;&amp;#10;-Duser.home=$${system_property:user.home}&quot;/>
+            &lt;stringAttribute key=&quot;pde.version&quot; value=&quot;3.3&quot;/>
+            &lt;stringAttribute key=&quot;product&quot; value=&quot;org.eclipse.e4.demo.cssbridge.product&quot;/>
+            &lt;setAttribute key=&quot;selected_target_bundles&quot;>
+                &lt;setEntry value=&quot;org.eclipse.oomph.util@default:default&quot;/>
+            &lt;/setAttribute>
+            &lt;setAttribute key=&quot;selected_workspace_bundles&quot;/>
+            &lt;booleanAttribute key=&quot;show_selected_only&quot; value=&quot;false&quot;/>
+            &lt;stringAttribute key=&quot;templateConfig&quot; value=&quot;$${target_home}\configuration\config.ini&quot;/>
+            &lt;booleanAttribute key=&quot;tracing&quot; value=&quot;false&quot;/>
+            &lt;booleanAttribute key=&quot;useCustomFeatures&quot; value=&quot;false&quot;/>
+            &lt;booleanAttribute key=&quot;useDefaultConfig&quot; value=&quot;true&quot;/>
+            &lt;booleanAttribute key=&quot;useDefaultConfigArea&quot; value=&quot;true&quot;/>
+            &lt;booleanAttribute key=&quot;useProduct&quot; value=&quot;false&quot;/>
+        &lt;/launchConfiguration>
+
+      </content>
     </setupTask>
     <stream
         name="master"


### PR DESCRIPTION
- Include the platform docs project in the base working sets.
- Require org.eclipse.oomph.util in the web site project to support launching a localhost http server.
- Add all the *.docs projects to the website working set.
- Create a launch configuration HttpServer to launch a local host server that serves the local contents of the eclipse web site project and also the *.docs projects.