### PR TITLE
[RelEng] Keep up to ten builds of the Promotion/Publication jobs

### DIFF
--- a/JenkinsJobs/Releng/promoteBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/promoteBuild.jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
 		skipDefaultCheckout()
 		timestamps()
 		timeout(time: 120, unit: 'MINUTES')
-		buildDiscarder(logRotator(numToKeepStr:'5'))
+		buildDiscarder(logRotator(numToKeepStr:'10'))
 	}
 	agent {
 		label 'basic'

--- a/JenkinsJobs/Releng/publishPromotedBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/publishPromotedBuild.jenkinsfile
@@ -2,8 +2,8 @@ pipeline {
 	options {
 		skipDefaultCheckout()
 		timestamps()
-		timeout(time: 15, unit: 'MINUTES')
-		buildDiscarder(logRotator(numToKeepStr:'5'))
+		timeout(time: 45, unit: 'MINUTES')
+		buildDiscarder(logRotator(numToKeepStr:'10'))
 	}
 	agent {
 		label 'basic'


### PR DESCRIPTION
This way at least one release cycle is available in the history, as these jobs run at least six times per release (M1, M2, M3, RC1, RC2 and R/GA).

Also extend the timeout for the publication job, which runs usually at most 7min (for a release), to 45min. This is safety factor is similarly high to the promotion-job (which runs about 20min max and has a 120min timeout, as I don't want to have a promotion/publication aborted, just due to a slow network or busy Jenkins.