### PR TITLE
Do not publish p2.discovery.feature.source

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
@@ -3,7 +3,6 @@
    <feature id="org.eclipse.sdk.tests" version="0.0.0"/>
    <feature id="org.eclipse.equinox.p2.sdk" version="0.0.0"/>
    <feature id="org.eclipse.equinox.p2.discovery.feature" version="0.0.0"/>
-   <feature id="org.eclipse.equinox.p2.discovery.feature.source" version="0.0.0"/>
    <feature id="org.eclipse.core.runtime.feature" version="0.0.0"/>
    <feature id="org.eclipse.equinox.sdk" version="0.0.0"/>
    <feature id="org.eclipse.sdk.examples.source" version="0.0.0"/>


### PR DESCRIPTION
It's not needed as both Tycho and PDE support source bundles without source features.
SDK feature inclusion was handled via
https://github.com/eclipse-equinox/p2/pull/882