### PR TITLE
Include all sources in equinox-sdk, i.e., o.e.equinox.sdk.product

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/equinox-sdk/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/equinox-sdk/pom.xml
@@ -42,6 +42,7 @@
         <artifactId>tycho-p2-repository-plugin</artifactId>
         <configuration>
           <includeAllDependencies>false</includeAllDependencies>
+          <includeAllSources>true</includeAllSources>
           <compress>false</compress>
           <repositoryName>Eclipse Equinox and p2 runtime target repository</repositoryName>
         </configuration>


### PR DESCRIPTION
- This is in preparation for discontinuing source features (and source bundles) from the Equinox and p2 SDK features.