### PR TITLE
Refine check if PR can be updated in version increments workflow

### DIFF
--- a/.github/workflows/publishVersionCheckResults.yml
+++ b/.github/workflows/publishVersionCheckResults.yml
@@ -118,7 +118,7 @@ jobs:
                pull_number: prNumber,
                ...context.repo
             })
-            const applyChangeMessagePart = pr.data.maintainer_can_modify
+            const applyChangeMessagePart = pr.data.maintainer_can_modify || pr.data.base.repo.full_name == pr.data.head.repo.full_name
               ? "An additional commit containing all the necessary changes was pushed to the top of this PR's branch. To obtain these changes (for example if you want to push more changes) either fetch from your fork or apply the _git patch_."
               : "> [!WARNING]\n> :construction: **This PR cannot be modified by maintainers** because edits are disabled or it is created from an organization repository. To obtain the required changes apply the _git patch_ manually as an additional commit."
             const commentBody = `


### PR DESCRIPTION
Maintainers and consequently the organization's Eclipse Bot can always modify a PR from a branch in the same repository, even if edit's by maintainers are not (explicitly) enabled.

This avoids a false positive warning that a required version-increment cannot be pushed, if for example a Bot has created a PR from a branch within the target repository.

Follow-up on
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3136