### PR TITLE
[RelEng] Simplify/shorten 'sign-off page' link in the download page

### DIFF
--- a/JenkinsJobs/Releng/promoteBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/promoteBuild.jenkinsfile
@@ -76,7 +76,6 @@ pipeline {
 					} else if (env.SIGNOFF_BUG ==~ '\\d+') {
 						assignEnvVariable('SIGNOFF_BUG', "https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/${SIGNOFF_BUG}")
 					}
-					assignEnvVariable('SIGNOFF_BUG_LABEL', env.SIGNOFF_BUG.replace('https://github.com/','').replace('/issues/','#'))
 				}
 			}
 		}
@@ -118,7 +117,7 @@ pipeline {
 								
 								# SIGNOFF_BUG should not be defined if there are no JUnit failures to investigate and explain
 								if [[ -n "${SIGNOFF_BUG}" ]]; then
-									echo -e "<p>Any unit test failures below have been investigated and found to be test-related and do not affect the quality of the build.\\nSee the sign-off page <a href=\\"${SIGNOFF_BUG}\\">${SIGNOFF_BUG_LABEL}</a> for details.</p>" > 'testNotes.html'
+									echo -e "<p>Any unit test failures below have been investigated and found to be test-related and do not affect the quality of the build.\\nSee the <a href=\\"${SIGNOFF_BUG}\\">sign-off page</a> for details.</p>" > 'testNotes.html'
 								fi
 							'''
 						}


### PR DESCRIPTION
Makes the page content more compact and the promotion pipeline a little bit simpler.
The GH-issue style label was added in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3225, but seems not to help that much.