### PR TITLE
Do not include source features in SDK

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.product
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/sdk.product
@@ -182,11 +182,8 @@ United States, other countries, or both.
    <features>
       <feature id="org.eclipse.sdk"/>
       <feature id="org.eclipse.equinox.p2.user.ui"/>
-      <feature id="org.eclipse.equinox.p2.user.ui.source"/>
       <feature id="org.eclipse.e4.core.tools.feature" installMode="root"/>
-      <feature id="org.eclipse.e4.core.tools.feature.source" installMode="root"/>
       <feature id="org.eclipse.tips.feature" installMode="root"/>
-      <feature id="org.eclipse.tips.feature.source" installMode="root"/>
    </features>
 
    <configurations>


### PR DESCRIPTION
All the content should still be there as materialize-products has includeSources=true property set.