### PR TITLE
[Build] Define IU categories directly within each build repository

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
@@ -1,12 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature id="org.eclipse.sdk.tests" version="0.0.0"/>
+   <feature id="org.eclipse.sdk.tests">
+      <category name="org.eclipse.releng.testsIU"/>
+   </feature>
    <feature id="org.eclipse.equinox.p2.sdk" version="0.0.0"/>
    <feature id="org.eclipse.equinox.p2.discovery.feature" version="0.0.0"/>
    <feature id="org.eclipse.core.runtime.feature" version="0.0.0"/>
-   <feature id="org.eclipse.equinox.sdk" version="0.0.0"/>
-   <feature id="org.eclipse.sdk.examples" version="0.0.0"/>
-   <feature id="org.eclipse.swt.tools.feature" version="0.0.0"/>
+   <feature id="org.eclipse.equinox.sdk">
+      <category name="org.eclipse.equinox.target.categoryIU"/>
+   </feature>
+   <feature id="org.eclipse.sdk.examples">
+      <category name="org.eclipse.releng.testsIU"/>
+   </feature>
+   <feature id="org.eclipse.swt.tools.feature">
+      <category name="org.eclipse.releng.testsIU"/>
+   </feature>
    <feature id="org.eclipse.equinox.executable" version="0.0.0"/>
    <feature id="org.eclipse.sdk" version="0.0.0"/>
    <feature id="org.eclipse.e4.core.tools.feature" version="0.0.0"/>
@@ -15,13 +23,66 @@
    <feature id="org.eclipse.tips.feature" version="0.0.0"/>
    <feature id="org.eclipse.jdt.ui.unittest.junit.feature" version="0.0.0"/>
    <feature id="org.eclipse.terminal.feature"/>
+   <feature id="org.eclipse.rcp">
+      <category name="org.eclipse.rcp.categoryIU"/>
+   </feature>
+   <feature id="org.eclipse.test">
+      <category name="org.eclipse.releng.testsIU"/>
+   </feature>
+   <feature id="org.eclipse.jdt">
+      <category name="org.eclipse.releng.java.languages.categoryIU"/>
+   </feature>
+   <feature id="org.eclipse.pde">
+      <category name="org.eclipse.releng.pde.categoryIU"/>
+   </feature>
    <bundle id="jakarta.annotation-api" version="1.3.5"/>
    <bundle id="jakarta.inject.jakarta.inject-api" version="1.0.5"/>
    <bundle id="org.eclipse.equinox.slf4j"/>
    <bundle id="org.eclipse.debug.terminal"/>
+   <iu id = "org.eclipse.sdk.ide">
+     <category name="org.eclipse.sdk.ide.categoryIU"/>
+   </iu>
+   <iu id = "org.eclipse.platform.ide">
+     <category name="org.eclipse.platform.ide.categoryIU"/>
+   </iu>
    <iu>
      <query> 
        <expression type="match">id == 'org.eclipse.equinox.executable'</expression>
      </query>
    </iu>
+   <category-def name="org.eclipse.equinox.target.categoryIU" label="Equinox Target Components">
+      <description>
+         Features especially useful to install as PDE runtime targets.
+      </description>
+   </category-def>
+   <category-def name="org.eclipse.sdk.ide.categoryIU" label="Eclipse SDK">
+      <description>
+         The full version of Eclipse, with source and documentation: Platform, JDT and PDE.
+      </description>
+   </category-def>
+   <category-def name="org.eclipse.platform.ide.categoryIU" label="Eclipse Platform">
+      <description>
+         Minimum version of Eclipse: no source or API documentation, no PDE or JDT.
+      </description>
+   </category-def>
+   <category-def name="org.eclipse.rcp.categoryIU" label="Eclipse RCP Target Components">
+      <description>
+         Features to use as PDE runtime target, while developing RCP applications.
+      </description>
+   </category-def>
+   <category-def name="org.eclipse.releng.testsIU" label="Eclipse Tests, Tools, Examples, and Extras">
+      <description>
+         Collection of Misc. Features, such as unit tests, SWT and e4 tools, examples, and compatibility features not shipped as part of main SDK, but which some people may desire in creating products based on previous versions of Eclipse.
+      </description>
+   </category-def>
+   <category-def name="org.eclipse.releng.java.languages.categoryIU" label="Eclipse Java Development Tools">
+      <description>
+         Tools to allow development with Java.
+      </description>
+   </category-def>
+   <category-def name="org.eclipse.releng.pde.categoryIU" label="Eclipse Plugin Development Tools">
+      <description>
+         Tools to develop bundles, plugins and features.
+      </description>
+   </category-def>
 </site>


