### PR TITLE
[RelEng] Automate more tasks in promotion/publication jobs

### DIFF
--- a/JenkinsJobs/Releng/FOLDER.groovy
+++ b/JenkinsJobs/Releng/FOLDER.groovy
@@ -112,7 +112,6 @@ It must match the name of the build on the build machine.
 		''')
 		stringParam('CHECKPOINT', null, 'M1, M3, RC1, RC2, RC3 etc (blank for final releases).')
 		stringParam('SIGNOFF_BUG', null, 'The issue that was used to "signoff" the checkpoint. If there are no unit test failures, this can be left blank. Otherwise a link is added to test page explaining that "failing unit tests have been investigated".')
-		stringParam('TRAIN_NAME', null, 'The name of the release stream, typically yyyy-mm. For example: 2022-09')
 	}
 	definition {
 		cpsScm {

--- a/JenkinsJobs/Releng/deployToMaven.jenkinsfile
+++ b/JenkinsJobs/Releng/deployToMaven.jenkinsfile
@@ -226,7 +226,6 @@ pipeline {
 
 def determineDeploymentType() {
 	if ("${sourceRepository}".trim() =~ /\/(?<version>\d+\.\d+)\/R-\k<version>(\.\d+)?-\d{12}(\/)?$/) {
-		input message: 'The specified P2 repository is a release and will be deployed to Maven-Central.', ok : 'Proceed deploying to Maven-Central'
 		return 'release'
 	} else {
 		return 'snapshot'

--- a/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
+++ b/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
@@ -81,6 +81,10 @@ pipeline {
 		stage('Checkout SCM') {
 			steps {
 				checkout scm
+				script { // Always load the script from the very same state this pipeline is loaded (to ensure consistency)
+					githubAPI = load "JenkinsJobs/shared/githubAPI.groovy"
+					githubAPI.setDryRun(params.DRY_RUN)
+				}
 				sh '''
 					git submodule update --init --recursive
 					git config --global user.email 'releng-bot@eclipse.org'
