### PR TITLE
Remove maven-enforcer from the build

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -21,14 +21,6 @@
   <artifactId>eclipse-platform-parent</artifactId>
   <version>4.37.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <!--
-    See maven-enforcer-plugin configuration to actually break the build if
-    run with older maven.
-    prerequisites section is kept for now as even if it doesn't break the build, it
-    is used by other plugins like versions-maven-plugin which check and warn
-    for using plugins with older than they require Maven version.
-    If version number changed in one place, be sure to change in the other.
-  -->
   <prerequisites>
     <maven>3.9.9</maven>
   </prerequisites>
@@ -310,34 +302,6 @@
             <goals>
               <goal>copy-resources</goal>
             </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <!--
-          This maven-enforcer-plugin configuration to actually break the build if
-          run with older maven.
-          prerequisites section is kept for now as even if it doesn't break the build, it
-          is used by other plugins like versions-maven-plugin which check and warn
-          for using plugins with older than they require Maven version.
-          If version number changed in one place, be sure to change in the other.
-        -->
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.6.0</version>
-        <executions>
-          <execution>
-            <id>enforce-maven</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireMavenVersion>
-                  <version>3.9.0</version>
-                </requireMavenVersion>
-              </rules>
-            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
It is configured to check for Maven 3.9.0 which is definetely not enough for Tycho for a while
(https://github.com/eclipse-tycho/tycho/blob/936379891707b19d19a4879c6b7271ef11c9a498/pom.xml#L70 ).
As no one noticed nor complained this seems to be totally useless execution in the build.