### PR TITLE
Improve warning message if automated version increments cannot modify PR

### DIFF
--- a/.github/workflows/publishVersionCheckResults.yml
+++ b/.github/workflows/publishVersionCheckResults.yml
@@ -104,7 +104,7 @@ jobs:
 
     - name: Add or update information comment
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-      if: always()
+      if: always() && steps.search-patch.outputs.result
       env:
         FILELIST: ${{ steps.git-commit.outputs.file-list }}
       with:
@@ -120,7 +120,7 @@ jobs:
             })
             const applyChangeMessagePart = pr.data.maintainer_can_modify
               ? "An additional commit containing all the necessary changes was pushed to the top of this PR's branch. To obtain these changes (for example if you want to push more changes) either fetch from your fork or apply the _git patch_."
-              : ":warning: :construction: **This PR cannot be modified by maintainers** because edits are disabled or it is created from an organization repository. To obtain the required changes apply the _git patch_ manually as additional commit."
+              : "> [!WARNING]\n> :construction: **This PR cannot be modified by maintainers** because edits are disabled or it is created from an organization repository. To obtain the required changes apply the _git patch_ manually as an additional commit."
             const commentBody = `
           ${{ env.COMMENT_FIRST_LINE }}.
           Therefore the following files need a version increment:


### PR DESCRIPTION
and skip the comment creation step on the step level when no version increment is needed.

As suggested in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3136#issuecomment-2982556906, this enhances the warning message if a required version increment could not be applied automatically by the bot, to now look like:

![grafik](https://github.com/user-attachments/assets/43fbeb89-3c5d-40d1-bbf1-f8c7d9ca739f)

Thanks Christoph for the suggestion. With that I think the warning is definitively visible enough.