### PR TITLE
Use the latest feature of the CBI p2 Aggregator for SDK4Mvn.aggr

### DIFF
--- a/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr
+++ b/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr
@@ -1,11 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<aggregator:Aggregation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="SDK4Mvn" packedStrategy="UNPACK_AS_SIBLING" type="R" mavenResult="true" versionFormat="MavenRelease" includeSources="true">
+<aggregator:Aggregation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="SDK4Mvn" packedStrategy="UNPACK_AS_SIBLING" type="R" mavenResult="true" versionFormat="MavenRelease" includeSources="true" excludeFeatures="true" includedIUPattern="org\.eclipse(?!\.(emf|jetty|ecf|orbit)).*" validateNexusPublishingRequirements="true">
   <validationSets label="main">
-    <contributions label="sdk">
-      <repositories enabled="false" location="/home/data/httpd/download.eclipse.org/eclipse/updates/4.36-I-builds"/>
-    </contributions>
     <contributions label="sdk_http">
-      <repositories location="https://download.eclipse.org/eclipse/updates/4.36-I-builds"/>
+      <repositories location="https://download.eclipse.org/eclipse/updates/4.36-I-builds">
+        <bundles name="org.eclipse.equinox.slf4j"/>
+        <bundles name="org.eclipse.tm.terminal.control"/>
+        <features name="org.eclipse.equinox.p2.sdk.feature.group"/>
+        <features name="org.eclipse.equinox.p2.discovery.feature.feature.group"/>
+        <features name="org.eclipse.core.runtime.feature.feature.group"/>
+        <features name="org.eclipse.equinox.sdk.feature.group"/>
+        <features name="org.eclipse.swt.tools.feature.feature.group"/>
+        <features name="org.eclipse.sdk.feature.group"/>
+        <features name="org.eclipse.e4.core.tools.feature.feature.group"/>
+        <features name="org.eclipse.e4.tools.persistence.feature.feature.group"/>
+        <features name="org.eclipse.pde.unittest.junit.feature.group"/>
+        <features name="org.eclipse.tips.feature.feature.group"/>
+        <features name="org.eclipse.jdt.ui.unittest.junit.feature.feature.group"/>
+      </repositories>
     </contributions>
   </validationSets>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="aarch64"/>


### PR DESCRIPTION
- Specify the root features explicitly to avoid aggregating tests.
- Use includedIUPattern to specify which IUs we want to aggregated, i.e., only JDT, PDE, and Platform IUs.
- Use validateNexusPublishingRequirements to ensure we don't miss any required content in the pom.
- Use excludeFeatures to exclude features, binary content, and purely metadata content.