### PR TITLE
Add CDT core native API bundle for compilation

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -68,6 +68,16 @@
       <unit id="org.eclipse.license.feature.group" version="2.0.2.v20181016-2210"/>
       <repository location="https://download.eclipse.org/cbi/updates/license/2.0.2.v20181016-2210"/>
     </location>
+    
+    <!--  
+      We consume the bundle form CDT unless we can fully migrate it to platform, this is only used for compilation
+      If one wants to use the terminal console feature in a product (e.g. EPP) one needs to include the CDT terminal support,
+      together with bundle org.eclipse.debug.terminal.
+     -->
+    <location includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
+       <repository location="https://download.eclipse.org/tools/cdt/releases/12.1/cdt-12.1.0/"/>
+       <unit id="org.eclipse.cdt.core.native" />
+    </location>
 
     <!-- uncomment 'eclipse_home' location, with text editor, for use in Eclipse IDE
     <location path="${eclipse_home}" type="Profile"/>

--- a/eclipse.platform.releng/features/org.eclipse.test-feature/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.test-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.test"
       label="%featureName"
-      version="3.9.200.qualifier"
+      version="3.9.300.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
This is required for 

- https://github.com/eclipse-platform/eclipse.platform/pull/1762

currently it contains the cdt-main, but probably should reference the M2 repo (where relevant API was added) or a future CDT release.

Even though the bundle is **named cdt** it actually depends on nothing than JNA, therefore it can be used without really depend on CDT releases like any other API bundle (we just can't depend on new API if such would be ever added).

In a product one then would need to include the terminal feature (that includes the API and native fragments) to actually use the terminal console feature of platform.

FYI @merks @jonahgraham @akurtakov @stbischof