### PR TITLE
Convert remaining XHTML documents in platform.doc.isv to HTML

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/about.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/about.html
@@ -1,8 +1,7 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
 <title>About</title>
 </head>
 <body lang="EN-US">

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/p2_repositorytasks.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/p2_repositorytasks.htm
@@ -1,13 +1,12 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
   <head>
     <meta name="copyright" content=
-    "Copyright (c) IBM Corporation and others 2009, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta http-equiv="Content-Style-Type" content="text/css" />
+    "Copyright (c) IBM Corporation and others 2009, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Style-Type" content="text/css">
     <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type=
-    "text/css" />
+    "text/css">
     <title>
       Ant tasks for managing repositories
     </title>
@@ -238,7 +237,7 @@
     </table>
     <h2>
       Ant Tasks
-    </h2><br />
+    </h2><br>
     <table cellspacing="1" cellpadding="2" width="95%" align="center">
       <tr>
         <td>
@@ -436,7 +435,7 @@
                             properties that the artifact descriptor must have.
                           </td>
                         </tr>
-                      </table><br />
+                      </table><br>
                       Example: Exclude all pack.gz artifacts:
                       <pre>
     &lt;exclude&gt;
@@ -597,7 +596,7 @@
           </table>
         </td>
       </tr>
-    </table><br />
+    </table><br>
     Examples:
     <p>
 
@@ -729,7 +728,7 @@
           </table>
         </td>
       </tr>
-    </table><br />
+    </table><br>
     <table cellspacing="1" cellpadding="2" width="95%" align="center">
       <tr>
         <td>
@@ -872,7 +871,7 @@
           </table>
         </td>
       </tr>
-    </table><br />
+    </table><br>
     <table cellspacing="1" cellpadding="2" width="95%" align="center">
       <tr>
         <td>
@@ -925,7 +924,7 @@
 
         </td>
       </tr>
-    </table><br />
+    </table><br>
     <table cellspacing="1" cellpadding="2" width="95%" align="center">
       <tr>
         <td>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/p2_uipolicy.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/p2_uipolicy.htm
@@ -1,17 +1,16 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
   <head>
     <meta name="copyright" content=
-    "Copyright (c) IBM Corporation and others 2008, 2016. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta http-equiv="Content-Style-Type" content="text/css" />
+    "Copyright (c) IBM Corporation and others 2008, 2016. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Style-Type" content="text/css">
     <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type=
-    "text/css" />
+    "text/css">
     <title>
       Configuring the UI Policy
     </title>
-    <link rel="stylesheet" type="text/css" href="../book.css" />
+    <link rel="stylesheet" type="text/css" href="../book.css">
 
     <style type="text/css">
 /*<![CDATA[*/
@@ -239,7 +238,7 @@ org.eclipse.equinox.p2.ui.sdk.scheduler/download=true
 
     <p>
       <img border="0" src="images/p2cloudinstall.png" alt=
-      "Example Install Wizard" />
+      "Example Install Wizard">
     </p>
     <h3>
       Example: Customizing the UI Queries
@@ -278,7 +277,7 @@ org.eclipse.equinox.p2.ui.sdk.scheduler/download=true
 
     <p>
       <img border="0" src="images/p2allbundles.png" alt=
-      "Example Install Wizard showing all bundles in the repository" />
+      "Example Install Wizard showing all bundles in the repository">
     </p>
     <p>
       Likewise, the <b>Installed Software</b> page shows every bundle in the
@@ -287,7 +286,7 @@ org.eclipse.equinox.p2.ui.sdk.scheduler/download=true
     </p>
     <p>
       <img border="0" src="images/p2allbundlesinstalled.png" alt=
-      "Example Installed Software page showing all bundles that are installed" />
+      "Example Installed Software page showing all bundles that are installed">
 
     </p>
     <p>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_cheatsheet_composite.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_cheatsheet_composite.htm
@@ -1,13 +1,12 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
   <head>
     <meta name="copyright" content=
-    "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta http-equiv="Content-Style-Type" content="text/css" />
+    "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Style-Type" content="text/css">
     <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type=
-    "text/css" />
+    "text/css">
     <script language="JavaScript" src=
     "PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript">
 </script>
@@ -222,18 +221,18 @@
     <p>
       <a href=
       "../../org.eclipse.platform.doc.user/reference/ref-cheatsheets.htm">Working
