### PR TITLE
Migration guide for Eclipse 4.37 from 4.36

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/META-INF/MANIFEST.MF
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.doc.isv; singleton:=true
-Bundle-Version: 3.14.2800.qualifier
+Bundle-Version: 3.14.2900.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.2.0,4.0.0)"

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.doc.isv</artifactId>
-  <version>3.14.2800-SNAPSHOT</version>
+  <version>3.14.2900-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <profiles>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/4.37/faq.html
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/4.37/faq.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2025 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../../book.css" charset="ISO-8859-1" type="text/css">
+<title>Eclipse JDT 4.37 Plug-in Migration FAQ</title>
+</head>
+
+<body>
+
+<h1>Eclipse JDT 4.37 Plug-in Migration FAQ</h1>
+
+<ol>
+	<li>None</li>
+</ol>
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/4.37/incompatibilities.html
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/4.37/incompatibilities.html
@@ -1,0 +1,19 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2025 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../../book.css" type="text/css">
+<title>Incompatibilities between Eclipse 4.36 and 4.37</title>
+</head>
+<body>
+<h1>Incompatibilities Between Eclipse 4.36 and 4.37</h1>
+
+<p>
+  So far Eclipse did not change incompatibly between 4.36 and 4.37 in ways that affect
+  plug-ins. Plug-ins that ran on 4.36 should run on 4.37 without any problems.
+</p>
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/4.37/recommended.html
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/4.37/recommended.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2025 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../../book.css" charset="ISO-8859-1" type="text/css">
+<title>Adopting JDT 4.37 mechanisms and APIs</title>
+</head>
+
+<body>
+
+<h1>Adopting JDT 4.37 Mechanisms and APIs</h1>
+<p>
+  This section describes changes that are required if you are trying to change
+  your 4.36 plug-in to adopt the 4.37 mechanisms and APIs.
+</p>
+
+<ol>
+	<li>None</li>
+</ol>
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/eclipse_4_37_porting_guide.html
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/eclipse_4_37_porting_guide.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+
+<head>
+
+<meta name="copyright" content="Copyright (c) IBM 2025 Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
+<title>Eclipse JDT 4.37 Plug-in Migration Guide</title>
+</head>
+
+<body>
+
+<h1>Eclipse JDT 4.37 Plug-in Migration Guide</h1>
+<p>This guide covers migrating Eclipse JDT 4.36 plug-ins to Eclipse JDT 4.37.</p>
+<p>One of the goals of Eclipse 4.37 was to move Eclipse forward while remaining compatible
+  with previous versions to the greatest extent possible. That is, plug-ins written
+  against the Eclipse 4.36 APIs should continue to work in 4.37 in spite of the
+  API changes.</p>
+<p>The key kinds of compatibility are API contract compatibility and binary compatibility.
+  API contract compatibility means that valid use of 4.36 APIs remains valid for
+  4.37, so there is no need to revisit working code. Binary compatibility means
+  that the API method signatures, etc. did not change in ways that would cause
+  existing compiled (&quot;binary&quot;) code to no longer link and run with the
+  new 4.37 libraries.</p>
+<p>While every effort was made to avoid breakage, there are a few areas of incompatibility or new
+  APIs that should be adopted by clients.
+  This document describes those areas and provides instructions for migrating 4.36 plug-ins to
+  4.37.</p>
+<ul>
+  <li><a href="4.37/faq.html">Eclipse JDT 4.37 Plug-in Migration FAQ</a></li>
+  <li><a href="4.37/incompatibilities.html">Incompatibilities between Eclipse JDT 4.36 and 4.37</a></li>
+  <li><a href="4.37/recommended.html">Adopting 4.37 mechanisms and API</a></li>
+</ul>
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/topics_Porting.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/topics_Porting.xml
@@ -4,6 +4,12 @@
 <!-- Define topics for the porting guide index                                     -->
 <!-- ============================================================================= -->
 <toc label="Migration">
