### PR TITLE
Add the isv bundles to org.eclipse.sdk

### DIFF
--- a/eclipse.platform.releng/features/org.eclipse.sdk/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.sdk/feature.xml
@@ -55,4 +55,12 @@
          id="org.eclipse.sdk"
          version="0.0.0"/>
 
+   <plugin
+         id="org.eclipse.jdt.doc.isv"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.platform.doc.isv"
+         version="0.0.0"/>
+
 </feature>


### PR DESCRIPTION
- These bundles are only required by the removed source features.