@@ -240,7 +244,7 @@ pipeline {
 				script {
 					def prHeadline = "Prepare ${NEXT_RELEASE_VERSION} development"
 					def prBranch = "prepare_R${NEXT_RELEASE_VERSION}"
-					def aggregatorPreparationPR = createPullRequest('eclipse-platform/eclipse.platform.releng.aggregator', prHeadline, """\
+					def aggregatorPreparationPR = githubAPI.createPullRequest('eclipse-platform/eclipse.platform.releng.aggregator', prHeadline, """\
 						Prepare development of Eclipse ${NEXT_RELEASE_VERSION}.
 						This includes:
 						- Updating the version of the Maven parent, all references to it and the Eclipse products to `${NEXT_RELEASE_VERSION}`
@@ -263,7 +267,7 @@ pipeline {
 							error "Unexpected of submodule URL: ${submoduleURL}"
 						}
 						def repoName = submoduleURL.substring(expectedPrefix.length(), submoduleURL.length() - expectedSuffix.length())
-						createPullRequest(repoName, prHeadline, """\
+						githubAPI.createPullRequest(repoName, prHeadline, """\
 							Prepare development of Eclipse ${NEXT_RELEASE_VERSION}.
 							This complements:
 							- ${aggregatorPreparationPR}
@@ -280,7 +284,7 @@ pipeline {
 				script {
 					def organisations = [ 'eclipse-platform', 'eclipse-jdt', 'eclipse-pde', 'eclipse-equinox' ]
 					for (organisation in organisations) {
-						def repositories = listReposOfOrganization(organisation)
+						def repositories = githubAPI.listReposOfOrganization(organisation)
 						echo "${organisation} repositories: ${repositories.name}"
 						for (repositoryData in repositories) {
 							def repository = repositoryData.name
@@ -291,12 +295,12 @@ pipeline {
 								echo "Skipping .eclipsefdn repository of : ${organisation}"
 								continue
 							}
-							createMilestone(organisation, repository, "${NEXT_RELEASE_VERSION} M1",  "${NEXT_RELEASE_VERSION} Milestone 1",         "${M1_DATE}")
-							createMilestone(organisation, repository, "${NEXT_RELEASE_VERSION} M2",  "${NEXT_RELEASE_VERSION} Milestone 2",         "${M2_DATE}")
-							createMilestone(organisation, repository, "${NEXT_RELEASE_VERSION} M3",  "${NEXT_RELEASE_VERSION} Milestone 3",         "${M3_DATE}")
-							createMilestone(organisation, repository, "${NEXT_RELEASE_VERSION} RC1", "${NEXT_RELEASE_VERSION} Release Candidate 1", "${RC1_DATE}")
-							createMilestone(organisation, repository, "${NEXT_RELEASE_VERSION} RC2", "${NEXT_RELEASE_VERSION} Release Candidate 2", "${RC2_DATE}")
-							createMilestone(organisation, repository, "${NEXT_RELEASE_VERSION}",     "${NEXT_RELEASE_VERSION} Release",             "${GA_DATE}")
+							githubAPI.createMilestone(organisation, repository, "${NEXT_RELEASE_VERSION} M1",  "${NEXT_RELEASE_VERSION} Milestone 1",         "${M1_DATE}")
+							githubAPI.createMilestone(organisation, repository, "${NEXT_RELEASE_VERSION} M2",  "${NEXT_RELEASE_VERSION} Milestone 2",         "${M2_DATE}")
+							githubAPI.createMilestone(organisation, repository, "${NEXT_RELEASE_VERSION} M3",  "${NEXT_RELEASE_VERSION} Milestone 3",         "${M3_DATE}")
+							githubAPI.createMilestone(organisation, repository, "${NEXT_RELEASE_VERSION} RC1", "${NEXT_RELEASE_VERSION} Release Candidate 1", "${RC1_DATE}")
+							githubAPI.createMilestone(organisation, repository, "${NEXT_RELEASE_VERSION} RC2", "${NEXT_RELEASE_VERSION} Release Candidate 2", "${RC2_DATE}")
+							githubAPI.createMilestone(organisation, repository, "${NEXT_RELEASE_VERSION}",     "${NEXT_RELEASE_VERSION} Release",             "${GA_DATE}")
 						}
 					}
 				}
@@ -304,6 +308,9 @@ pipeline {
 		}
 	}
 }
+
+@groovy.transform.Field
+def githubAPI = null
 
 // --- utility methods
 
@@ -333,69 +340,4 @@ def commitAllChangesExcludingSubmodules(String commitMessage) {
 			git commit --message "${COMMIT_MESSAGE}"
 		'''
 	}
-}
-
-// Github API interactions
-
-def listReposOfOrganization(String orga) {
-	def response = queryGithubAPI('', "orgs/${orga}/repos", null)
-	if (!(response instanceof List) && (response.errors || (response.status && response.status != 201))) {
-		error "Response contains errors:\n${response}"
-	}
-	return response
-}
-
-/**
- * Create a new milestone.
- * @param msDueDay the milestone's due-date, format: YYYY-MM-DD
- */
-def createMilestone(String orga, String repo, String msTitle, String msDescription, String msDueDay) {
-	echo "In ${orga}/${repo} create milestone: ${msTitle} due on ${msDueDay}"
-	def params = [title: msTitle, description: msDescription, due_on: "${msDueDay}T23:59:59Z"]
-	def response = queryGithubAPI('-X POST', "repos/${orga}/${repo}/milestones", params)
-	if (response?.errors || (response?.status && response.status != 201)) {
-		if (response.errors && response.errors[0]?.code == 'already_exists') {
-			echo 'Milestone already exists and is not modified'
-			// TODO: update milestone in this case: https://docs.github.com/en/rest/issues/milestones?apiVersion=2022-11-28#update-a-milestone
-			// Usefull if e.g. the dates are wrongly read from the calendar
-		} else {
-			error "Response contains errors:\n${response}"
-		}
-	}
-}
-
-/**
- * Create a PR in the specified repo, from a branch that is expected to reside in the same repository.
- */
-def createPullRequest(String orgaSlashRepo, String prTitle, String prBody, String headBranch, String baseBranch = 'master') {
-	echo "In ${orgaSlashRepo} create PR: '${prTitle}' on branch ${headBranch}"
-	def params = [title: prTitle, body: prBody, head: headBranch, base: baseBranch]
-	def response = queryGithubAPI('-X POST',"repos/${orgaSlashRepo}/pulls", params)
-	if (response?.errors || (response?.status && response.status != 201)) {
-		error "Response contains errors:\n${response}"
-	}
-	return response?.html_url
-}
-
-def queryGithubAPI(String method, String endpoint, Map<String, String> queryParameters) {
-	def query = """\
-		curl -L ${method} \
-			-H "Accept: application/vnd.github+json" \
-			-H "Authorization: Bearer \${GITHUB_BOT_TOKEN}" \
-			-H "X-GitHub-Api-Version: 2022-11-28" \
-			https://api.github.com/${endpoint} \
-		""".stripIndent()
-	if (queryParameters != null) {
-		def params = writeJSON(json: queryParameters, returnText: true)
-		query += "-d '" + params + "'"
-	}
-	if (params.DRY_RUN && !method.isEmpty()) {
-		echo "Query (not send): ${query}"
-		return null
-	}
-	def response = sh(script: query, returnStdout: true)
-	if (response == null || response.isEmpty()) {
-		error 'Response is null or empty. This commonly indicates: HTTP/1.1 500 Internal Server Error'
-	}
-	return readJSON(text: response)
 }

--- a/JenkinsJobs/Releng/promoteBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/promoteBuild.jenkinsfile
@@ -27,11 +27,6 @@ pipeline {
 					}
 					env.CHECKPOINT = readParameter('CHECKPOINT')
 					env.SIGNOFF_BUG = readParameter('SIGNOFF_BUG')
-					env.TRAIN_NAME = readParameter('TRAIN_NAME')
-					//TODO: record the train in buildproperties.shsource and read it here
-					if (!"${TRAIN_NAME}") {
-						error("Parameter 'TRAIN_NAME' is not specified")
-					}
 					def idMatcher = null
 					if ((idMatcher = env.DROP_ID =~ /I(?<date>\d{8})-(?<time>\d{4})/).matches()) {
 						assignEnvVariable('BUILD_LABEL', "${DROP_ID}")
@@ -58,14 +53,10 @@ pipeline {
 					assignEnvVariable('BUILD_SERVICE', versionMatcher.group('service'))
 					versionMatcher = null // release matcher as it's not serializable
 					
-					assignEnvVariable('BUILD_REPO_ORIGINAL', "${BUILD_MAJOR}.${BUILD_MINOR}-I-builds")
-					
 					if ("${CHECKPOINT}" ==~ /M\d+([a-z])?/ || "${CHECKPOINT}" ==~ /RC\d+([a-z])?/) { // milestone or RC promotion
 						assignEnvVariable('DL_TYPE', 'S')
-						// REPO_SITE_SEGMENT variale not used in this case
 					} else if (!"${CHECKPOINT}") { // release promotion
 						assignEnvVariable('DL_TYPE', 'R')
-						assignEnvVariable('REPO_SITE_SEGMENT', "${BUILD_MAJOR}.${BUILD_MINOR}")
 					} else {
 						error "CHECKPOINT, ${CHECKPOINT}, did not match any expected pattern."
 					}
@@ -93,6 +84,9 @@ pipeline {
 			steps {
 				dir("${WORKSPACE}/repository") {
 					checkout scm
+					script { // Always load the script from the very same state this pipeline is loaded (to ensure consistency)
+						githubAPI = load "JenkinsJobs/shared/githubAPI.groovy"
+					}
 					sh '''#!/bin/bash -xe
 						git fetch origin tag "${REPO_ID}"
 						git checkout "${REPO_ID}"
@@ -107,26 +101,6 @@ pipeline {
 		}
 		stage('Move and rename Pages') {
 			steps {
-				writeFile(file: "${WORKSPACE}/stage2output${TRAIN_NAME}${CHECKPOINT}/mailtemplate.txt", text: """\
-					We are pleased to announce that ${TRAIN_NAME} ${CHECKPOINT} is available for download and updates.
-					
-						Eclipse downloads:
-						https://download.eclipse.org/eclipse/downloads/drops4/${DL_DROP_ID}/
-						
-						New and Noteworthy:
-						https://www.eclipse.org/eclipse/news/${BUILD_MAJOR}.${BUILD_MINOR}/
-						
-						Update existing (non-production) installs:
-						https://download.eclipse.org/eclipse/updates/${DL_TYPE == 'R' ? REPO_SITE_SEGMENT : BUILD_REPO_ORIGINAL}/
-						
-						Specific repository good for building against:
-						https://download.eclipse.org/eclipse/updates/${DL_TYPE == 'R' ? (REPO_SITE_SEGMENT + '/' + DL_DROP_ID) : (BUILD_REPO_ORIGINAL + '/' + DROP_ID)}/
-						
-						Equinox specific downloads:
-						https://download.eclipse.org/equinox/drops/${DL_DROP_ID}/
-					
-					Thank you to everyone who made this checkpoint possible.
-				""".stripIndent())
 				sshagent(['projects-storage.eclipse.org-bot-ssh']) {
 					
 					echo 'Promote Equinox'
@@ -186,8 +160,8 @@ pipeline {
 				dir("${WORKSPACE}/updates") {
 					sshagent(['projects-storage.eclipse.org-bot-ssh']) {
 						sh '''#!/bin/bash -xe
-							sourceRepo="eclipse/updates/${BUILD_REPO_ORIGINAL}/${REPO_ID}"
-							targetRepo="eclipse/updates/${REPO_SITE_SEGMENT}/${DL_DROP_ID}"
+							sourceRepo="eclipse/updates/${BUILD_MAJOR}.${BUILD_MINOR}-I-builds/${REPO_ID}"
+							targetRepo="eclipse/updates/${BUILD_MAJOR}.${BUILD_MINOR}/${DL_DROP_ID}"
 							ssh genie.releng@projects-storage.eclipse.org cp -r "${EP_ROOT}/${sourceRepo}/." "${EP_ROOT}/${targetRepo}"
 							
 							MIRRORS_URL="https://www.eclipse.org/downloads/download.php?file=/${targetRepo}"
@@ -204,28 +178,44 @@ pipeline {
 				}
 			}
 		}
+		stage('Stage for Maven-Central') {
+			when {
+				environment name: 'DL_TYPE', value: 'R'
+			}
+			steps {
+				build job: 'Releng/deployToMaven', wait: true, propagate: true, parameters: [
+					string(name: 'sourceRepository', value: "https://download.eclipse.org/eclipse/updates/${BUILD_MAJOR}.${BUILD_MINOR}/${DL_DROP_ID}/")
+				]
+			}
+		}
+		stage('Update acknowledgements') {
+			environment {
+				GITHUB_BOT_TOKEN = credentials('github-bot-token')
+			}
+			steps {
+				script {
+					githubAPI.triggerWorkflow('eclipse-platform/www.eclipse.org-eclipse', 'generateAcknowledgements.yml', [ 'eclipse-version': "${BUILD_MAJOR}.${BUILD_MINOR}" ])
+				}
+			}
+		}
+		stage('Trigger publication') {
+			when {
+				not {
+					environment name: 'DL_TYPE', value: 'R'
+				}
+			}
+			steps {
+				build job: 'Releng/publishPromotedBuild', wait: true, propagate: true, parameters: [
+					string(name: 'releaseBuildID', value: "${DL_DROP_ID}")
+				]
+			}
+		}
 	}
 	post {
 		always {
 			archiveArtifacts artifacts: '**/*', excludes: 'repository/**'
 		}
 	}
-}
-
-@NonCPS
-def assignEnvVariable(String name, String value) {
-	env."${name}" = value
-	println("${name}=${value}")
-}
-
-@NonCPS
-def readParameter(String name) {
-	//TODO: let jenkins trim the parameters
-	def value = (params[name] ?: '').trim()
-	if (value) {
-		println("${name}: ${value}")
-	}
-	return value
 }
 
 def renameBuildDrop(String baseDropPath, String oldDropID, String oldBuildLabel, String newDropID, String newBuildLabel, Closure extraTasks=null) {
@@ -301,4 +291,21 @@ EOF
 			ssh genie.releng@projects-storage.eclipse.org cp -r '${targetPath}' /home/data/httpd/archive.eclipse.org/${baseDropPath}/
 		fi
 	"""
+}
+
+@groovy.transform.Field
+def githubAPI = null
+
+@NonCPS
+def readParameter(String name) {
+	//TODO: let jenkins trim the parameters
+	def value = (params[name] ?: '').trim()
+	println("${name}: ${value}")
+	return value
+}
+
+@NonCPS
+def assignEnvVariable(String name, String value) {
+	env."${name}" = value
+	println("${name}=${value}")
 }

--- a/JenkinsJobs/Releng/publishPromotedBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/publishPromotedBuild.jenkinsfile
@@ -8,6 +8,10 @@ pipeline {
 	agent {
 		label 'basic'
 	}
+	tools {
+		jdk 'temurin-jdk21-latest'
+		maven 'apache-maven-latest'
+	}
 	stages {
 		stage('Process Input') {
 			steps {
@@ -15,23 +19,40 @@ pipeline {
 					if (!params.releaseBuildID) {
 						error "Required parameter 'releaseBuildID' is not defined."
 					}
-					env.RELEASE_BUILD_ID = params.releaseBuildID.trim()
-					def releaseIDMatcher = env.RELEASE_BUILD_ID =~ /(?<type>[SR])-(?<major>\d+)\.(?<minor>\d+)(\.\d+)?((M|RC)\d+[a-z]?)?-\d{12}/
-					if (!releaseIDMatcher.matches()) {
+					assignEnvVariable('RELEASE_BUILD_ID', params.releaseBuildID.trim())
+					def idMatcher = env.RELEASE_BUILD_ID =~ /(?<type>[SR])-(?<major>\d+)\.(?<minor>\d+)(\.\d+)?(?<checkpoint>(M|RC)\d+[a-z]?)?-(?<date>\d{8})(?<time>\d{4})/
+					if (!idMatcher.matches()) {
 						error "releaseID: ${RELEASE_BUILD_ID}, does not match the expected pattern."
 					}
-					env.RELEASE_TYPE = releaseIDMatcher.group('type')
-					env.RELEASE_VERSION_MAJOR = releaseIDMatcher.group('major')
-					env.RELEASE_VERSION_MINOR = releaseIDMatcher.group('minor')
-					dropIDMatcher = null // release matcher as it's not serializable
+					assignEnvVariable('RELEASE_TYPE', idMatcher.group('type'))
+					assignEnvVariable('RELEASE_VERSION_MAJOR', idMatcher.group('major'))
+					assignEnvVariable('RELEASE_VERSION_MINOR', idMatcher.group('minor'))
+					assignEnvVariable('CHECKPOINT', idMatcher.group('checkpoint') ?: 'GA')
+					def buildId = "I${idMatcher.group('date')}-${idMatcher.group('time')}"
+					idMatcher = null // release matcher as it's not serializable
+					
+					if (env.RELEASE_TYPE == 'R') {
+						assignEnvVariable('REPOSITORY_PATH', "${RELEASE_VERSION_MAJOR}.${RELEASE_VERSION_MINOR}/${RELEASE_BUILD_ID}")
+					} else if (env.RELEASE_TYPE == 'S') {
+						assignEnvVariable('REPOSITORY_PATH', "${RELEASE_VERSION_MAJOR}.${RELEASE_VERSION_MINOR}-I-builds/${buildId}")
+					} else {
+						error "RELEASE_TYPE, ${RELEASE_TYPE}, did not match any expected pattern."
+					}
+					
+					sh """
+							git clone --depth=1 --filter=tree:0 --no-checkout --branch=${buildId} https://github.com/eclipse-platform/eclipse.platform.releng.aggregator.git
+							cd eclipse.platform.releng.aggregator
+							git sparse-checkout set --no-cone eclipse-platform-parent/pom.xml
+							git checkout
+							
+							mvn -f eclipse-platform-parent help:evaluate -Dexpression=releaseName '-Doutput=${WORKSPACE}/releaseName-value.txt' \
+								--batch-mode --no-transfer-progress --no-snapshot-updates
+					"""
+					assignEnvVariable('TRAIN_NAME', readFile('releaseName-value.txt').trim())
+					if (!env.TRAIN_NAME) {
+						error "TRAIN_NAME is empty."
+					}
 				}
-				sh '''
-					echo 'Input parameters read successfully'
-					echo "RELEASE_BUILD_ID='$RELEASE_BUILD_ID'"
-					echo "RELEASE_TYPE='$RELEASE_TYPE'"
-					echo "RELEASE_VERSION_MAJOR='$RELEASE_VERSION_MAJOR'"
-					echo "RELEASE_VERSION_MINOR='$RELEASE_VERSION_MINOR'"
-				'''
 			}
 		}
 		stage('Make Download Page visible') {
@@ -76,5 +97,43 @@ pipeline {
 				]
 			}
 		}
+		stage('Send announcement mail') {
+			steps {
+				emailext subject: "Eclipse and Equinox ${RELEASE_VERSION_MAJOR}.${RELEASE_VERSION_MINOR} (${TRAIN_NAME}) ${CHECKPOINT} is available",
+					body: ("""\
+					Hello everyone,
+					
+					We are pleased to announce that Eclipse and Equinox ${RELEASE_VERSION_MAJOR}.${RELEASE_VERSION_MINOR} ${CHECKPOINT} (for ${TRAIN_NAME}) is available for download and updates.
+					
+						Eclipse downloads:
+						https://download.eclipse.org/eclipse/downloads/drops4/${RELEASE_BUILD_ID}/
+						
+						New and Noteworthy:
+						https://www.eclipse.org/eclipse/news/${RELEASE_VERSION_MAJOR}.${RELEASE_VERSION_MINOR}/
+						
+						Update existing (non-production) installs:
+						https://download.eclipse.org/eclipse/updates/${REPOSITORY_PATH.substring(0, REPOSITORY_PATH.lastIndexOf('/'))}/
+						
+						Specific repository good for building against:
+						https://download.eclipse.org/eclipse/updates/${REPOSITORY_PATH}/
+						
+						Equinox specific downloads:
+						https://download.eclipse.org/equinox/drops/${RELEASE_BUILD_ID}/
+					
+					Thank you to everyone who made this checkpoint possible.
+					
+					Best regards,
+					
+					The Eclipse contributors
+					""").stripIndent(), mimeType: 'text/plain', from:'genie.releng@eclipse.org',
+					to: "platform-releng-dev@eclipse.org eclipse-dev@eclipse.org platform-dev@eclipse.org equinox-dev@eclipse.org jdt-dev@eclipse.org pde-dev@eclipse.org"
+			}
+		}
 	}
+}
+
+@NonCPS
+def assignEnvVariable(String name, String value) {
+	env."${name}" = value
+	println("${name}=${value}")
 }

--- a/JenkinsJobs/shared/githubAPI.groovy
+++ b/JenkinsJobs/shared/githubAPI.groovy
@@ -1,0 +1,85 @@
+
+@groovy.transform.Field
+def boolean IS_DRY_RUN = false
+
+def setDryRun(boolean isDryRun) {
+	IS_DRY_RUN = isDryRun
+}
+
+/** Returns a list of all repositories in the specified organization.*/
+def listReposOfOrganization(String orga) {
+	def response = queryGithubAPI('', "orgs/${orga}/repos", null)
+	if (!(response instanceof List) && (response.errors || (response.status && response.status != 201))) {
+		error "Response contains errors:\n${response}"
+	}
+	return response
+}
+
+/**
+ * Create a new milestone.
+ * @param msDueDay the milestone's due-date, format: YYYY-MM-DD
+ */
+def createMilestone(String orga, String repo, String msTitle, String msDescription, String msDueDay) {
+	echo "In ${orga}/${repo} create milestone: ${msTitle} due on ${msDueDay}"
+	def params = [title: msTitle, description: msDescription, due_on: "${msDueDay}T23:59:59Z"]
+	def response = queryGithubAPI('-X POST', "repos/${orga}/${repo}/milestones", params)
+	if (response?.errors || (response?.status && response.status != 201)) {
+		if (response.errors && response.errors[0]?.code == 'already_exists') {
+			echo 'Milestone already exists and is not modified'
+			// TODO: update milestone in this case: https://docs.github.com/en/rest/issues/milestones?apiVersion=2022-11-28#update-a-milestone
+			// Usefull if e.g. the dates are wrongly read from the calendar
+		} else {
+			error "Response contains errors:\n${response}"
+		}
+	}
+}
+
+/**
+ * Create a PR in the specified repo, from a branch that is expected to reside in the same repository.
+ */
+def createPullRequest(String orgaSlashRepo, String prTitle, String prBody, String headBranch, String baseBranch = 'master') {
+	echo "In ${orgaSlashRepo} create PR: '${prTitle}' on branch ${headBranch}"
+	def params = [title: prTitle, body: prBody, head: headBranch, base: baseBranch]
+	def response = queryGithubAPI('-X POST',"repos/${orgaSlashRepo}/pulls", params)
+	if (response?.errors || (response?.status && response.status != 201)) {
+		error "Response contains errors:\n${response}"
+	}
+	return response?.html_url
+}
+
+def triggerWorkflow(String orgaSlashRepo, String workflowId, Map<String, String> inputs, String referenceBranch = 'master') {
+	echo "In ${orgaSlashRepo} trigger workflow '${workflowId}' on branch ${referenceBranch} with inputs ${inputs}"
+	def params = ['ref': referenceBranch, 'inputs': inputs]
+	def response = queryGithubAPI('-X POST',"repos/${orgaSlashRepo}/actions/workflows/${workflowId}/dispatches", params, true)
+	if (response?.errors || (response?.status && response.status != 204)) {
+		error "Response contains errors:\n${response}"
+	}
+}
+
+def queryGithubAPI(String method, String endpoint, Map<String, Object> queryParameters, boolean allowEmptyReponse = false) {
+	def query = """\
+		curl -L ${method} \
+			-H "Accept: application/vnd.github+json" \
+			-H "Authorization: Bearer \${GITHUB_BOT_TOKEN}" \
+			-H "X-GitHub-Api-Version: 2022-11-28" \
+			https://api.github.com/${endpoint} \
+		""".stripIndent()
+	if (queryParameters != null) {
+		def params = writeJSON(json: queryParameters, returnText: true)
+		query += "-d '" + params + "'"
+	}
+	if (IS_DRY_RUN && !method.isEmpty()) {
+		echo "Query (not send): ${query}"
+		return null
+	}
+	def response = sh(script: query, returnStdout: true)
+	if (response == null || response.isEmpty()) {
+		if (allowEmptyReponse) {
+			return null
+		}
+		error 'Response is null or empty. This commonly indicates: HTTP/1.1 500 Internal Server Error'
+	}
+	return readJSON(text: response)
+}
+
+return this

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -36,11 +36,10 @@
    - **Friday**:
      * **Promote** the release candidate (if go).
        * Run the [Promote Build](https://ci.eclipse.org/releng/job/Releng/job/promoteBuild/) job in Jenkins
-         - DROP_ID: Release candidate build ID (make sure there is no space before or after the ID).
-         - CHECKPOINT: M1 etc (blank for final releases)
-         - SIGNOFF_BUG: Needs to be updated to sign-off issue (numeric part only)
-         - TRAIN_NAME: Whenever the current GA release is planned for (formatted 4 digit year - 2 digit month, i.e `2022-06`)
-         - After the build  find and open the mail template [artifact](https://ci.eclipse.org/releng/job/Releng/job/promoteBuild/lastSuccessfulBuild/artifact/) and have it ready.
+         - `DROP_ID`: ID of the build to promote, e.g.: `I20250817-1800`
+         - `CHECKPOINT`: M1 etc. (blank for final releases)
+         - `SIGNOFF_BUG`: Needs to be updated to sign-off issue (numeric part only)
+         - For Milestones/RC promotions, this should automatically run the [Publish Promoted Build](https://ci.eclipse.org/releng/job/Releng/job/publishPromotedBuild/) job to make the promoted build immediatly visible on the download page.
        * Contribute to SimRel
          - If you have not already set up SimRel you can do so using Auto Launch [here](https://www.eclipse.org/setups/installer/?url=https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/interim/SimultaneousReleaseTrainConfiguration.setup&show=true)
          - Clone [org.eclipse.simrel.build](https://git.eclipse.org/c/simrel/org.eclipse.simrel.build.git) (Should have been done by the installer during set up, but make sure you have latest).
@@ -50,11 +49,6 @@
            4. Update the Location property to the "Specific repository for building against" in the mailtemplate.txt from promotion.
            5. Commit Simrel updates to Gerrit
               - Message should use year-month format, i.e "Simrel updates for Eclipse and Equinox for 2022-06 M1"
-       * Run the [Publish Promoted Build](https://ci.eclipse.org/releng/job/Releng/job/publishPromotedBuild/) job in Releng jenkins to make the promoted build visible on the download page.
-         - `releaseBuildID`: the full id of the milestone, release-candidate or release build to publish, e.g. `S-4.26M1-202209281800` or `R-4.36-202505281830`
-       * Send email that the M1 build is available
-         - Use the mail template from the promotion build [artifacts](https://ci.eclipse.org/releng/job/Releng/job/promoteBuild/lastSuccessfulBuild/artifact/) in Jenkins to get the download urls.
-         - Make sure to mention that the Master branch is now again open for development.
        * For **Milestone builds** return the I-builds to the normal schedule.
      * **After RC1**
        * Leave the I-builds running on the milestone schedule for RC2. 
@@ -100,16 +94,9 @@ The actual steps to release
 
 **Friday**
   * #### **Promote to GA**
-    - After Simrel declares RC2 (usually the Friday before release) run the [Promote Build](https://ci.eclipse.org/releng/job/Releng/job/promoteBuild/) job to promote RC2 (or RC2a). If the [daily cleanup for old builds](https://ci.eclipse.org/releng/job/Cleanup/job/dailyCleanOldBuilds/) job was not disabled and the original I-build is no longer available you can use the promoted RC2 build.
-      - Change the DL_TYPE from S to R.  
-      - TAG will be set to R as well, for example `R4_27` 
+    - After Simrel declares RC2 (usually the Friday before release) run the [Promote Build](https://ci.eclipse.org/releng/job/Releng/job/promoteBuild/) job to promote RC2 (or RC2a).
+      - `DROP_ID`: Final delease candidate's ID, e.g.: `S-4.36RC2-202505281830/`
     - You can subscribe to [cross-project-issues](https://accounts.eclipse.org/mailing-list/cross-project-issues-dev) to get the notifications on Simrel releases.
-  * #### **Deploy to Maven central**
-    - Deploying to maven should happen by at least Tuesday before the release since there is up to a 24 hour delay for the maven mirrors.
-    - Run the [Deploy to Maven](https://ci.eclipse.org/releng/job/Releng/job/deployToMaven/) job in Jenkins with the release build as `sourceRepository`.
-      - About a minute after triggering the job, Jenkins will ask for confirmation on the console, if the specified build should really be deployed to Maven-Central staging.
-    - Once that deploy-job has completed successfully, log into https://central.sonatype.com/ and close the `Platform`, `JDT` and `PDE` repositories.
-      - If you do not have an account on `central.sonatype.com` for performing the rest of the release request one by creating an [EF Help Desk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues) issue to get permissions for platform, JDT and PDE projects and tag an existing release engineer to give approval.
   * **Contribute to SimRel**
     - If SimRel is not updated before the I-builds are cleaned up (specifically the build for RC2/GA) it will break. 
 
@@ -117,10 +104,15 @@ The actual steps to release
 The release is scheduled for 10AM EST. Typically the jobs are scheduled beforehand and run automatically.
 
   * **Make the Release Visible**
-    - Same process as for a milestone but with release versions.
+    - Run the [Publish Promoted Build](https://ci.eclipse.org/releng/job/Releng/job/publishPromotedBuild/) job in Releng jenkins to make the promoted build visible on the download page.
+      - `releaseBuildID`: the full id of the release build to publish, e.g. `R-4.36-202505281830`
   * **Complete Publication to Maven Central**
-    - Go to https://oss.sonatype.org/#stagingRepositories and "Release" the three staging repositories.
-  * **Send the Announcement Email**
+    - The final release to Maven-Central should happen latest by Tuesday before the release since there is up to a 24 hour delay for the Maven mirrors.
+    - The artifacts have been deployed into a Maven-Central _staging_ repository by the `Promote Build` job when the RC was promoted to GA release.
+    - Login to https://central.sonatype.com/ and "Release" the three staging repositories for `Platform`, `JDT` and `PDE` by closing them.
+      - Make sure the name of the deployment you are about to release matches the tag and timestamp of the final release repository.
+        E.g for a P2 repo with id `R-4.36-202505281830` the deploymenets should be named `PLATFORM_R-4.36-202505281830`, `PDE_R-4.36-202505281830` or `JDT_R-4.36-202505281830` respectivly.
+      - If you do not have an account on `central.sonatype.com` for performing the rest of the release request one by creating an [EF Help Desk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues) issue to get permissions for platform, JDT and PDE projects and tag an existing release engineer to give approval.
 
 ### **Post Release Tasks:**
   * #### **Clean up intermediate artifacts** 


### PR DESCRIPTION
Automate the following tasks that are current executed manually as part of the build promotion and publication jobs
- Trigger Maven-Central staging for release promotions
- Update acknowledgements on each promotion (to have the list up-to-date even for Milestones, etc.)
- Trigger publication immediately for Milestone- and RC-promotions
  - Only defer for release promotion
- Send mail on milestone/RC/release publication
  - And remove mail template generation from promotion job
  - Requires https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6536

Extract code to interact with the GitHub-API into a dedicated Groovy-file, which is shared among all using jobs.

@MohananRahul can you please check if the proposed changes are fine?
@elsazac as per updated documentation, with this the promotion to Maven-Central staging should happen automatically during the release promotion (which I assume happens usually at the Friday before the release, on a Wednesday). The only manual task left is then to close the staging repository to perform the final release to Maven-Central.