### PR TITLE
Simplify publishToMaven.jenkinsfile

### DIFF
--- a/JenkinsJobs/Releng/publishToMaven.jenkinsfile
+++ b/JenkinsJobs/Releng/publishToMaven.jenkinsfile
@@ -15,7 +15,6 @@ pipeline {
 	}
 	environment {
 		// Filter out all the feature, test, and product IUs that are not published. Escape dots to match them literally
-		EXCLUDED_ARTIFACTS = "${'.feature.group$|.feature.jar$|.test|org.eclipse.equinox.executable|org.eclipse.platform.ide|org.eclipse.sdk.ide|_root$'.replace('.', '\\.')}"
 		REPO = "${WORKSPACE}/repo"
 		PATH = "${installMavenDaemon('1.0.2')}/bin:${PATH}"
 		// Folder ~/.m2 is not writable for builds, ensure mvnd metadata are written within the workspace.
@@ -58,60 +57,7 @@ pipeline {
 					mv ${repoRaw}/final ${REPO}
 					rm -rf ${repoRaw}
 					
-					echo "==== Enrich POMs ===="
-					# Add some required information to the generated poms:
-					# - dynamic content (retrieved mostly from MANIFEST.MF):
-					#   - name
-					#   - url
-					#   - scm connection, tag and url
-					# - semi dynamic
-					#   - developers (based on static map git-repo-base -> project leads)
-					# - static content
-					#   - license
-					#   - organization
-					#   - issue management
-					
-					enrichPomsSourceFile="${MAVEN_PUBLISH_BASE}/src/org/eclipse/platform/releng/maven/pom/EnrichPoms.java"
-					set -x
-					java ${enrichPomsSourceFile} ${REPO}/org/eclipse/{platform,jdt,pde}
-					set +x
-					
-					echo "==== Add Javadoc stubs ===="
-					
-					# (groupSimpleName, javadocArtifactGA)
-					function createJavadocs() {
-						group=${1}
-						jar="${1}-javadoc.jar"
-						artifact=${2}
-						if [ -r ${jar} ]; then
-							rm ${jar}
-						fi
-						echo -e "Corresponding javadoc can be found in artifact ${artifact}\\n" > README.txt
-						jar cf ${jar} README.txt
-						for pom in org/eclipse/${group}/*/*/*.pom; do
-							pomFolder=$(dirname ${pom})
-							# This is not working because EXCLUDED_ARTIFACTS_PATTERN is not defined and the empty string matches everything.
-							# if [[ ! $pomFolder =~ ${EXCLUDED_ARTIFACTS_PATTERN} ]]; then
-								javadoc=`echo ${pom} | sed -e "s|\\(.*\\)\\.pom|\\1-javadoc.jar|"`
-								cp ${jar} ${javadoc}
-							# fi
-						done	
-					}
-					
 					pushd ${REPO}
-					createJavadocs platform org.eclipse.platform:org.eclipse.platform.doc.isv
-					createJavadocs jdt org.eclipse.jdt:org.eclipse.jdt.doc.isv
-					createJavadocs pde org.eclipse.pde:org.eclipse.pde.doc.user
-					
-					
-					echo "==== Recalculate pom-file hashes ===="
-					
-					# Because the pom enhancer modified the poms the checksums are wrong which produces noisy warnings.
-					# So regenerate the sha1 for every pom.
-					for i in $(find org -name *.pom); do
-						echo "Recalculate checksum of $i"
-						sha1sum -b < $i | awk '{print $1}' > $i.sha1
-					done
 					
 					echo "========== Repo aggregation completed ========="
 					
@@ -119,9 +65,6 @@ pipeline {
 					for project in {platform,jdt,pde}; do
 						for pomPath in org/eclipse/${project}/*/*/*.pom; do
 							artifactId=$(basename $(dirname $(dirname ${pomPath})))
-							if [[ $artifactId =~ ${EXCLUDED_ARTIFACTS} ]]; then
-								continue # Skip excluded artifact
-							fi
 							version=$(basename $(dirname ${pomPath}))
 							groupPath=$(dirname $(dirname $(dirname ${pomPath})))
 							groupId=${groupPath//'/'/.}


### PR DESCRIPTION
- There is no need to filter out wanted content because the aggregator only aggregates what we want to publish.
- There is no need to enrich the poms because the aggregator creates poms the meet the nexus publishing requirements and tests that the poms do actually conform.
- There is no need to create javadoc stubs because the aggregator generates one (for every artifact with a corresponding `sources.jar`.
- There is no need to recompute checksums because nothing is modified.