### PR TITLE
Backport: Common-io to 2.19.0

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -73,11 +73,6 @@
       <unit id="org.apache.commons.jxpath" version="1.3.0.v200911051830"/>
       <unit id="org.apache.commons.jxpath.source" version="1.3.0.v200911051830"/>
 
-      <unit id="org.apache.commons.fileupload" version="1.3.2.v20170320-2229"/>
-      <unit id="org.apache.commons.fileupload.source" version="1.3.2.v20170320-2229"/>
-      <unit id="org.apache.commons.io" version="2.8.0.v20210415-0900"/>
-      <unit id="org.apache.commons.io.source" version="2.8.0.v20210415-0900"/>
-
       <unit id="org.apache.lucene.core" version="8.4.1.v20200122-1459"/>
       <unit id="org.apache.lucene.analyzers-smartcn" version="8.4.1.v20200122-1459"/>
       <unit id="org.apache.lucene.analyzers-common" version="8.4.1.v20200122-1459"/>
@@ -247,6 +242,18 @@
 				  <groupId>org.bouncycastle</groupId>
 				  <artifactId>bcutil-jdk18on</artifactId>
 				  <version>1.78.1</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>commons-fileupload</groupId>
+				  <artifactId>commons-fileupload</artifactId>
+				  <version>1.5</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>commons-io</groupId>
+				  <artifactId>commons-io</artifactId>
+				  <version>2.19.0</version>
 				  <type>jar</type>
 			  </dependency>
 			</dependencies>


### PR DESCRIPTION
Update common-io to 2.19.0, due to CVE-2024-47554