-      with cheat sheets</a><br />
+      with cheat sheets</a><br>
       <a href=
       "../../org.eclipse.platform.doc.user/reference/ref-composite-cheatsheets.htm">
-      Working with composite cheat sheets</a><br />
-      <a href="ua_cheatsheet_simple.htm">Creating cheat sheets</a><br />
+      Working with composite cheat sheets</a><br>
+      <a href="ua_cheatsheet_simple.htm">Creating cheat sheets</a><br>
 
-      <a href="ua_cheatsheet_guidelines.htm">Authoring guidelines</a><br />
+      <a href="ua_cheatsheet_guidelines.htm">Authoring guidelines</a><br>
       <a href="ua_cheatsheet_composite_content.htm">Composite cheat sheet
-      content file specification</a><br />
+      content file specification</a><br>
       <a href=
       "../reference/extension-points/org_eclipse_ui_cheatsheets_cheatSheetContent.html">
-      org.eclipse.ui.cheatsheets.cheatSheetContent extension point</a><br />
+      org.eclipse.ui.cheatsheets.cheatSheetContent extension point</a><br>
     </p>
   </body>
 </html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_dynamic_extensions.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_dynamic_extensions.htm
@@ -1,13 +1,12 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
   <head>
     <meta name="copyright" content=
-    "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta http-equiv="Content-Style-Type" content="text/css" />
+    "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Style-Type" content="text/css">
     <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type=
-    "text/css" />
+    "text/css">
     <script language="JavaScript" src=
     "PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript">
 </script>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_dynamic_includes.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_dynamic_includes.htm
@@ -1,13 +1,12 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
   <head>
     <meta name="copyright" content=
-    "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta http-equiv="Content-Style-Type" content="text/css" />
+    "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Style-Type" content="text/css">
     <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type=
-    "text/css" />
+    "text/css">
     <script language="JavaScript" src=
     "PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript">
 </script>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_abstract_scope.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_abstract_scope.htm
@@ -1,13 +1,12 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
   <head>
     <meta name="copyright" content=
-    "Copyright (c) IBM Corporation and others 2010, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta http-equiv="Content-Style-Type" content="text/css" />
+    "Copyright (c) IBM Corporation and others 2010, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Style-Type" content="text/css">
     <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type=
-    "text/css" />
+    "text/css">
     <script language="JavaScript" src=
     "PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript">
 </script>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_child_links.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_child_links.htm
@@ -1,13 +1,12 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
   <head>
     <meta name="copyright" content=
-    "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta http-equiv="Content-Style-Type" content="text/css" />
+    "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Style-Type" content="text/css">
     <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type=
-    "text/css" />
+    "text/css">
     <title>
       Adding Child Links to Help Pages
     </title>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_setup_help_data.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_setup_help_data.htm
@@ -1,17 +1,16 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
   <head>
     <meta name="copyright" content=
-    "Copyright (c) IBM Corporation and others 2006, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    "Copyright (c) IBM Corporation and others 2006, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>
       Help Data
     </title>
     <link rel="stylesheet" href="../schema.css" charset="utf-8" type=
-    "text/css" />
+    "text/css">
     <link rel="stylesheet" href="../book.css" charset="utf-8" type=
