### PR TITLE
[RelEng] Include release in name of deployment to Maven Central Portal

### DIFF
--- a/JenkinsJobs/Releng/deployToMaven.jenkinsfile
+++ b/JenkinsJobs/Releng/deployToMaven.jenkinsfile
@@ -161,6 +161,12 @@ pipeline {
 								'''
 								script {
 									if ("${DEPLOYMENT_TYPE}" == 'release') {
+										def repoTag = "${sourceRepository}".trim()
+										if (repoTag.endsWith('/')) {
+											repoTag = repoTag.substring(0, repoTag.length() - 1)
+										}
+										env.REPO_TAG = repoTag.substring(repoTag.lastIndexOf('/') + 1, repoTag.length())
+										
 										// Documentation of the Central Portal Publisher API 
 										// - https://central.sonatype.org/publish/publish-portal-api
 										// - https://central.sonatype.com/api-doc
@@ -172,7 +178,7 @@ pipeline {
 												--header 'accept: text/plain' \
 												--header 'Content-Type: multipart/form-data' \
 												--form "bundle=@${PROJECT}-artifacts.zip" \
-												'https://central.sonatype.com/api/v1/publisher/upload?publishingType=USER_MANAGED'
+												"https://central.sonatype.com/api/v1/publisher/upload?name=${PROJECT^^}_${REPO_TAG}&publishingType=USER_MANAGED"
 										''')
 										writeFile(file: "${WORKSPACE}/deploymentId-${PROJECT}.txt", text: "${deploymentId}")
 										waitUntil(initialRecurrencePeriod: 5_000) {


### PR DESCRIPTION
This simplifies distinguishing deployments in case more than one was done recently.

CC @elsazac this is what I suggest in https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6130#note_4565661

Future deployments will have names similar to
- `PLATFORM_R-4.36-202505281830`
- `PDE_R-4.36-202505281830`
- `JDT_R-4.36-202505281830`

and the second 'tag' part must match the id of the repo that was passed to the Maven deploy job.