### PR TITLE
Remove removed o.e.jsch.tests plugin from sdk.tests feature

### DIFF
--- a/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
@@ -180,10 +180,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.jsch.tests"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.core.filebuffers.tests"
          version="0.0.0"/>
 


### PR DESCRIPTION
Part of:
- https://github.com/eclipse-platform/eclipse.platform/pull/1865