### PR TITLE
Fix running p2repo analyzers

### DIFF
--- a/cje-production/mbscripts/mb500_createRepoReports.sh
+++ b/cje-production/mbscripts/mb500_createRepoReports.sh
@@ -35,16 +35,7 @@ wget --no-proxy --no-verbose --no-cache -O $CJE_ROOT/$TMP_DIR/$tar_name https://
 mkdir -p $report_app_dir
 tar -xf $CJE_ROOT/$TMP_DIR/$tar_name -C $report_app_dir
 
-# Get the latest JustJ 17 JRE and package it.
-justj_jre_url=https://download.eclipse.org/justj/jres/17/downloads/latest
-justj_jre_relative_path=$(curl -s  $justj_jre_url/justj.manifest | grep -E org.eclipse.justj.openjdk.hotspot.jre.full-[0-9.]+-linux-x86_64.tar.gz)
-justj_jre_name=$(basename $justj_jre_relative_path)
-
-wget --no-proxy --no-verbose --no-cache -O $CJE_ROOT/$TMP_DIR/$justj_jre_name $justj_jre_url}/$justj_jre_relative_path
-mkdir -p $report_app_dir/jre
-tar -xf $CJE_ROOT/$TMP_DIR/$justj_jre_name -C $report_app_dir/jre
-
-$report_app_dir/p2analyze/p2analyze -data $CJE_ROOT/$TMP_DIR/workspace-report -vm $report_app_dir/jre/bin -vmargs -Xmx1g \
+$report_app_dir/p2analyze/p2analyze -data $CJE_ROOT/$TMP_DIR/workspace-report -vmargs -Xmx1g \
   -DreferenceRepo=$CJE_ROOT/$TMP_DIR/$BUILD_TO_COMPARE_SITE/$PREVIOUS_RELEASE_VER/$BASEBUILD_ID \
   -DreportRepoDir=$buildToTest \
   -DreportOutputDir=$output_dir


### PR DESCRIPTION
Java 17 is not good anymore thus running it failed. As the analyzers product has been fixed to include the JRE itself