### PR TITLE
Add CDT native fragments so we can include them in the update-site

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -70,13 +70,20 @@
     </location>
     
     <!--  
-      We consume the bundle form CDT unless we can fully migrate it to platform, this is only used for compilation
-      If one wants to use the terminal console feature in a product (e.g. EPP) one needs to include the CDT terminal support,
-      together with bundle org.eclipse.debug.terminal.
+      We consume the bundle form CDT unless we can fully migrate it to platform, this is only used for compilation / inclusion in update site.
+      If one wants to use the terminal console feature in a product (e.g. EPP) one needs to include the bundle org.eclipse.debug.terminal.
      -->
     <location includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
        <repository location="https://download.eclipse.org/tools/cdt/releases/12.1/cdt-12.1.0"/>
        <unit id="org.eclipse.cdt.core.native" version="6.4.0.202505200054" />
+       <unit id="org.eclipse.cdt.core.linux" version="6.1.100.202402230238" />
+       <unit id="org.eclipse.cdt.core.linux.x86_64" version="12.1.0.202506041907" />
+       <unit id="org.eclipse.cdt.core.linux.ppc64le" version="12.1.0.202506041907" />
+       <unit id="org.eclipse.cdt.core.linux.aarch64" version="12.1.0.202506041907" />
+       <unit id="org.eclipse.cdt.core.macosx" version="12.1.0.202506041907" />
+       <unit id="org.eclipse.cdt.core.win32" version="6.1.200.202505191828" />
+       <unit id="org.eclipse.cdt.core.win32.x86_64" version="12.1.0.202506041907" />
+       <unit id="org.eclipse.cdt.core.win32.aarch64" version="12.1.0.202506041907" />
     </location>
 
     <!-- uncomment 'eclipse_home' location, with text editor, for use in Eclipse IDE


### PR DESCRIPTION
Currently one needs to install the terminal features to get the native fragments. It seems more useful to include them here as well so one can install the new bundle independently from the terminal-view.

required for
- https://github.com/eclipse-platform/eclipse.platform/pull/1963