### PR TITLE
docs/help: fix DTD for P2 feature.xml

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/feature_manifest.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/feature_manifest.html
@@ -16,8 +16,8 @@ Eclipse Platform Feature Manifest</h1>
 
 <p>The feature manifest format is defined by the following dtd:</p>
 <p><tt>&lt;?xml encoding="ISO-8859-1"?&gt;</tt></p>
-<p><tt>&lt;!ELEMENT feature (install-handler? | description? | copyright? |
-license? | url? | includes* | requires? | plugin* | data*)&gt;</tt>
+<p><tt>&lt;!ELEMENT feature (install-handler? , description? , copyright? ,
+license? , url? , includes* , requires? , plugin* , data*)&gt;</tt>
 <br><tt>&lt;!ATTLIST feature</tt>
 <br><tt>&nbsp;&nbsp;&nbsp; id&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 CDATA #REQUIRED</tt>


### PR DESCRIPTION
Replace pipe with comma, since pipe means "or" / choice. But that would mean you can only use one of the elements. Comma means that feature must contain the following elements, which is what we want here

I found an archived site which uses comma: https://archive.eclipse.org/eclipse/downloads/documentation/2.0/html/plugins/org.eclipse.platform.doc.isv/reference/misc/feature_archive.html

