### PR TITLE
[Build] Use own cache in Version-Increment workflow

### DIFF
--- a/.github/workflows/checkVersions.yml
+++ b/.github/workflows/checkVersions.yml
@@ -48,7 +48,15 @@ jobs:
       with:
         java-version: 21
         distribution: 'temurin'
-        cache: maven
+
+      # Use a dedicated cache to prevent conflicts with the verification build cache
+    - name: Cache local Maven repository
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
+      with:
+        path: ~/.m2/repository
+        key: version-check-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          version-check-${{ runner.os }}-maven-
 
     - name: Set up Maven
       uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5


### PR DESCRIPTION
As it was pointed out by @akurtakov, the version-check for SWT maybe fails because the used caches interfere with the caches of the verification workflows.
This change ensures that the version-check workflow has its own cache.
