### PR TITLE
[I/Y-build] Generalize addition of new builds to composite repository

### DIFF
--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -286,7 +286,7 @@ spec:
 							return
 						}
 						build job: 'Releng/modifyP2CompositeRepository', wait: true, propagate: true, parameters: [
-							string(name: 'repositoryPath', value: "eclipse/updates/${RELEASE_VER}-I-builds"),
+							string(name: 'repositoryPath', value: "eclipse/updates/${RELEASE_VER}-${BUILD_TYPE}-builds"),
 							string(name: 'add', value: "${BUILD_IID}"),
 							string(name: 'sizeLimit', value: '3')
 						]

--- a/JenkinsJobs/Releng/FOLDER.groovy
+++ b/JenkinsJobs/Releng/FOLDER.groovy
@@ -62,7 +62,7 @@ Releases are published to <a href="https://repo1.maven.org/maven2/org/eclipse/">
 }
 
 pipelineJob('Releng/modifyP2CompositeRepository'){
-	displayName('Modify P2 composite repository')
+	displayName('Modify P2 Composite Repository')
 	description('Add or remove children from an Eclipse-P2 composite repository.')
 	parameters {
 		stringParam('repositoryPath', null, "Relative repository path from https://download.eclipse.org/. E.g. 'eclipse/updates/4.37-I-builds'")


### PR DESCRIPTION
to fix addition for Y-builds.
Also unify the new display name of 'Modify P2 Composite Repository' job.

Follow-up on
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3165