### PR TITLE
Add org.eclipse.debug.terminal to be part of the repository

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
@@ -23,4 +23,5 @@
    <bundle id="jakarta.inject.jakarta.inject-api" version="1.0.5"/>
    <bundle id="org.eclipse.equinox.slf4j"/>
    <bundle id="org.eclipse.tm.terminal.control"/>
+   <bundle id="org.eclipse.debug.terminal"/>
 </site>


### PR DESCRIPTION
`org.eclipse.debug.terminal` is currently not meant to be referenced in any feature but to be consumed for example by an EPP. To do so we need to have it part of the update-site.