### PR TITLE
Include org.eclipse.terminal.feature.feature.group in SDK4Mvn.aggr

### DIFF
--- a/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr
+++ b/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr
@@ -4,7 +4,6 @@
     <contributions label="sdk_http">
       <repositories location="https://download.eclipse.org/eclipse/updates/4.37-I-builds">
         <bundles name="org.eclipse.equinox.slf4j"/>
-        <bundles name="org.eclipse.tm.terminal.control"/>
         <features name="org.eclipse.equinox.p2.sdk.feature.group"/>
         <features name="org.eclipse.equinox.p2.discovery.feature.feature.group"/>
         <features name="org.eclipse.core.runtime.feature.feature.group"/>
@@ -16,6 +15,7 @@
         <features name="org.eclipse.pde.unittest.junit.feature.group"/>
         <features name="org.eclipse.tips.feature.feature.group"/>
         <features name="org.eclipse.jdt.ui.unittest.junit.feature.feature.group"/>
+        <features name="org.eclipse.terminal.feature.feature.group"/>
       </repositories>
     </contributions>
   </validationSets>


### PR DESCRIPTION
- Remove the org.eclipse.tm.terminal.control bundle which has been renamed.