### PR TITLE
Enable "Remove unused private members" cleanups

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -553,13 +553,23 @@
                         <cleanup.remove_unnecessary_array_creation>true</cleanup.remove_unnecessary_array_creation>
                         <!-- Remove unnecessary suppress warning tokens -->
                         <cleanup.remove_unnecessary_suppress_warnings>true</cleanup.remove_unnecessary_suppress_warnings>
-						<!-- Remove unnecessary whitespace-->
+                        <!-- Remove unnecessary whitespace-->
                         <cleanup.remove_trailing_whitespaces>true</cleanup.remove_trailing_whitespaces>
                         <cleanup.remove_trailing_whitespaces_all>true</cleanup.remove_trailing_whitespaces_all>
                         <cleanup.remove_trailing_whitespaces_ignore_empty>false</cleanup.remove_trailing_whitespaces_ignore_empty>
                         <!-- Removes unused imports -->
                         <cleanup.remove_unused_imports>true</cleanup.remove_unused_imports>
                         <cleanup.organize_imports>false</cleanup.organize_imports>
+                        <!-- Remove unused private members -->
+                        <cleanup.remove_unused_private_members>true</cleanup.remove_unused_private_members>
+                        <!-- Remove unused private types -->
+                        <cleanup.remove_unused_private_types>true</cleanup.remove_unused_private_types>
+                        <!-- Remove unused private constructors -->
+                        <cleanup.remove_private_constructors>true</cleanup.remove_private_constructors>
+                        <!-- Remove unused private fields -->
+                        <cleanup.remove_unused_private_fields>true</cleanup.remove_unused_private_fields>
+                        <!-- Remove unused private methods -->
+                        <cleanup.remove_unused_private_methods>true</cleanup.remove_unused_private_methods>
                     </cleanUpProfile>
                 </configuration>
             </execution>


### PR DESCRIPTION
Currently some other cleanups can lead to a private method become unused, what then results in a warning and maybe build failure.

This now enables the cleanups to remove unused private methods/fields/constructors to avoid that situation.