### PR TITLE
[Build] Fix mail of Eclipse Releng Bot

### DIFF
--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -133,8 +133,8 @@ spec:
                   sshagent(['github-bot-ssh']) {
                     sh '''
                         set -eo pipefail
-                        git config --global user.email "eclipse-releng-bot@eclipse.org"
-                        git config --global user.name "Eclipse Releng Bot"
+                        git config --global user.email 'releng-bot@eclipse.org'
+                        git config --global user.name 'Eclipse Releng Bot'
                         ./mb100_cloneRepos.sh $CJE_ROOT/buildproperties.shsource 2>&1 | tee $logDir/mb100_cloneRepos.sh.log
                     '''
                   }

--- a/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
+++ b/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
@@ -83,7 +83,7 @@ pipeline {
 				checkout scm
 				sh '''
 					git submodule update --init --recursive
-					git config --global user.email 'eclipse-releng-bot@eclipse.org'
+					git config --global user.email 'releng-bot@eclipse.org'
 					git config --global user.name 'Eclipse Releng Bot'
 				'''
 			}


### PR DESCRIPTION
Use the actual email of the `eclipse-releng-bot` as recorded in the EF-API (https://api.eclipse.org/bots) and that is also associated with it's Github account.

Fixes
- https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6227