### PR DESCRIPTION
Define the IU categories for the eclipse artifacts directly in the `category.xml`.
This simplifies the management of those categories and adds them to each build repository. Due to the latter it's not necessary anymore to define the categories in a separated, colocated metadata repository, which is just hosting these categories (which is cumbersome to maintain), e.g. for the 4.36 release:
https://download.eclipse.org/eclipse/updates/4.36/categories/

This is required for (and with more context):
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3215

The current state of this PR is based on and replicates the
<details>
<summary>current `category/content.xml` file content</summary>

```
<?metadataRepository class='org.eclipse.equinox.internal.p2.metadata.repository.LocalMetadataRepository' version='1.0.0'?>
<repository name="The Eclipse Project Updates" type="org.eclipse.equinox.internal.p2.metadata.repository.LocalMetadataRepository" version="1.0.0">
    <properties size="2">
        <property name="p2.compressed" value="true"/>
        <property name="p2.timestamp" value="1235426489722"/>
    </properties>
    <units size="7">
        <unit id="org.eclipse.equinox.target.categoryIU" version="0.0.0">
            <properties size="2">
                <property name="org.eclipse.equinox.p2.name" value="Equinox Target Components"/>
                <property name="org.eclipse.equinox.p2.description" value="Features especially useful to install as PDE runtime targets."/>
                <property name="org.eclipse.equinox.p2.type.category" value="true"/>
            </properties>
            <provides size="1">
                <provided namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.equinox.target.categoryIU" version="0.0.0"/>
            </provides>
            <requires size="1">
                <required namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.equinox.sdk.feature.group" range="0.0.0"/>
            </requires>
            <touchpoint id="null" version="0.0.0"/>
        </unit>
        <unit id="org.eclipse.sdk.ide.categoryIU" version="0.0.0">
            <properties size="2">
                <property name="org.eclipse.equinox.p2.name" value="Eclipse SDK"/>
                <property name="org.eclipse.equinox.p2.description" value="The full version of Eclipse, with source and documentation: Platform, JDT and PDE."/>
                <property name="org.eclipse.equinox.p2.type.category" value="true"/>
            </properties>
            <provides size="1">
                <provided namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.sdk.ide.categoryIU" version="0.0.0"/>
            </provides>
            <requires size="1">
                <required namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.sdk.ide" range="0.0.0"/>
            </requires>
            <touchpoint id="null" version="0.0.0"/>
        </unit>
        <unit id="org.eclipse.platform.ide.categoryIU" version="0.0.0">
            <properties size="2">
                <property name="org.eclipse.equinox.p2.name" value="Eclipse Platform"/>
                <property name="org.eclipse.equinox.p2.description" value="Minimum version of Eclipse: no source or API documentation, no PDE or JDT."/>
                <property name="org.eclipse.equinox.p2.type.category" value="true"/>
            </properties>
            <provides size="1">
                <provided namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.platform.ide.categoryIU" version="0.0.0"/>
            </provides>
            <requires size="1">
                <required namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.platform.ide" range="0.0.0"/>
            </requires>
            <touchpoint id="null" version="0.0.0"/>
        </unit>
        <unit id="org.eclipse.rcp.categoryIU" version="0.0.0">
            <properties size="2">
                <property name="org.eclipse.equinox.p2.name" value="Eclipse RCP Target Components"/>
                <property name="org.eclipse.equinox.p2.description" value="Features to use as PDE runtime target, while developing RCP applications."/>
                <property name="org.eclipse.equinox.p2.type.category" value="true"/>
            </properties>
            <provides size="1">
                <provided namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.rcp.categoryIU" version="0.0.0"/>
            </provides>
            <requires size="2">
                <required namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.rcp.feature.group" range="0.0.0"/>
                <required namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.rcp.source.feature.group" range="0.0.0"/>
            </requires>
            <touchpoint id="null" version="0.0.0"/>
        </unit>
        <unit id="org.eclipse.releng.testsIU" version="0.0.0">
            <properties size="2">
                <property name="org.eclipse.equinox.p2.name" value="Eclipse Tests, Tools, Examples, and Extras"/>
                <property name="org.eclipse.equinox.p2.description" value="Collection of Misc. Features, such as unit tests, SWT and e4 tools, examples, and compatibility features not shipped as part of main SDK, but which some people may desire in creating products based on previous versions of Eclipse."/>
                <property name="org.eclipse.equinox.p2.type.category" value="true"/>
            </properties>
            <provides size="1">
                <provided namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.releng.testsIU" version="0.0.0"/>
            </provides>
            <requires size="6">
                <required namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.test.feature.group" range="0.0.0"/>
                <required namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.sdk.tests.feature.group" range="0.0.0"/>
                <required namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.sdk.examples.source.feature.group" range="0.0.0"/>
                <required namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.osgi.compatibility.plugins.feature.feature.group" range="0.0.0"/>
                <required namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.swt.tools.feature.feature.group" range="0.0.0"/>
                <required namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.e4.core.tools.feature.source.feature.group" range="0.0.0"/>
            </requires>
            <touchpoint id="null" version="0.0.0"/>
        </unit>
        <unit id="org.eclipse.releng.java.languages.categoryIU" version="0.0.0">
            <properties size="3">
                <property name="org.eclipse.equinox.p2.name" value="Eclipse Java Development Tools"/>
                <property name="org.eclipse.equinox.p2.description" value="Tools to allow development with Java."/>
                <property name="org.eclipse.equinox.p2.type.category" value="true"/>
            </properties>
            <provides size="1">
                <provided namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.releng.java.languages.categoryIU" version="0.0.0"/>
            </provides>
            <requires size="2">
                <required namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.jdt.feature.group" range="0.0.0"/>
                <required namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.jdt.source.feature.group" range="0.0.0"/>
            </requires>
            <touchpoint id="null" version="0.0.0"/>
        </unit>
        <unit id="org.eclipse.releng.pde.categoryIU" version="0.0.0">
            <properties size="3">
                <property name="org.eclipse.equinox.p2.name" value="Eclipse Plugin Development Tools"/>
                <property name="org.eclipse.equinox.p2.description" value="Tools to develop bundles, plugins and features."/>
                <property name="org.eclipse.equinox.p2.type.category" value="true"/>
            </properties>
            <provides size="1">
                <provided namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.releng.pde.categoryIU" version="0.0.0"/>
            </provides>
            <requires size="2">
                <required namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.pde.feature.group" range="0.0.0"/>
                <required namespace="org.eclipse.equinox.p2.iu" name="org.eclipse.pde.source.feature.group" range="0.0.0"/>
            </requires>
            <touchpoint id="null" version="0.0.0"/>
        </unit>
    </units>
</repository>
```
</details>

with the difference that declared source features, are replaced by the main feature and that the non existing `org.eclipse.osgi.compatibility.plugins.feature.feature.group` (for which I didn't found a replacement) is omitted.
The inclusion of products is currently work in progress.

And as many artifacts are uncategorized, we could think about moving them into existing or new categories and generally think if we want to rename or restructure the existing categories (but this can also be done in a follow-up):

<img width="700" src="https://github.com/user-attachments/assets/ca726eba-66e9-400d-a0bf-56dee1df32ea" />
