### PR TITLE
[Build] Run mavenBuild-workflow with CMD shell on Windows

### DIFF
--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -47,8 +47,8 @@ jobs:
           - { name: Windows, os: windows-latest }
           - { name: MacOS,   os: macos-13   }
     defaults:
-      run: # Run always on bash, because powershell (the Windows default) interprets dots in arguments differently
-        shell: bash
+      run: # Run on bash/cmd, because powershell (the Windows default) interprets dots in arguments differently
+        shell: ${{ matrix.config.name == 'Windows' && 'cmd' || 'bash' }}
 
     name: Verify ${{ matrix.config.name }}
     steps:


### PR DESCRIPTION
As currently some P2 tests fail and the executing shell might be the cause.

Follow-up on:
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2998