### PR TITLE
XHTML tags must be closed with a closing tag or a trailing slash #3236

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/p2_repositorytasks.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/p2_repositorytasks.htm
@@ -1011,7 +1011,7 @@
                 <tt>destination</tt>
               </td>
               <td>
-                The destination repository to modify, defined as outlined <a href="#destination_repositories">above</a>.<br>
+                The destination repository to modify, defined as outlined <a href="#destination_repositories">above</a>.<br/>
                 If it already exists, it is modified in place; otherwise, an initially empty repository is created.
               </td>
             </tr>
@@ -1020,7 +1020,7 @@
                 <tt>source</tt>
               </td>
               <td>
-                Optional source repositories, as outlined <a href="#source_repositories">above</a>.<br>
+                Optional source repositories, as outlined <a href="#source_repositories">above</a>.<br/>
                 If specified, the content of the sources is copied to the destination, before it is modified.
                 This can be used to modify a remote (read-only) repository, by specifying it as the <code>source</code>, writing the result to a local <code>destination</code> repository, and then copying the resulting files to the remote server.
               </td>


### PR DESCRIPTION
A single <br> without a matching </br> is forbidden in HTML, but required in XHTML.