### PR TITLE
add gcc-aarch64-linux-gnu to swtgtk3nativebuild to enable cross-compilation

### DIFF
--- a/cje-production/dockerfiles/debian/swtgtk3nativebuild/Dockerfile
+++ b/cje-production/dockerfiles/debian/swtgtk3nativebuild/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update -qq && apt-get install -qq -y \
       git \
       libgtk-3-dev \
       freeglut3-dev \
-      webkit2gtk-driver
+      webkit2gtk-driver \
+      gcc-aarch64-linux-gnu
 
 ENV HOME=/home/swtbuild
 ENV DISPLAY :0


### PR DESCRIPTION
This PR is supplemental to https://github.com/eclipse-equinox/equinox/pull/1056.

Fixes https://github.com/eclipse-equinox/equinox/issues/1037.