### PR TITLE
Add org.eclipse.tm.terminal.view.core to be part of the repository

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
@@ -22,6 +22,7 @@
    <bundle id="jakarta.annotation-api" version="1.3.5"/>
    <bundle id="jakarta.inject.jakarta.inject-api" version="1.0.5"/>
    <bundle id="org.eclipse.equinox.slf4j"/>
-   <bundle id="org.eclipse.tm.terminal.control"/>
    <bundle id="org.eclipse.debug.terminal"/>
+   <bundle id="org.eclipse.tm.terminal.control"/>
+   <bundle id="org.eclipse.tm.terminal.view.core"/>
 </site>


### PR DESCRIPTION
org.eclipse.tm.terminal.view.core is currently not meant to be referenced in any feature but needs to be consumable e.g. by CDT. To do so we need to have it part of the update-site.