### PR TITLE
[RelEng] Specify P2 repository to publish to Maven as job parameter

### DIFF
--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -298,10 +298,12 @@ spec:
 			steps {
 				script {
 					for (c in BUILD.testConfigurations) {
-						build job: "${BUILD.testJobFolder}/${BUILD.testPrefix}-${c.os}-${c.arch}-java${c.javaVersion}", parameters: [string(name: 'buildId', value: "${BUILD_IID}")], wait: false
+						build job: "${BUILD.testJobFolder}/${BUILD.testPrefix}-${c.os}-${c.arch}-java${c.javaVersion}", wait: false, parameters: [
+							string(name: 'buildId', value: "${BUILD_IID}")
+						]
 					}
 				}
-				build job: 'SmokeTests/Start-smoke-tests', parameters: [string(name: 'buildId', value: "${BUILD_IID}")], wait: false
+				build job: 'SmokeTests/Start-smoke-tests', wait: false, parameters: [string(name: 'buildId', value: "${BUILD_IID}")]
 			}
 		}
 		stage('Trigger publication to Maven snapshots repo') {
@@ -314,7 +316,10 @@ spec:
 				}
 			}
 			steps {
-				build job: 'Releng/PublishToMaven', parameters: [string(name: 'snapshotOrRelease', value: '-snapshot')], wait: false
+				build job: 'Releng/PublishToMaven', wait: false, parameters: [
+					string(name: 'snapshotOrRelease', value: 'snapshot'),
+					string(name: 'sourceRepository', value: "https://download.eclipse.org/eclipse/updates/${RELEASE_VER}-${BUILD_TYPE}-builds/${BUILD_IID}")
+				]
 			}
 		}
 	}

