### PR TITLE
[Build] Set up I-build tests for Java-25 EA

### DIFF
--- a/JenkinsJobs/AutomatedTests/I_unit_tests.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_tests.groovy
@@ -3,7 +3,8 @@ def STREAMS = config.Streams
 
 def TEST_CONFIGURATIONS = [
 	[os: 'linux' , ws:'gtk'  , arch: 'x86_64' , javaVersion: 21, agentLabel: 'ubuntu-2404'        , javaHome: "tool(type:'jdk', name:'temurin-jdk21-latest')" ],
-	[os: 'linux' , ws:'gtk'  , arch: 'x86_64' , javaVersion: 24, agentLabel: 'ubuntu-2404'        , javaHome: "tool(type:'jdk', name:'openjdk-jdk24-latest')" ],
+	[os: 'linux' , ws:'gtk'  , arch: 'x86_64' , javaVersion: 24, agentLabel: 'ubuntu-2404'        , javaHome: "tool(type:'jdk', name:'temurin-jdk24-latest')" ],
+	[os: 'linux' , ws:'gtk'  , arch: 'x86_64' , javaVersion: 25, agentLabel: 'ubuntu-2404'        , javaHome: "tool(type:'jdk', name:'openjdk-jdk25-latest')" ],
 	[os: 'macosx', ws:'cocoa', arch: 'aarch64', javaVersion: 21, agentLabel: 'nc1ht-macos11-arm64', javaHome: "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11-arm64/Contents/Home'" ],
 	[os: 'macosx', ws:'cocoa', arch: 'x86_64' , javaVersion: 21, agentLabel: 'nc1ht-macos11-arm64', javaHome: "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11/Contents/Home'" ],
 	[os: 'win32' , ws:'win32', arch: 'x86_64' , javaVersion: 21, agentLabel: 'qa6xd-win11'        , javaHome: "'C:\\\\Program Files\\\\Eclipse Adoptium\\\\jdk-21.0.5.11-hotspot'" ],

--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -2,6 +2,7 @@
 def I_TEST_CONFIGURATIONS = [
   [ os: 'linux' , ws: 'gtk'  , arch: 'x86_64' , javaVersion: 21],
   [ os: 'linux' , ws: 'gtk'  , arch: 'x86_64' , javaVersion: 24],
+  [ os: 'linux' , ws: 'gtk'  , arch: 'x86_64' , javaVersion: 25],
   [ os: 'macosx', ws: 'cocoa', arch: 'aarch64', javaVersion: 21],
   [ os: 'macosx', ws: 'cocoa', arch: 'x86_64' , javaVersion: 21],
   [ os: 'win32' , ws: 'win32', arch: 'x86_64' , javaVersion: 21],


### PR DESCRIPTION
As discussed in today's PMC meeting this adds a new I-build test configuration for Java-25 EA. For Y-builds such a configuration already exists.

If we consider constant EA testing important, we could also have a permanent Java-_EA_ configuration using the `openjdk-ea-latest` JDK tool:
https://github.com/eclipse-cbi/jiro/blob/faaca45c9cbaaeaa59b0433c41d02ae9e639badd/templates/jenkins/partials/tools-jdk.hbs#L5-L6

But I think it's also fine to just the configuration for a new Java already when it's EA. The EF-infra team usually adds the corresponding tools in time (and if not, we can ask them).
Another option would be adding just a Smoke test for a Java-EA configuration.

@akurtakov or anybody else, what do you think?
