### PR TITLE
Update the TP to latest Orbit milestone

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -18,19 +18,15 @@
       <!-- needed because org.eclipse.jdt.feature.group  includes it, but it should include org.hamcrest (direct-from-maven) instead --> 
       <unit id="org.junit" version="4.13.2.v20240929-1000"/>
 
-      <unit id="org.apache.lucene.core" version="10.2.1.v20250501-1000"/>
-      <unit id="org.apache.lucene.analysis-smartcn" version="10.2.1.v20250501-1000"/>
-      <unit id="org.apache.lucene.analysis-common" version="10.2.1.v20250501-1000"/>
+      <unit id="org.apache.lucene.core" version="10.2.2.v20250621-0700"/>
+      <unit id="org.apache.lucene.analysis-smartcn" version="10.2.2.v20250621-0700"/>
+      <unit id="org.apache.lucene.analysis-common" version="10.2.2.v20250621-0700"/>
 
       <!-- This version contains with notarized *.jnilib -->
       <unit id="com.sun.jna" version="5.17.0.v20250316-1700"/>
 
       <!-- Batik dependencies -->
       <unit id="org.eclipse.orbit.xml-apis-ext" version="1.0.0.v20240917-0534"/>
-
-      <!-- Markdown support for JEP 467 -->
-      <unit id="org.commonmark" version="0.24.0.v20241021-1700"/>
-      <unit id="org.commonmark-gfm-tables" version="0.24.0.v20241021-1700"/>
 
       <!-- ECF -->
       <unit id="org.apache.httpcomponents.client5.httpclient5" version="5.5.0.v20250522-2300"/>
@@ -39,7 +35,7 @@
       <unit id="org.apache.httpcomponents.core5.httpcore5-h2" version="5.3.4.v20250320-1400"/>
 
       <!-- This is the "normal" Orbit repository is expected to be updated on milestones and releases based on Orbit deliveries. -->
-      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.36.0"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202506211357"/>
     </location>
 
     <location includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
@@ -75,15 +71,15 @@
      -->
     <location includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
        <repository location="https://download.eclipse.org/tools/cdt/releases/12.1/cdt-12.1.0"/>
-       <unit id="org.eclipse.cdt.core.native" version="6.4.0.202505200054" />
-       <unit id="org.eclipse.cdt.core.linux" version="6.1.100.202402230238" />
-       <unit id="org.eclipse.cdt.core.linux.x86_64" version="12.1.0.202506041907" />
-       <unit id="org.eclipse.cdt.core.linux.ppc64le" version="12.1.0.202506041907" />
-       <unit id="org.eclipse.cdt.core.linux.aarch64" version="12.1.0.202506041907" />
-       <unit id="org.eclipse.cdt.core.macosx" version="12.1.0.202506041907" />
-       <unit id="org.eclipse.cdt.core.win32" version="6.1.200.202505191828" />
-       <unit id="org.eclipse.cdt.core.win32.x86_64" version="12.1.0.202506041907" />
-       <unit id="org.eclipse.cdt.core.win32.aarch64" version="12.1.0.202506041907" />
+       <unit id="org.eclipse.cdt.core.native" version="6.4.0.202505200054"/>
+       <unit id="org.eclipse.cdt.core.linux" version="6.1.100.202402230238"/>
+       <unit id="org.eclipse.cdt.core.linux.x86_64" version="12.1.0.202506041907"/>
+       <unit id="org.eclipse.cdt.core.linux.ppc64le" version="12.1.0.202506041907"/>
+       <unit id="org.eclipse.cdt.core.linux.aarch64" version="12.1.0.202506041907"/>
+       <unit id="org.eclipse.cdt.core.macosx" version="12.1.0.202506041907"/>
+       <unit id="org.eclipse.cdt.core.win32" version="6.1.200.202505191828"/>
+       <unit id="org.eclipse.cdt.core.win32.x86_64" version="12.1.0.202506041907"/>
+       <unit id="org.eclipse.cdt.core.win32.aarch64" version="12.1.0.202506041907"/>
     </location>
 
     <!-- uncomment 'eclipse_home' location, with text editor, for use in Eclipse IDE
@@ -180,7 +176,7 @@
 			  <dependency>
 				  <groupId>org.jsoup</groupId>
 				  <artifactId>jsoup</artifactId>
-				  <version>1.20.1</version>
+				  <version>1.21.1</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
@@ -883,6 +879,23 @@
 				  <groupId>org.osgi</groupId>
 				  <artifactId>org.osgi.test.junit5</artifactId>
 				  <version>1.3.0</version>
+				  <type>jar</type>
+			  </dependency>
+		  </dependencies>
+	  </location>
+	  <!-- Markdown support for JEP 467 -->
+	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="commonmark" missingManifest="error" type="Maven">
+		  <dependencies>
+			  <dependency>
+				  <groupId>org.commonmark</groupId>
+				  <artifactId>commonmark</artifactId>
+				  <version>0.25.0</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>org.commonmark</groupId>
+				  <artifactId>commonmark-ext-gfm-tables</artifactId>
+				  <version>0.25.0</version>
 				  <type>jar</type>
 			  </dependency>
 		  </dependencies>


### PR DESCRIPTION
- Update org.apache.lucene to 10.2.2.
- Move org.commonmark to be a direct-from-maven dependency.
- Update jsoup to 1.21.1.