-    "text/css" />
+    "text/css">
     <style type="text/css">
 /*<![CDATA[*/
     span.c3 {color: #008000}
@@ -54,8 +53,8 @@
     <p class="">
 
       The extension data for Help.
-    </p><br />
-    <br />
+    </p><br>
+    <br>
     <p class="SchemaDtd">
       &lt;!ELEMENT <a name="e.tocOrder" id="e.tocOrder">tocOrder</a> (<a href=
       "#e.toc">toc</a> | <a href="#e.category">category</a>)*&gt;
@@ -67,8 +66,8 @@
       the items listed is not available, it is ignored. If there are items
       available that are not listed and not hidden, they will be displayed
       after the ones listed here.
-    </p><br />
-    <br />
+    </p><br>
+    <br>
     <p class="SchemaDtd">
       &lt;!ELEMENT <a name="e.toc" id="e.toc">toc</a> EMPTY&gt;
 
@@ -83,7 +82,7 @@
 
       A reference to a top-level table of contents (TOC) entry, also called a
       "book".
-    </p><br />
+    </p><br>
     <ul class="ConfigMarkupAttlistDesc">
       <li>
         <b>id</b> - The unique identifier for this book. For XML file TOC
@@ -94,7 +93,7 @@
         originating <code>AbstractTocProvider</code>.
       </li>
 
-    </ul><br />
+    </ul><br>
     <p class="SchemaDtd">
       &lt;!ELEMENT <a name="e.category" id="e.category">category</a> EMPTY&gt;
     </p>
@@ -112,12 +111,12 @@
       specifying a <code>category</code> attribute for the <code>toc</code>
 
       element in the <code>org.eclipse.help.toc</code> extension point.
-    </p><br />
+    </p><br>
     <ul class="ConfigMarkupAttlistDesc">
       <li>
         <b>id</b> - The unique id of the category.
       </li>
-    </ul><br />
+    </ul><br>
 
     <p class="SchemaDtd">
       &lt;!ELEMENT <a name="e.hidden" id="e.hidden">hidden</a> (<a href=
@@ -127,8 +126,8 @@
 
     <p class="ConfigMarkupElementDesc">
       Contains a set of help items that should be hidden from the user.
-    </p><br />
-    <br />
+    </p><br>
+    <br>
     <p class="SchemaDtd">
       &lt;!ELEMENT <a name="e.index" id="e.index">index</a> EMPTY&gt;
     </p>
@@ -141,7 +140,7 @@
     </p>
     <p class="ConfigMarkupElementDesc">
       A reference to a contribution of help index keywords.
-    </p><br />
+    </p><br>
 
     <ul class="ConfigMarkupAttlistDesc">
       <li>
@@ -153,7 +152,7 @@
         originating <code>AbstractIndexProvider</code>.
       </li>
 
-    </ul><br />
+    </ul><br>
     <h6 class="CaptionFigColumn">
       Examples:
     </h6>
@@ -225,7 +224,7 @@
     <code>org.eclipse.help</code>, including the default help implementation
     provided by Eclipse.
     <p class="SchemaCopyright">
-      Copyright (c) 2006, 2011 IBM Corporation and others.<br />
+      Copyright (c) 2006, 2011 IBM Corporation and others.<br>
       All rights reserved. This program and the accompanying materials are made
       available under the terms of the Eclipse Public License v1.0 which
       accompanies this distribution, and is available at <a href=

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/questions/index.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/questions/index.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
 <head>
-	<meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2013. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
-   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css"/>
+	<meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2013. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
    <title>Platform questions index</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/extension-points/index.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/extension-points/index.html
@@ -1,15 +1,14 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
   <head>
     <meta name="copyright" content=
-    "Copyright (c) 2000, 2016 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    "Copyright (c) 2000, 2016 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>
       Platform Extension Points
     </title>
     <link rel="STYLESHEET" href="../../book.css" charset="ISO-8859-1" type=
-    "text/css" />
+    "text/css">
     <style type="text/css">
 /*<![CDATA[*/
     :link { color: #0000FF }

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/services/index.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/services/index.html
@@ -1,15 +1,14 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
   <head>
     <meta name="copyright" content=
-    "Copyright (c) 2021 Red Hat Inc. Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    "Copyright (c) 2021 Red Hat Inc. Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>
       OSGi services used by Platform and open to extensibility
     </title>
     <link rel="STYLESHEET" href="../../book.css" charset="ISO-8859-1" type=
-    "text/css" />
+    "text/css">
     <style type="text/css">
 /*<![CDATA[*/
     :link { color: #0000FF }

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/whatsNew/platform_isv_whatsnew.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/whatsNew/platform_isv_whatsnew.html
@@ -1,10 +1,10 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
 <head>
-  <meta name="copyright" content="Copyright (c) Eclipse contributors and others 2025. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page."/>
-  <meta http-equiv="Content-Language" content="en-us"/>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-  <link rel="STYLESHEET" href="../book.css" type="text/css"/>
+  <meta name="copyright" content="Copyright (c) Eclipse contributors and others 2025. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+  <meta http-equiv="Content-Language" content="en-us">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <link rel="STYLESHEET" href="../book.css" type="text/css">
   <style type="text/css">
     body { max-width: 900px; font-family: sans-serif; }
   </style>


### PR DESCRIPTION
Unlike plain HTML, XHTML also follows the XML rules and is therefore more restrictive. By mixing both HTML and XHTML documents, this can very easily lead to a situation where syntax is used that is valid in one, but not the other document.

With this change, all documents within org.eclipse.platform.doc.isv that are still using XHTML are converted to HTML.