### PR TITLE
`clean-bundles` should consider configured branch

### DIFF
--- a/.github/workflows/cleanCode.yml
+++ b/.github/workflows/cleanCode.yml
@@ -113,7 +113,7 @@ jobs:
         if: ${{ fromJson(steps.list-prs.outputs.prs)[9] == null }}
         with:
           fetch-depth: 0
-          ref: master
+          ref: ${{ inputs.branch }}
       - name: Set up Maven
         uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
         if: ${{ fromJson(steps.list-prs.outputs.prs)[9] == null }}


### PR DESCRIPTION
The defect was discovered during attempt to apply this workflow to Mylyn. 
It was not possible to reach it earlier, since token for Mylyn was not available