### PR TITLE
Silence deprecation warnings for junit jars

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
@@ -16,6 +16,7 @@ org.apache.httpcomponents.client5.httpclient5
 org.apache.httpcomponents.core5.httpcore5
 org.apache.httpcomponents.core5.httpcore5-h2
 junit-jupiter-api
+junit-jupiter-params
 junit-platform-commons
 junit-platform-engine
 


### PR DESCRIPTION
API stability for JUnit is not guaranteed by Eclipse project thus it shouldn't be included in reports like
https://download.eclipse.org/eclipse/downloads/drops4/I20250617-1800/apitools/deprecation/apideprecation.html