### PR TITLE
add bnd / biz.aQute.libg

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -585,6 +585,12 @@
 			  </dependency>
 			  <dependency>
 				  <groupId>biz.aQute.bnd</groupId>
+				  <artifactId>aQute.libg</artifactId>
+				  <version>7.1.0</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>biz.aQute.bnd</groupId>
 				  <artifactId>biz.aQute.repository</artifactId>
 				  <version>7.1.0</version>
 				  <type>jar</type>


### PR DESCRIPTION
- required for PR https://github.com/eclipse-pde/eclipse.pde/pull/1763
- this bundle contains util classes which are often used in bnd / bndtools which we partly migrate to PDE (for example specifically we need `aQute.libg.glob.Glob`