### PR TITLE
Revert "Remove explicit inclusion of source-features in Eclipse SDK repository"

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
@@ -3,20 +3,32 @@
    <feature id="org.eclipse.sdk.tests" version="0.0.0"/>
    <feature id="org.eclipse.equinox.p2.sdk" version="0.0.0"/>
    <feature id="org.eclipse.equinox.p2.discovery.feature" version="0.0.0"/>
+   <feature id="org.eclipse.equinox.p2.discovery.feature.source" version="0.0.0"/>
    <feature id="org.eclipse.core.runtime.feature" version="0.0.0"/>
    <feature id="org.eclipse.equinox.sdk" version="0.0.0"/>
+   <feature id="org.eclipse.sdk.examples.source" version="0.0.0"/>
    <feature id="org.eclipse.swt.tools.feature" version="0.0.0"/>
+   <feature id="org.eclipse.swt.tools.feature.source" version="0.0.0"/>
    <feature id="org.eclipse.equinox.executable" version="0.0.0"/>
    <feature id="org.eclipse.sdk" version="0.0.0"/>
+   <feature id="org.eclipse.e4.core.tools.feature.source" version="0.0.0"/>
    <feature id="org.eclipse.e4.tools.persistence.feature" version="0.0.0"/>
    <feature id="org.eclipse.pde.unittest.junit" version="0.0.0"/>
+   <feature id="org.eclipse.pde.unittest.junit.source" version="0.0.0"/>
    <feature id="org.eclipse.tips.feature" version="0.0.0"/>
+   <feature id="org.eclipse.tips.feature.source" version="0.0.0"/>
    <feature id="org.eclipse.jdt.ui.unittest.junit.feature" version="0.0.0"/>
+   <feature id="org.eclipse.jdt.ui.unittest.junit.feature.source" version="0.0.0"/>
    <feature id="org.eclipse.emf.common" version="0.0.0"/>
    <feature id="org.eclipse.emf.ecore" version="0.0.0"/>
    <feature id="org.eclipse.emf.edit" version="0.0.0"/>
    <feature id="org.eclipse.emf.databinding" version="0.0.0"/>
    <feature id="org.eclipse.emf.databinding.edit" version="0.0.0"/>
+   <feature id="org.eclipse.emf.common.source" version="0.0.0"/>
+   <feature id="org.eclipse.emf.ecore.source" version="0.0.0"/>
+   <feature id="org.eclipse.emf.edit.source" version="0.0.0"/>
+   <feature id="org.eclipse.emf.databinding.source" version="0.0.0"/>
+   <feature id="org.eclipse.emf.databinding.edit.source" version="0.0.0"/>
    <bundle id="jakarta.annotation-api" version="1.3.5"/>
    <bundle id="jakarta.inject.jakarta.inject-api" version="1.0.5"/>
    <bundle id="org.eclipse.equinox.slf4j"/>


### PR DESCRIPTION
Reverts eclipse-platform/eclipse.platform.releng.aggregator#3107 as it was submitted too early.