+	<topic label="Migrating to Eclipse JDT 4.37 from 4.36">
+		<topic label="Introduction" href="porting/eclipse_4_37_porting_guide.html"/>
+		<topic label="FAQ"                             href="porting/4.37/faq.html" />
+		<topic label="Incompatibilities"               href="porting/4.37/incompatibilities.html" />
+		<topic label="Adopting 4.37 Mechanisms and API" href="porting/4.37/recommended.html" />
+	</topic>
 	<topic label="Migrating to Eclipse JDT 4.36 from 4.35">
 		<topic label="Introduction" href="porting/eclipse_4_36_porting_guide.html"/>
 		<topic label="FAQ"                             href="porting/4.36/faq.html" />
@@ -22,13 +28,13 @@
 		<topic label="Incompatibilities"               href="porting/4.34/incompatibilities.html" />
 		<topic label="Adopting 4.34 Mechanisms and API" href="porting/4.34/recommended.html" />
 	</topic>
-	<topic label="Migrating to Eclipse JDT 4.33 from 4.32">
+	<topic label="Migrating to Eclipse JDT 4.32 from 4.31">
+		<topic label="Migrating to Eclipse JDT 4.33 from 4.32">
 		<topic label="Introduction" href="porting/eclipse_4_33_porting_guide.html"/>
 		<topic label="FAQ"                             href="porting/4.33/faq.html" />
 		<topic label="Incompatibilities"               href="porting/4.33/incompatibilities.html" />
 		<topic label="Adopting 4.33 Mechanisms and API" href="porting/4.33/recommended.html" />
 	</topic>
-	<topic label="Migrating to Eclipse JDT 4.32 from 4.31">
 		<topic label="Introduction" href="porting/eclipse_4_32_porting_guide.html"/>
 		<topic label="FAQ"                             href="porting/4.32/faq.html" />
 		<topic label="Incompatibilities"               href="porting/4.32/incompatibilities.html" />

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.37/faq.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.37/faq.html
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2025 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../../book.css" charset="ISO-8859-1" type="text/css">
+<title>Eclipse 4.37 Plug-in Migration FAQ</title>
+</head>
+<body>
+<h1>Eclipse 4.37 Plug-in Migration FAQ</h1>
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.37/incompatibilities.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.37/incompatibilities.html
@@ -1,0 +1,47 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2025 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../../book.css" type="text/css">
+<title>Incompatibilities between Eclipse 4.36 and 4.37</title>
+</head>
+<body>
+<h1>Incompatibilities Between Eclipse 4.36 and 4.37</h1>
+
+<p>
+  Eclipse changed in incompatible ways between 4.36 and 4.37 in ways that affect
+  plug-ins. The following entries describe the areas that changed and provide
+  instructions for migrating 4.36 plug-ins to 4.37. Note that you only need to look
+  here if you are experiencing problems running your 4.36 plug-in on 4.37.
+</p>
+<p>
+See also the list of <a href="../removals.html">deprecated API removals</a> for this release.
+</p>
+
+<ol>
+<li><a href="#upstream-bundles">Several bundles renamed for 3rd party libraries</a></li>
+</ol>
+
+<hr>
+
+<!-- ############################################## -->
+
+<h2>1. <a name="native-fragments-merge">Multiple Platform-specific Fragments Merged Into Their Host</a></h2>
+<p>
+	The following platform-specific fragments have been merged into their respective host bundle:
+	<ul>
+		<li><code>org.eclipse.core.resources.win32.win32.x86_64</code></li>
+		<li><code>org.eclipse.core.filesystem.win32.x86_64</code></li>
+		<li><code>org.eclipse.core.net.linux</code></li>
+		<li><code>org.eclipse.core.net.win32</code></li>
+	</ul>
+</p>
+<p>
+	All functionality formerly provided through these platform-specific fragments is now provided by the fragment's host bundle alone and no code change is required.
+	If any of the mentioned fragments is referenced in a PDE <em>feature.xml</em> or listed as content of a product definition it just has to be removed.
+</p>
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.37/recommended.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.37/recommended.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+
+<head>
+	<meta name="copyright"
+		content="Copyright (c) 2025 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+	<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+	<meta http-equiv="Content-Style-Type" content="text/css">
+	<link rel="STYLESHEET" href="../../book.css" type="text/css">
+	<title>Adopting 4.37 mechanisms and APIs</title>
+</head>
+
+<body>
+	<h1>Adopting 4.37 Mechanisms and APIs</h1>
+
+	<p>This section describes changes that are required if you are
+		trying to change your 4.36 plug-in to adopt the 4.37 mechanisms and
+		APIs.</p>
+
+	<!-- ##############################################
+	 ############################################## -->
+
+</body>
+1
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/eclipse_4_37_porting_guide.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/eclipse_4_37_porting_guide.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2025 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
+<title>Eclipse 4.37 Plug-in Migration Guide</title>
+</head>
+
+<body>
+
+<h1>Eclipse 4.37 Plug-in Migration Guide</h1>
+<p>This guide covers migrating Eclipse 4.36 plug-ins to Eclipse 4.37.</p>
+<p>One of the goals of Eclipse 4.37 was to move Eclipse forward while remaining compatible
+  with previous versions to the greatest extent possible. That is, plug-ins written
+  against the Eclipse 4.36 APIs should continue to work in 4.37 in spite of any API changes.</p>
+<p>The key kinds of compatibility are API contract compatibility and binary compatibility.
+  API contract compatibility means that valid use of 4.36 APIs remains valid for
+  4.37, so there is no need to revisit working code. Binary compatibility means
+  that the API method signatures, etc. did not change in ways that would cause
+  existing compiled (&quot;binary&quot;) code to no longer link and run with the
+  new 4.37 libraries.</p>
+<p>While every effort was made to avoid breakage, there are a few areas of incompatibility or new
+  APIs that should be adopted by clients.
+  This document describes those areas and provides instructions for migrating 4.36 plug-ins to
+  4.37.</p>
+<ul>
+  <li><a href="4.37/faq.html">Eclipse 4.37 Plug-in Migration FAQ</a></li>
+  <li><a href="4.37/incompatibilities.html">Incompatibilities between Eclipse 4.36 and 4.37</a></li>
+  <li><a href="4.37/recommended.html">Adopting 4.37 mechanisms and API</a></li>
+</ul>
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/topics_Porting.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/topics_Porting.xml
@@ -5,6 +5,12 @@
 <!-- ============================================================================= -->
 <toc label="Migration">
 	<topic label="Deprecated API removals" href="porting/removals.html"/>
