### PR TITLE
Use Tycho 5.0.0-SNAPSHOT in the build

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -73,7 +73,7 @@
     <releaseNumberSDK>${releaseVersion}</releaseNumberSDK>
     <releaseNumberPlatform>${releaseVersion}</releaseNumberPlatform>
 
-    <tycho.version>4.0.13</tycho.version>
+    <tycho.version>5.0.0-SNAPSHOT</tycho.version>
 
     <cbi-plugins.version>1.5.2</cbi-plugins.version>
     <surefire.version>3.5.3</surefire.version>


### PR DESCRIPTION
Tycho 4.x is EOL now and we should use the next release to identify potential issues with Tycho 5.x so they can be fixed and released at the end of the release cycle.

**This should be merged as soon as master opens.**