### PR TITLE
Exclude source generation for all linux file system fragments

### DIFF
--- a/eclipse.platform.releng/features/org.eclipse.platform-feature/pom.xml
+++ b/eclipse.platform.releng/features/org.eclipse.platform-feature/pom.xml
@@ -55,9 +55,11 @@
               </plugins>
               <excludes>
                 <plugin id="org.eclipse.platform.doc.user"/>
+                <plugin id="org.eclipse.core.filesystem.linux.aarch64"/>
+                <plugin id="org.eclipse.core.filesystem.linux.loongarch64"/>
+                <plugin id="org.eclipse.core.filesystem.linux.ppc64le"/>
                 <plugin id="org.eclipse.core.filesystem.linux.x86_64"/>
                 <plugin id="org.eclipse.core.filesystem.macosx"/>
-                <plugin id="org.eclipse.core.filesystem.linux.ppc64le"/>
               </excludes>
             </configuration>
           </execution>


### PR DESCRIPTION
- Reorder the excluded plugins alphabetically.