### PR TITLE
Add terminal control to update site

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
@@ -40,4 +40,5 @@
    <bundle id="jakarta.annotation-api" version="1.3.5"/>
    <bundle id="jakarta.inject.jakarta.inject-api" version="1.0.5"/>
    <bundle id="org.eclipse.equinox.slf4j"/>
+   <bundle id="org.eclipse.tm.terminal.control"/>
 </site>


### PR DESCRIPTION
Since we migrated it from CDT, there should be a way for CDT to get rid of this bundle. Adding it to the update site would allow this without platform explicitly referencing it (yet).