+	<topic label="Migrating to Eclipse 4.37 from 4.36">
+		<topic label="Introduction" href="porting/eclipse_4_37_porting_guide.html"/>
+		<topic label="FAQ" href="porting/4.37/faq.html" />
+		<topic label="Incompatibilities" href="porting/4.37/incompatibilities.html" />
+		<topic label="Adopting 4.37 mechanisms and API" href="porting/4.37/recommended.html" />
+	</topic>
 	<topic label="Migrating to Eclipse 4.36 from 4.35">
 		<topic label="Introduction" href="porting/eclipse_4_36_porting_guide.html"/>
 		<topic label="FAQ" href="porting/4.36/faq.html" />
@@ -41,13 +47,13 @@
 		<topic label="Incompatibilities" href="porting/4.31/incompatibilities.html" />
 		<topic label="Adopting 4.31 mechanisms and API" href="porting/4.31/recommended.html" />
 	</topic>
-	<topic label="Migrating to Eclipse 4.30 from 4.29">
+		<topic label="Older Migration Guides">
+		<topic label="Migrating to Eclipse 4.30 from 4.29">
 		<topic label="Introduction" href="porting/eclipse_4_30_porting_guide.html"/>
 		<topic label="FAQ" href="porting/4.30/faq.html" />
 		<topic label="Incompatibilities" href="porting/4.30/incompatibilities.html" />
 		<topic label="Adopting 4.30 mechanisms and API" href="porting/4.30/recommended.html" />
 	</topic>
-		<topic label="Older Migration Guides">
 		<topic label="Migrating to Eclipse 4.29 from 4.28">
 			<topic label="Introduction" href="porting/eclipse_4_29_porting_guide.html"/>
 			<topic label="FAQ" href="porting/4.29/faq.html" />


### PR DESCRIPTION
Migration guide for Eclipse 4.37