### PR TITLE
Exclude org.commonmark from deprecated list

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
@@ -19,6 +19,7 @@ junit-jupiter-api
 junit-jupiter-params
 junit-platform-commons
 junit-platform-engine
+org.commonmark
 
 ## SPECIAL CASE FOR SWT: THE FRAGMENT IS ANALYZED AS PART OF THE HOST
 org.eclipse.swt.win32.win32.x86_64


### PR DESCRIPTION
Removes it from
https://download.eclipse.org/eclipse/downloads/drops4/I20250731-1800/apitools/deprecation/apideprecation.html