### PR TITLE
[Build] Update snapshots in Version-Increment workflow

### DIFF
--- a/.github/workflows/checkVersions.yml
+++ b/.github/workflows/checkVersions.yml
@@ -69,7 +69,7 @@ jobs:
         command: >
           mvn verify ${{ inputs.extra-maven-args }} -DskipTests -Dcompare-version-with-baselines.skip=false
           org.eclipse.tycho:tycho-versions-plugin:bump-versions -Dtycho.bump-versions.increment=100
-          --threads 1C --fail-at-end --show-version
+          --update-snapshots --threads 1C --fail-at-end --show-version
 
     - name: Commit version increments, if any
       run: |


### PR DESCRIPTION
This ensures that the workflow for automated version increments always operates on the latest content from the I-builds repository and discards cached data.
At least that's my hope and that worked locally for me. Let's see if it also helps in the CI.