--- a/JenkinsJobs/Releng/FOLDER.groovy
+++ b/JenkinsJobs/Releng/FOLDER.groovy
@@ -8,7 +8,7 @@ pipelineJob('Releng/PublishToMaven'){
 <p>
 This job uses the <a href="https://github.com/eclipse-cbi/p2repo-aggregator">CBI aggregator</a> to produce a Maven-compatible repository 
 with contents as specified by the <a href="https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/master/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr">SDK4Mvn.aggr</a> and
-then publishes the artifacts for <code>Eclipse-Platform</code>, <code>JDT</code> and <code>PDE</code> from the output:
+then publishes the artifacts for <code>Eclipse-Platform</code>, <code>JDT</code>, <code>Equinox</code> and <code>PDE</code> from the output:
 </p>
 <ul>
 <li>
@@ -19,27 +19,10 @@ Releases are published to <a href="https://repo1.maven.org/maven2/org/eclipse/">
 </li>
 </ul>
 <p>
-The source repository to be published is specified via the
-<a href="https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/b6c45b1b38b74ad1fa7955e996976da4c259f926/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr#L5">local</a> and 
-<a href="https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/b6c45b1b38b74ad1fa7955e996976da4c259f926/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr#L8">remote</a> repository locations.
-<b>
-For a release build, these should specify the release repository location.
-After the release, these should specify the current 4.x-I-Builds.
-</b>
-</p>
 ''')
 	parameters { // Define parameters in job configuration to make them available even for the very first build after this job was (re)created.
-		choiceParam('snapshotOrRelease', ['-snapshot' /*default*/, '-release'], '''\
-<p>
-The source repository to be published is specified via the
-<a href="https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/b6c45b1b38b74ad1fa7955e996976da4c259f926/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr#L5">local</a> and 
-<a href="https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/b6c45b1b38b74ad1fa7955e996976da4c259f926/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr#L8">remote</a> repository locations 
-the <a href="https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/master/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr">SDK4Mvn.aggr</a>.
-<b>
-For a release build, these should specify the release repository location.
-After the release, these should specify the current 4.x-I-Builds.
-</b>
-</p>
+		choiceParam('snapshotOrRelease', ['snapshot' /*default*/, 'release'], '''\
+If this is the publication of a snapshot or a release build. 
 <ul>
 <li>
 Snapshots are published to <a href="https://repo.eclipse.org/content/repositories/eclipse-snapshots/">https://repo.eclipse.org/content/repositories/eclipse-snapshots/</a>.
@@ -48,6 +31,12 @@ Snapshots are published to <a href="https://repo.eclipse.org/content/repositorie
 Releases are published to <a href="https://repo1.maven.org/maven2/org/eclipse/">Maven central</a> by publishing to a <a href="https://oss.sonatype.org/#stagingRepositories">staging repository</a>.
 </li>
 </ul>
+''')
+		stringParam('sourceRepository', null, '''\
+The URL of the source P2 repository to be published.<br>
+<b>If this is a <em>release</em> publication, the corresponding release repository should be specified</b>, e.g. 'https://download.eclipse.org/eclipse/updates/4.36/R-4.36-202505281830/'<br>
+For a snapshot publication, the 4.x-I-Builds child repository of the specific build should be specified, e.g. 'https://download.eclipse.org/eclipse/updates/4.37-I-builds/I20250710-1800/'<br>
+If left blank (not recommended), the latest I-build is published.
 ''')
 	}
 	definition {

--- a/JenkinsJobs/Releng/publishToMaven.jenkinsfile
+++ b/JenkinsJobs/Releng/publishToMaven.jenkinsfile
@@ -27,8 +27,12 @@ pipeline {
 				sh '''#!/bin/bash -e
 					FILE_SDK_AGGR="${WORKSPACE}/git-repo/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr"
 					
+					# Set the specified source repository
+					if [ -n "${sourceRepository}" ]; then
+						sed -e "s|<repositories location=\\".*\\">|<repositories location=\\"${sourceRepository}\\">|" -i ${FILE_SDK_AGGR}
+					fi
 					# Set whether this is a snapshot build or not
-					if [ "${snapshotOrRelease}" = "-snapshot" ]; then
+					if [ "${snapshotOrRelease}" != 'release' ]; then
 						sed -e 's/snapshot=".*"/snapshot="true"/g' -i ${FILE_SDK_AGGR}
 					fi
 					
@@ -134,7 +138,7 @@ pipeline {
 											SOURCES_ARG="-Dsources=${sourcesFile}"
 										else
 											SOURCES_ARG=""
-											echo "No ${sourcesFile}."
+											echo "Missing sources file ${sourcesFile}."
 										fi
 									
 										if [ -f "${javadocFile}" ]; then
@@ -142,7 +146,7 @@ pipeline {
 											JAVADOC_ARG="-Djavadoc=${javadocFile}"
 										else
 											JAVADOC_ARG=""
-											echo "No ${javadocFile}."
+											echo "Missing JavaDoc file ${javadocFile}."
 										fi
 										set -x
 									

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -110,9 +110,7 @@ The actual steps to release
     - You can subscribe to [cross-project-issues](https://accounts.eclipse.org/mailing-list/cross-project-issues-dev) to get the notifications on Simrel releases.
   * #### **Publish to Maven central**
     - Publishing to maven should happen by at least Tuesday before the release since there is up to a 24 hour delay for the maven mirrors.
-    - Update [SDK4Mvn.aggr](https://github.com/eclipse-platform/eclipse.platform.releng/blob/master/publish-to-maven-central/SDK4Mvn.aggr) to the release build.
-      - SDK4Mvn.aggr determines what is being published to Maven
-    - Run the [Publish to Maven](https://ci.eclipse.org/releng/job/Releng/job/PublishToMaven/) job in jenkins with the `-release` parameter.
+    - Run the [Publish to Maven](https://ci.eclipse.org/releng/job/Releng/job/PublishToMaven/) job in jenkins with the `release` parameter and the release build as `sourceRepository`.
     - Once that publish job has completed successfully, log into https://oss.sonatype.org/#stagingRepositories and close the Platform, JDT and PDE repositories.
       - If you do not have an account on oss.sonatype.org for performing the rest of the release request one by creating an issue like https://issues.sonatype.org/browse/OSSRH-43870 to get permissions for platform, JDT and PDE projects and tag an existing release engineer to give approval.
   * **Contribute to SimRel**

--- a/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr
+++ b/eclipse.platform.releng/publish-to-maven-central/SDK4Mvn.aggr
@@ -2,7 +2,7 @@
 <aggregator:Aggregation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="SDK4Mvn" packedStrategy="UNPACK_AS_SIBLING" type="R" mavenResult="true" versionFormat="MavenRelease" includeSources="true" excludeFeatures="true" includedIUPattern="org\.eclipse(?!\.(emf|jetty|ecf|orbit)).*" validateNexusPublishingRequirements="true">
   <validationSets label="main">
     <contributions label="sdk_http">
-      <repositories location="https://download.eclipse.org/eclipse/updates/4.37-I-builds">
+      <repositories location="https://download.eclipse.org/eclipse/updates/I-builds">
         <bundles name="org.eclipse.equinox.slf4j"/>
         <features name="org.eclipse.equinox.p2.sdk.feature.group"/>
         <features name="org.eclipse.equinox.p2.discovery.feature.feature.group"/>


### PR DESCRIPTION
instead of changing the `SDK4Mvn.aggr` files to just run the publication job subsequently and then changing it again to the next release cycle's I-build repository.
This avoids the described changes and simplifies the release process.