### PR TITLE
Publish o.e.sdk.examplese not source

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
@@ -5,7 +5,7 @@
    <feature id="org.eclipse.equinox.p2.discovery.feature" version="0.0.0"/>
    <feature id="org.eclipse.core.runtime.feature" version="0.0.0"/>
    <feature id="org.eclipse.equinox.sdk" version="0.0.0"/>
-   <feature id="org.eclipse.sdk.examples.source" version="0.0.0"/>
+   <feature id="org.eclipse.sdk.examples" version="0.0.0"/>
    <feature id="org.eclipse.swt.tools.feature" version="0.0.0"/>
    <feature id="org.eclipse.equinox.executable" version="0.0.0"/>
    <feature id="org.eclipse.sdk" version="0.0.0"/>


### PR DESCRIPTION
Sources will be auto published without the use of deprecated (at least by tycho) source feature usage.