### PR TITLE
Replace EMF's features with EMF's bundles in the target platform

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -43,19 +43,13 @@
     </location>
 
     <location includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-       <!-- Check version in "<EMF>/features" directory -->
-      <unit id="org.eclipse.emf.common.feature.group" version="2.35.0.v20250401-0947"/>
-      <unit id="org.eclipse.emf.common.source.feature.group" version="2.35.0.v20250401-0947"/>
-      <unit id="org.eclipse.emf.ecore.feature.group" version="2.40.0.v20250414-1351"/>
-      <unit id="org.eclipse.emf.ecore.source.feature.group" version="2.40.0.v20250414-1351"/>
-       <!-- For org.eclipse.ui.tools, and PDE's spy dependencies as of Eclipse 4.22 -->
-       <!-- Check version in "<EMF>/features" directory -->
-      <unit id="org.eclipse.emf.edit.feature.group" version="2.24.0.v20250330-0741"/>
-      <unit id="org.eclipse.emf.edit.source.feature.group" version="2.24.0.v20250330-0741"/>
-      <unit id="org.eclipse.emf.databinding.feature.group" version="1.12.0.v20240604-0832"/>
-      <unit id="org.eclipse.emf.databinding.source.feature.group" version="1.12.0.v20240604-0832"/>
-      <unit id="org.eclipse.emf.databinding.edit.feature.group" version="1.12.0.v20240604-0832"/>
-      <unit id="org.eclipse.emf.databinding.edit.source.feature.group" version="1.12.0.v20240604-0832"/>
+      <unit id="org.eclipse.emf.common" version="2.42.0.v20250401-0947"/>
+      <unit id="org.eclipse.emf.ecore" version="2.39.0.v20250401-0947"/>
+      <unit id="org.eclipse.emf.ecore.change" version="2.17.0.v20240604-0832"/>
+      <unit id="org.eclipse.emf.ecore.xmi" version="2.39.0.v20250414-1351"/>
+      <unit id="org.eclipse.emf.edit" version="2.23.0.v20250330-0741"/>
+      <unit id="org.eclipse.emf.databinding" version="1.9.0.v20240604-0832"/>
+      <unit id="org.eclipse.emf.databinding.edit" version="1.10.0.v20240604-0832"/>
       <repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.42.0"/>
     </location>
 

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
@@ -3,20 +3,22 @@
    <feature id="org.eclipse.sdk.tests" version="0.0.0"/>
    <feature id="org.eclipse.equinox.p2.sdk" version="0.0.0"/>
    <feature id="org.eclipse.equinox.p2.discovery.feature" version="0.0.0"/>
+   <feature id="org.eclipse.equinox.p2.discovery.feature.source" version="0.0.0"/>
    <feature id="org.eclipse.core.runtime.feature" version="0.0.0"/>
    <feature id="org.eclipse.equinox.sdk" version="0.0.0"/>
+   <feature id="org.eclipse.sdk.examples.source" version="0.0.0"/>
    <feature id="org.eclipse.swt.tools.feature" version="0.0.0"/>
+   <feature id="org.eclipse.swt.tools.feature.source" version="0.0.0"/>
    <feature id="org.eclipse.equinox.executable" version="0.0.0"/>
    <feature id="org.eclipse.sdk" version="0.0.0"/>
+   <feature id="org.eclipse.e4.core.tools.feature.source" version="0.0.0"/>
    <feature id="org.eclipse.e4.tools.persistence.feature" version="0.0.0"/>
    <feature id="org.eclipse.pde.unittest.junit" version="0.0.0"/>
+   <feature id="org.eclipse.pde.unittest.junit.source" version="0.0.0"/>
    <feature id="org.eclipse.tips.feature" version="0.0.0"/>
+   <feature id="org.eclipse.tips.feature.source" version="0.0.0"/>
    <feature id="org.eclipse.jdt.ui.unittest.junit.feature" version="0.0.0"/>
-   <feature id="org.eclipse.emf.common" version="0.0.0"/>
-   <feature id="org.eclipse.emf.ecore" version="0.0.0"/>
-   <feature id="org.eclipse.emf.edit" version="0.0.0"/>
-   <feature id="org.eclipse.emf.databinding" version="0.0.0"/>
-   <feature id="org.eclipse.emf.databinding.edit" version="0.0.0"/>
+   <feature id="org.eclipse.jdt.ui.unittest.junit.feature.source" version="0.0.0"/>
    <bundle id="jakarta.annotation-api" version="1.3.5"/>
    <bundle id="jakarta.inject.jakarta.inject-api" version="1.0.5"/>
    <bundle id="org.eclipse.equinox.slf4j"/>


### PR DESCRIPTION
- Remove EMF's features from the category.xml
- Restore source features accidentally committed in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3107.