### PR TITLE
Update ECF to 3.16.1

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -33,7 +33,7 @@
       <unit id="org.commonmark-gfm-tables" version="0.24.0.v20241021-1700"/>
 
       <!-- This is the "normal" Orbit repository is expected to be updated on milestones and releases based on Orbit deliveries. -->
-      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202505070543"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202505200825"/>
     </location>
 
     <location includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
@@ -60,9 +60,9 @@
       <unit id="org.eclipse.ecf.filetransfer.feature.source.feature.group" version="3.15.0.v20250115-0406"/>
       <unit id="org.eclipse.ecf.filetransfer.httpclientjava.feature.feature.group" version="2.1.0.v20250108-1923"/>
       <unit id="org.eclipse.ecf.filetransfer.httpclientjava.feature.source.feature.group" version="2.1.0.v20250108-1923"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" version="1.2.0.v20250203-1000"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.source.feature.group" version="1.2.0.v20250203-1000"/>
-      <repository location="https://download.eclipse.org/rt/ecf/3.15.7/site.p2/3.15.7.v20250315-1949"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" version="1.2.0.v20250501-1000"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.source.feature.group" version="1.2.0.v20250501-1000"/>
+      <repository location="https://download.eclipse.org/rt/ecf/3.16.1/site.p2/3.16.1.v20250520-0158"/>
     </location>
 
     <location includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
@@ -561,6 +561,12 @@
 		  <dependencies>
 			  <dependency>
 				  <groupId>biz.aQute.bnd</groupId>
+				  <artifactId>aQute.libg</artifactId>
+				  <version>7.1.0</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>biz.aQute.bnd</groupId>
 				  <artifactId>biz.aQute.bnd.annotation</artifactId>
 				  <version>7.1.0</version>
 				  <type>jar</type>
@@ -580,12 +586,6 @@
 			  <dependency>
 				  <groupId>biz.aQute.bnd</groupId>
 				  <artifactId>biz.aQute.bndlib</artifactId>
-				  <version>7.1.0</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>biz.aQute.bnd</groupId>
-				  <artifactId>aQute.libg</artifactId>
 				  <version>7.1.0</version>
 				  <type>jar</type>
 			  </dependency>


### PR DESCRIPTION
- The biz.aQute.bnd updates are from the upgrade button reordering alphabetically.
- Update to Orbit milestone, though no content changes that affect the Platform.