### PR TITLE
Migrate "reference" documents to HTML5

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/extension-points/index.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/extension-points/index.html
@@ -1,16 +1,14 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <meta name="copyright" content=
     "Copyright (c) 2000, 2016 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta charset="utf-8">
     <title>
       Platform Extension Points
     </title>
-    <link rel="STYLESHEET" href="../../book.css" charset="ISO-8859-1" type=
-    "text/css" />
-    <style type="text/css">
+    <link rel="STYLESHEET" href="../../book.css" type="text/css">
+    <style>
 /*<![CDATA[*/
     :link { color: #0000FF }
     :visited { color: #800080 }
@@ -24,8 +22,8 @@
       Platform Extension Points
     </h1>The following extension points can be used to extend the capabilities
     of the platform infrastructure:
-    <h3>
-      <a name="runtime" id="runtime"></a>Platform Runtime
+    <h3 id="runtime">
+      Platform Runtime
     </h3>
     <ul>
       <li>
@@ -60,8 +58,8 @@
         "org_eclipse_equinox_preferences_preferences.html">org.eclipse.equinox.preferences.preferences</a>
       </li>
     </ul>
-    <h3>
-      <a name="workspace" id="workspace"></a>Workspace
+    <h3 id="workspace">
+      Workspace
     </h3>
     <ul>
 
@@ -112,8 +110,8 @@
         "org_eclipse_core_resources_variableResolvers.html">org.eclipse.core.resources.variableResolvers</a>
       </li>
     </ul>
-    <h3>
-      <a name="text" id="text"></a>Platform Text
+    <h3 id="text">
+      Platform Text
     </h3>
     <ul>
       <li>
@@ -211,8 +209,8 @@
       </li>
     </ul>
 
-    <h3>
-      <a name="workbench" id="workbench"></a>Workbench
+    <h3 id="workbench">
+      Workbench
     </h3>
     <ul>
       <li>
@@ -473,8 +471,8 @@
         "org_eclipse_ui_workingSets.html">org.eclipse.ui.workingSets</a>
       </li>
     </ul>
-    <h3>
-      <a name="team" id="team"></a>Team
+    <h3 id="team">
+      Team
     </h3>
     <ul>
 <!-- Bug 467584: [JSch] document org.eclipse.jsch.core.authenticator extension-point
@@ -532,8 +530,8 @@
         "org_eclipse_team_ui_teamDecorators.html">org.eclipse.team.ui.teamDecorators</a>
       </li>
     </ul>
-    <h3>
-      <a name="debug" id="debug"></a>Debug
+    <h3 id="debug">
+      Debug
     </h3>
 
     <ul>
@@ -688,8 +686,8 @@
       </li>
     </ul>
 
-    <h3>
-      <a name="console" id="console"></a>Console
+    <h3 id="console">
+      Console
     </h3>
     <ul>
       <li>
@@ -706,8 +704,8 @@
         "org_eclipse_ui_console_consolePatternMatchListeners.html">org.eclipse.ui.console.consolePatternMatchListeners</a>
       </li>
     </ul>
-    <h3>
-      <a name="ua" id="ua"></a>User Assistance
+    <h3 id="ua">
+      User Assistance
     </h3>
     <ul>
 
@@ -822,8 +820,8 @@
       </li>
     </ul>
 
-    <h3>
-      <a name="ltk" id="ltk"></a>Language Toolkit
+    <h3 id="ltk">
+      Language Toolkit
     </h3>
     <ul>
       <li>
@@ -862,8 +860,8 @@
         "org_eclipse_ltk_ui_refactoring_statusContextViewers.html">org.eclipse.ltk.ui.refactoring.statusContextViewers</a>
       </li>
     </ul>
-    <h3>
-      <a name="security" id="security"></a>Security
+    <h3 id="security">
+      Security
     </h3>
     <ul>
 
@@ -890,8 +888,8 @@
       </li>
     </ul>
 
-    <h3>
-      <a name="other" id="other"></a>Other
+    <h3 id="other">
+      Other
     </h3>
     <ul>
       <li>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/about_customization.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/about_customization.html
@@ -1,12 +1,12 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 
 <head>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2005. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<link rel="STYLESHEET" href="../../book.css" charset="ISO-8859-1" type="text/css">
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../../book.css" type="text/css">
 <title>About.ini File Format</title>
 </head>
 

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/api-usage-rules.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/api-usage-rules.html
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"><html lang="en">
+<!DOCTYPE HTML><html lang="en">
 <HEAD>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
-<META HTTP-EQUIV="Content-Style-Type" CONTENT="text/css">
-<link REL="STYLESHEET" HREF="../../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+<META charset="utf-8">
+<link REL="STYLESHEET" HREF="../../book.css" TYPE="text/css">
    <title>Eclipse Platform API - Rules of Engagement</title>
 
 

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/bidi.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/bidi.html
@@ -1,10 +1,9 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"><html lang="en">
+<!DOCTYPE HTML><html lang="en">
 <head>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2013. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Language" content="en-us">
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<link REL="STYLESHEET" HREF="../../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+<meta charset="utf-8">
+<link REL="STYLESHEET" HREF="../../book.css" TYPE="text/css">
 <title>Supporting bidirectional text</title>
 </head>
 <BODY>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/buddy_loading.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/buddy_loading.html
@@ -1,11 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2005. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<link REL="STYLESHEET" HREF="../../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+   <meta charset="utf-8">
+<link REL="STYLESHEET" HREF="../../book.css" TYPE="text/css">
    <title>Third party libraries and classloading</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/bundle_manifest.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/bundle_manifest.html
@@ -1,12 +1,15 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2005, 2011. This page is made available under license. Full for details see the LEGAL in the documentation book that contains this page." >
 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<link REL="STYLESHEET" HREF="../../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+<meta charset="utf-8">
+<link REL="STYLESHEET" HREF="../../book.css" TYPE="text/css">
 <title>OSGi Bundle Manifest</title>
+<style>
+  ul.disc { list-style-type: disc; }
+</style>
 </head>
 
 <body>
@@ -214,7 +217,7 @@ Eclipse-PlatformFilter ::= a valid LDAP filter string
 The Framework supports filtering on the following system properties:
 </p>
 
-<ul type="disc">
+<ul class="disc">
  <li><b>osgi.nl</b> - the platform language setting.</li>
  <li><b>osgi.os</b> - the platform operating system.</li>
  <li><b>osgi.arch</b> - the platform architecture.</li>
@@ -482,7 +485,7 @@ The EModel-Fragment header must use the following syntax:
 Model-Fragment ::= filename;apply= ( 'always' | 'initial' | 'notexists' )
 </pre>
 
-
+<p>
 The following is an example of the Model-Fragment header:
 </p>
 
@@ -492,12 +495,12 @@ Model-Fragment: fragment.e4xmi;apply=always
 
 <p>
   The <code>apply</code> attribute is optional and defaults to <code>always</code>. It can have the following values:
-  <ul>
-    <li><b>always</b>: each time the application started potentially replacing existing model elements and loosing information stored</li>
-    <li><b>initial</b>: only when coming from a none persistent state</li>
-    <li><b>notexists</b>: only if the given element does not exist already in the model</li>
-  </ul>
 </p>
+<ul>
+  <li><b>always</b>: each time the application started potentially replacing existing model elements and loosing information stored</li>
+  <li><b>initial</b>: only when coming from a none persistent state</li>
+  <li><b>notexists</b>: only if the given element does not exist already in the model</li>
+</ul>
       
 </div>
 

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/eclipse-install.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/eclipse-install.html
@@ -1,14 +1,21 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 
 <head>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-<meta http-equiv="Content-Language" content="en-us">
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<link REL="STYLESHEET" HREF="../../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+<meta charset="utf-8">
+<link REL="STYLESHEET" HREF="../../book.css" TYPE="text/css">
 <title>How to write an Eclipse installer</title>
+<style>
+  table, td {
+    border: 1px;
+    width: 50%;
+  }
+  table { border-style: outset; }
+  td { border-style: inset; }
+</style>
 </head>
 
 <body>
@@ -181,26 +188,26 @@ details follow the list of steps):</p>
 <p>If the location specified in step 5 is &lt;<code><i>install</i></code>&gt;,
 the installer copies all the files in the &lt;<i><code>JRE</code></i>&gt;, <code>&lt;<i>platform</i>&gt;, </code> &lt;<i><code>product</code></i>&gt;,&nbsp;
 and <code>&lt;<i>product plug-ins</i>&gt;</code> directories into &lt;<code><i>install</i></code>&gt;.</p>
-<table border="1" width="50%">
+<table>
   <tr>
-    <td width="50%">Input file</td>
-    <td width="50%">Installed file</td>
+    <td>Input file</td>
+    <td>Installed file</td>
   </tr>
   <tr>
-    <td width="50%"><code>&lt;<i>JRE</i>&gt;/*</code></td>
-    <td width="50%"><code>&lt;<i>install</i>&gt;/eclipse/*</code></td>
+    <td><code>&lt;<i>JRE</i>&gt;/*</code></td>
+    <td><code>&lt;<i>install</i>&gt;/eclipse/*</code></td>
   </tr>
   <tr>
-    <td width="50%"><code>&lt;<i>product head</i>&gt;/*</code></td>
-    <td width="50%"><code>&lt;<i>install</i>&gt;/*</code></td>
+    <td><code>&lt;<i>product head</i>&gt;/*</code></td>
+    <td><code>&lt;<i>install</i>&gt;/*</code></td>
   </tr>
   <tr>
-    <td width="50%"><code>&lt;<i>product body</i>&gt;/*</code></td>
-    <td width="50%"><code>&lt;<i>install</i>&gt;/*</code></td>
+    <td><code>&lt;<i>product body</i>&gt;/*</code></td>
+    <td><code>&lt;<i>install</i>&gt;/*</code></td>
   </tr>
   <tr>
-    <td width="50%"><code>&lt;<i>platform</i>&gt;/*</code></td>
-    <td width="50%"><code>&lt;<i>install</i>&gt;/*</code></td>
+    <td><code>&lt;<i>platform</i>&gt;/*</code></td>
+    <td><code>&lt;<i>install</i>&gt;/*</code></td>
   </tr>
 </table>
 <p>The marker file created in step 8 is <code>&lt;<i>install</i>&gt;/eclipse/.eclipseproduct</code>
@@ -398,14 +405,14 @@ The areas where it differs are highlighted below:</p>
 <p>If the location specified in step 5 is &lt;<code><i>install</i></code>&gt;,
 the installer copies all the files in the <code>&lt;<i>extension</i>&gt; </code>directory
 into &lt;<code><i>install</i></code>&gt; in step 11.</p>
-<table border="1" width="50%">
+<table>
   <tr>
-    <td width="50%">Input file</td>
-    <td width="50%">Installed file</td>
+    <td>Input file</td>
+    <td>Installed file</td>
   </tr>
   <tr>
-    <td width="50%"><code>&lt;<i>extension</i>&gt;/*</code></td>
-    <td width="50%"><code>&lt;<i>install</i>&gt;/*</code></td>
+    <td><code>&lt;<i>extension</i>&gt;/*</code></td>
+    <td><code>&lt;<i>install</i>&gt;/*</code></td>
   </tr>
 </table>
 <p>For step 7, any Eclipse product might be a candidate. Eclipse-based product

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/eclipsestarter.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/eclipsestarter.html
@@ -1,13 +1,12 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 
 <head>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2007. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-<meta http-equiv="Content-Language" content="en-us">
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<link REL="STYLESHEET" HREF="../../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+<meta charset="utf-8">
+<link REL="STYLESHEET" HREF="../../book.css" TYPE="text/css">
 <title>Starting Eclipse from Java</title>
 </head>
 

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/feature_archive.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/feature_archive.html
@@ -1,11 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2005. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<link REL="STYLESHEET" HREF="../../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+   <meta charset="utf-8">
+<link REL="STYLESHEET" HREF="../../book.css" TYPE="text/css">
    <title>Feature Archives</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/feature_manifest.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/feature_manifest.html
@@ -1,11 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2012. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<link REL="STYLESHEET" HREF="../../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+   <meta charset="utf-8">
+<link REL="STYLESHEET" HREF="../../book.css" TYPE="text/css">
    <title>Feature Manifest</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/index.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/index.html
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"><html lang="en">
+<!DOCTYPE HTML><html lang="en">
 <HEAD>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2017. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
-<META HTTP-EQUIV="Content-Style-Type" CONTENT="text/css">
-<link REL="STYLESHEET" HREF="../../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+<meta charset="utf-8">
+<link REL="STYLESHEET" HREF="../../book.css" TYPE="text/css">
    <title>Other Reference Information</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/launcher.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/launcher.html
@@ -1,8 +1,8 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en"><head>
    <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
-   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-   <link rel="STYLESHEET" href="../../book.css" charset="ISO-8859-1" type="text/css">
+   <meta charset="utf-8">
+   <link rel="STYLESHEET" href="../../book.css" type="text/css">
    <title>Eclipse Launcher</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/launcher_ini.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/launcher_ini.html
@@ -1,10 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"><html lang="en">
+<!DOCTYPE HTML><html lang="en">
 <head>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<link REL="STYLESHEET" HREF="../../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+<meta charset="utf-8">
+<link REL="STYLESHEET" HREF="../../book.css" TYPE="text/css">
 <title>Eclipse launch configuration</title>
 </head>
 

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/message_bundles.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/message_bundles.html
@@ -1,10 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"><html lang="en">
+<!DOCTYPE HTML><html lang="en">
 <head>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<link REL="STYLESHEET" HREF="../../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+<meta charset="utf-8">
+<link REL="STYLESHEET" HREF="../../book.css" TYPE="text/css">
 <title>Message Bundles</title>
 </head>
 

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/multi_user_installs.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/multi_user_installs.html
@@ -1,15 +1,14 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2005. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-<meta http-equiv="Content-Language" content="en-us">
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<link REL="STYLESHEET" HREF="../../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+<meta charset="utf-8">
+<link REL="STYLESHEET" HREF="../../book.css" TYPE="text/css">
 <title>Eclipse Multi-user Installs</title>
 </head>
-<body text="#000000" bgcolor="#ffffff">
+<body>
 <h1>Eclipse Multi-user Installs</h1>
 <p>
   Eclipse provides a number of strategies for supporting multi-user installs.

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/naming.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/naming.html
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"><html lang="en">
+<!DOCTYPE HTML><html lang="en">
 <HEAD>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2012. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
-<META HTTP-EQUIV="Content-Style-Type" CONTENT="text/css">
-<link REL="STYLESHEET" HREF="../../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+<meta charset="utf-8">
+<link REL="STYLESHEET" HREF="../../book.css" TYPE="text/css">
    <title>Eclipse Platform - Naming Conventions</title>
 </head>
 <body>
@@ -16,10 +15,10 @@ Naming Conventions</h1>
 <p>Naming conventions and guidelines for the Eclipse Platform:</p>
 <ul>
 <li>
-<a href="#Java Packages">Java packages</a></li>
+<a href="#Java_Packages">Java packages</a></li>
 
 <li>
-<a href="#Classes and Interfaces">Classes and interfaces</a></li>
+<a href="#Classes_and_Interfaces">Classes and interfaces</a></li>
 
 <li>
 <a href="#Methods">Methods</a></li>
@@ -31,8 +30,7 @@ Naming Conventions</h1>
 <a href="#Plug-ins">Plug-ins and extension points</a></li>
 </ul>
 
-<h2>
-<a NAME="Java Packages"></a><b>Java Packages</b></h2>
+<h2 id="Java_Packages"><b>Java Packages</b></h2>
 The Eclipse Platform consists of a collection of Java packages. The package
 namespace is managed in conformance with <a href="http://www.oracle.com/technetwork/java/codeconventions-135099.html#367">Java's
 package naming guidelines</a>; subpackages should not be created without
@@ -132,8 +130,7 @@ Package names should contain only lowercase ASCII alphanumerics, and avoid
 underscore <tt>_</tt> or dollar sign <tt>$</tt> characters.</li>
 </ul>
 
-<h2>
-<a NAME="Classes and Interfaces"></a><b>Classes and Interfaces</b></h2>
+<h2 id="Classes_and_Interfaces"><b>Classes and Interfaces</b></h2>
 <p><a href="http://www.oracle.com/technetwork/java/codeconvtoc-136057.html">Java's naming guidelines</a>
 state</p>
 <blockquote>Class names should be nouns, in mixed case with the first letter
@@ -157,8 +154,7 @@ The names of exception classes (subclasses of <tt>Exception</tt>) should
 follow the common practice of ending in "<tt>Exception</tt>".</li>
 </ul>
 
-<h2>
-<a NAME="Methods"></a><b>Methods</b></h2>
+<h2 id="Methods"><b>Methods</b></h2>
 <p><a href="http://www.oracle.com/technetwork/java/codeconvtoc-136057.html">Java's naming guidelines</a>
 state</p>
 <blockquote>Methods should be verbs, in mixed case with the first letter
@@ -175,8 +171,7 @@ setters (<tt>set<i>X</i>()</tt>), and predicates (<tt>is<i>X</i>()</tt>,
 <tt>has<i>X</i>()</tt>).</li>
 </ul>
 
-<h2>
-<a NAME="Variables"></a><b>Variables</b></h2>
+<h2 id="Variables"><b>Variables</b></h2>
 <p><a href="http://www.oracle.com/technetwork/java/codeconvtoc-136057.html">Java's naming guidelines</a>
 state</p>
 <blockquote>Except for variables, all instance, class, and class constants
@@ -195,8 +190,7 @@ integers; <tt>c</tt>, <tt>d</tt>, and <tt>e</tt> for characters.<br>&nbsp;
 <br><tt>&nbsp;&nbsp;&nbsp; float myWidth;</tt></blockquote>
 <p>(Note: we are no longer following the convention that prefixes non-constant
 field names with "<tt>f</tt>", such as "<tt>fWidget</tt>".)</p>
-<h2>
-<a NAME="Constants"></a><b>Constants</b></h2>
+<h2 id="Constants"><b>Constants</b></h2>
 <p><a href="http://www.oracle.com/technetwork/java/codeconvtoc-136057.html">Java's naming guidelines</a>
 states</p>
 <blockquote>The names of variables declared class constants and of ANSI
@@ -206,8 +200,7 @@ constants should be all uppercase with words separated by underscores (&quot;_&q
 <br><tt>&nbsp;&nbsp;&nbsp; static final int MAX_WIDTH = 999;</tt>
 <br><tt>&nbsp;&nbsp;&nbsp; static final int GET_THE_CPU = 1;</tt></blockquote>
 
-<h2>
-<a NAME="Plug-ins"></a><b>Plug-ins and Extension Points</b></h2>
+<h2 id="Plug-ins"><b>Plug-ins and Extension Points</b></h2>
 <p>All plug-ins, including the ones that are part of the Eclipse Platform,
 like the Resources and Workbench plug-ins, must have unique identifiers
 following the same naming pattern as Java packages. For example, workbench

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/overview-platform.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/overview-platform.html
@@ -1,14 +1,23 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"><html lang="en">
+<!DOCTYPE HTML><html lang="en">
 
 <head>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2016. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
+<meta charset="utf-8">
 
-<link rel="STYLESHEET" href="../../book.css" charset="ISO-8859-1" type="text/css">
+<link rel="STYLESHEET" href="../../book.css" type="text/css">
 <title>Map of platform plug-ins</title>
+<style>
+  table, td { border: 1px; }
+  td { border-style: inset; }
+  table {
+    margin-left: auto;
+    margin-right: auto;
+    border-style: outset;
+    width: 80%;
+  }
+</style>
 </head>
 
 <body>
@@ -20,8 +29,7 @@ workbench.</p>
 The following table shows which API packages are found in which plug-ins.
 This table is useful for
 determining which plug-ins a given plug-in should include as prerequisites.</p>
-<center>
-<table border="1" width="80%">
+<table>
   <tr>
     <td><strong>API Package</strong></td>
     <td><strong>Required plug-in id</strong></td>
@@ -141,7 +149,7 @@ determining which plug-ins a given plug-in should include as prerequisites.</p>
     <td><tt>org.eclipse.core.runtime<br>
     org.eclipse.equinox.registry<br>
     org.eclipse.equinox.common</tt></td>
-    <td>[<a href="#Note 1">1</a>]</td>
+    <td>[<a href="#Note_1">1</a>]</td>
   </tr>
   <tr>
     <td><tt>org.eclipse.core.runtime.dynamichelpers<br>
@@ -380,7 +388,7 @@ determining which plug-ins a given plug-in should include as prerequisites.</p>
     org.eclipse.jface.wizard<br>
     org.eclipse.jface.wizard.images</tt></td>
       <td><tt>org.eclipse.jface</tt></td>
-    <td>[<a href="#Note 3">3</a>]</td>
+    <td>[<a href="#Note_3">3</a>]</td>
   </tr>
   <tr>
     <td><tt> org.eclipse.jface.contentassist<br>
@@ -402,7 +410,7 @@ determining which plug-ins a given plug-in should include as prerequisites.</p>
     org.eclipse.jface.text.templates (split)<br>
     org.eclipse.jface.text.templates.persistence</tt></td>
     <td><tt>org.eclipse.jface.text</tt></td>
-    <td>[<a href="#Note 4">4</a>]</td>
+    <td>[<a href="#Note_4">4</a>]</td>
   </tr>
   <tr>
     <td><tt> org.eclipse.jface.text (split)<br>
@@ -413,7 +421,7 @@ determining which plug-ins a given plug-in should include as prerequisites.</p>
     org.eclipse.text.edits<br>
     org.eclipse.text.undo</tt></td>
     <td><tt>org.eclipse.text</tt></td>
-    <td>[<a href="#Note 4">4</a>]</td>
+    <td>[<a href="#Note_4">4</a>]</td>
   </tr>
   <tr>
   	<td>
@@ -500,7 +508,7 @@ determining which plug-ins a given plug-in should include as prerequisites.</p>
     org.eclipse.swt.program<br>
     org.eclipse.swt.widgets</tt></td>
     <td><tt>org.eclipse.ui</tt></td>
-    <td>[<a href="#Note 5">5</a>]</td>
+    <td>[<a href="#Note_5">5</a>]</td>
   </tr>
   <tr>
     <td><tt> org.eclipse.swt.ole.win32</tt></td>
@@ -550,7 +558,7 @@ determining which plug-ins a given plug-in should include as prerequisites.</p>
       org.eclipse.ui.editors.text.templates<br>
       org.eclipse.ui.texteditor (split)</tt></td>
     <td><tt>org.eclipse.ui.editors</tt></td>
-    <td>[<a href="#Note 7">7</a>]</td>
+    <td>[<a href="#Note_7">7</a>]</td>
   </tr>
   <tr>
     <td><tt>org.eclipse.ui.forms<br>
@@ -603,7 +611,7 @@ determining which plug-ins a given plug-in should include as prerequisites.</p>
     org.eclipse.ui.views<br>
     org.eclipse.ui.wizards</code></td>
       <td><code>org.eclipse.ui.workbench</code></td>
-    <td>[<a href="#Note 8">8</a>,<a href="#Note 9">9</a>]</td>
+    <td>[<a href="#Note_8">8</a>,<a href="#Note_9">9</a>]</td>
   </tr>
   <tr>
     <td><code>org.eclipse.ui (split)<br>
@@ -624,7 +632,7 @@ determining which plug-ins a given plug-in should include as prerequisites.</p>
     org.eclipse.ui.wizards.datatransfer<br>
     org.eclipse.ui.wizards.newresource</code></td>
     <td><code>org.eclipse.ui.ide</code></td>
-    <td>[<a href="#Note 9">9</a>]</td>
+    <td>[<a href="#Note_9">9</a>]</td>
   </tr>
   <tr>
     <td><tt>org.eclipse.ui.intro.config<br>
@@ -657,7 +665,7 @@ determining which plug-ins a given plug-in should include as prerequisites.</p>
       org.eclipse.ui.texteditor.spelling<br>
       org.eclipse.ui.texteditor.templates</tt></td>
     <td><tt>org.eclipse.ui.workbench.texteditor</tt></td>
-    <td>[<a href="#Note 7">7</a>]</td>
+    <td>[<a href="#Note_7">7</a>]</td>
   </tr>
   <tr>
     <td><tt>org.eclipse.unittest.launcher<br>
@@ -683,9 +691,8 @@ determining which plug-ins a given plug-in should include as prerequisites.</p>
     <td>&nbsp;</td>
   </tr>
 </table>
-</center>
 
-<p><a name="Note 1">Note 1</a>:
+<p id="Note_1">Note 1:
 The content of the <tt>org.eclipse.core.runtime</tt> package is provided by the following plug-ins:</p>
 <ul><li><code>org.eclipse.equinox.common</code></li>
 <li><code>org.eclipse.equinox.registry</code></li>
@@ -695,25 +702,25 @@ The content of the <tt>org.eclipse.core.runtime</tt> package is provided by the 
 plug-in that combines all APIs present in this package. However, to improve modularity, plug-ins are
 encouraged to list only the required prerequisites.</p>
 
-<p><a name="Note 3">Note 3</a>: Plug-ins needing access to the JFace API must list <code>org.eclipse.ui</code>
+<p id="Note_3">Note 3: Plug-ins needing access to the JFace API must list <code>org.eclipse.ui</code>
 as a prerequisite plug-in. <code>org.eclipse.ui</code> re-exports API from the JFace plug-in.
 The <code>org.eclipse.jface</code> plug-in should never be explicitly listed as a prerequisite.</p>
 
-<p><a name="Note 4">Note 4</a>: Some of the JFace text packages are split between the <code>org.eclipse.jface.text</code>
+<p id="Note_4">Note 4: Some of the JFace text packages are split between the <code>org.eclipse.jface.text</code>
 and the <code>org.eclipse.text</code> plug-ins.</p>
 
-<p><a name="Note 5">Note 5</a>: Plug-ins needing access to the SWT API must list <code>org.eclipse.ui</code> as
+<p id="Note_5">Note 5: Plug-ins needing access to the SWT API must list <code>org.eclipse.ui</code> as
 a prerequisite plug-in. <code>org.eclipse.ui</code> re-exports API from the SWT plug-in. The <code>org.eclipse.swt</code>
 plug-in should never be explicitly listed as a prerequisite.</p>
 
-<p><a name="Note 7">Note 7</a>: The <code>org.eclipse.ui.texteditor</code> package is split between the
+<p id="Note_7">Note 7: The <code>org.eclipse.ui.texteditor</code> package is split between the
 <code>org.eclipse.ui.editors</code> and the <code>org.eclipse.ui.workbench.texteditor</code> plug-ins.</p>
 
-<p><a name="Note 8">Note 8</a>: Plug-ins needing access to the Workbench UI API must list <code>org.eclipse.ui</code>
+<p id="Note_8">Note 8: Plug-ins needing access to the Workbench UI API must list <code>org.eclipse.ui</code>
 as a prerequisite plug-in. <code>org.eclipse.ui</code> re-exports API from the <code>org.eclipse.ui.workbench</code> plug-in.
 The <code>org.eclipse.ui.workbench </code>plug-in should never be explicitly listed as a prerequisite.</p>
 
-<p><a name="Note 9">Note 9</a>: Some of the UI packages are split between the <code>org.eclipse.ui</code>
+<p id="Note_9">Note 9: Some of the UI packages are split between the <code>org.eclipse.ui</code>
 and the <code>org.eclipse.ui.ide</code> plug-ins.</p>
 
 </body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/p2_dropins_format.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/p2_dropins_format.html
@@ -1,13 +1,12 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 
 <meta name="copyright"
 	content="Copyright (c) IBM Corporation and others 2008. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<link REL="STYLESHEET" HREF="../../book.css" CHARSET="ISO-8859-1"
-	TYPE="text/css">
+ <meta charset="utf-8">
+<link REL="STYLESHEET" HREF="../../book.css" TYPE="text/css">
 <title>The dropins folder and supported file layouts</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/platform-scheme-uri.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/platform-scheme-uri.html
@@ -1,13 +1,17 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta name="copyright"
  content="Copyright (c) IBM Corporation and others 2008. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
-  <meta http-equiv="Content-Type"
- content="text/html; charset=ISO-8859-1">
-  <meta http-equiv="Content-Style-Type" content="text/css">
+  <meta charset="utf-8">
   <link rel="STYLESHEET" href="../../book.css" type="text/css">
   <title>Generating Metadata</title>
+  <style>
+    table, td { border: 1px; }
+    table { border-style: outset; }
+    td { border-style: inset; }
+    td.top { vertical-align: top; }
+  </style>
 </head>
 <body>
 <h2>Platform URLs in Eclipse</h2>
@@ -23,37 +27,37 @@ to work with files in these places. There is another way, though: platform URI.
 
 <p>There are a few ways to work with the "platform" scheme:</p>
 
-<table border="1">
+<table>
 <tbody>
 
-<tr><td valign="top">platform:/resource</td>
+<tr><td class="top">platform:/resource</td>
 <td>It is used to identify a resource located in the workspace. The next path
 segment after &quot;resource&quot; should be the name of a project, which can be
 followed by the folder and/or file we want to locate.</td></tr>
 
-<tr><td valign="top">platform:/plugin</td><td><p>It
+<tr><td class="top">platform:/plugin</td><td><p>It
 is used to locate a resource available in a plug-in/bundle. One really cool thing about this one is that it doesn't really
 matter if this resource is available in a directory or in a jar file.
 It also doesn't matter if the bundle is installed in a link folder or in the default directory.</p>
 <p>The path segment after &quot;plugin&quot; should be the identifier of the bundle,
 which can be followed by the path of the resource in the bundle.</p></td></tr>
 
-<tr><td valign="top">platform:/fragment</td><td>This
+<tr><td class="top">platform:/fragment</td><td>This
 one is quite similar to &quot;platform:/plugin&quot;, being used to locate
 fragment resources instead of bundle resources. As you are probably
 guessing, the segment after &quot;fragment&quot; should be the fragment's
 identifier.</td></tr>
 
-<tr><td valign="top">platform:/meta</td><td>We can
+<tr><td class="top">platform:/meta</td><td>We can
 use this to access a bundle's stage location. The path segment after
 &quot;meta&quot; should be the bundle's identifier, followed by the path of the
 resource we want to refer to.</td></tr>
 
-<tr><td valign="top">platform:/config</td><td>The &quot;config&quot; segment causes the
+<tr><td class="top">platform:/config</td><td>The &quot;config&quot; segment causes the
 platform URI to refer to the configuration area of the running Eclipse (usually the <i>eclipse/configuration</i> directory). This can
 be useful to read the <i>config.ini</i> file, for example.</td></tr>
 
-<tr><td valign="top">platform:/base</td><td>This always
+<tr><td class="top">platform:/base</td><td>This always
 refers to the directory of the Eclipse being executed.<br><br>It is interesting to note that, for example,
 <code>platform:/base/plugins/org.eclipse.mybundle/plugin.xml</code> and <code>platform:/plugin/org.eclipse.mybundle/plugin.xml</code>
 don't necessarily refer to the same resource. The former is a &quot;pointer&quot; to a <i>plugin.xml</i> file located in a directory

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/plugin_archive.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/plugin_archive.html
@@ -1,11 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2005. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<link REL="STYLESHEET" HREF="../../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+   <meta charset="utf-8">
+<link REL="STYLESHEET" HREF="../../book.css" TYPE="text/css">
    <title>Plugin-in Archives</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/plugin_dtd.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/plugin_dtd.html
@@ -1,11 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 
 <head>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<meta charset="utf-8">
 
 <title>Plug-in manifest dtd</title>
 </head>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/plugin_manifest.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/plugin_manifest.html
@@ -1,12 +1,12 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 
 <head>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<link REL="STYLESHEET" HREF="../../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+<meta charset="utf-8">
+<link REL="STYLESHEET" HREF="../../book.css" TYPE="text/css">
 <title>Plug-in manifest</title>
 </head>
 

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/project_description_file.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/project_description_file.html
@@ -1,16 +1,16 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2005. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-  <link REL="STYLESHEET" HREF="../../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+   <meta charset="utf-8">
+  <link REL="STYLESHEET" HREF="../../book.css" TYPE="text/css">
   <title>Project description file</title>
 </head>
-<body link="#0000FF" vlink="#800080">
+<body>
 
-<h1 align="left">
+<h1>
 The Project Description File</h1>
 <b><i>Description:</i></b> When a project is created in the workspace,
 a project description file is automatically generated that describes the

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/runtime-options.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/runtime-options.html
@@ -1,14 +1,26 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 
 <head>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2014. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-<meta http-equiv="Content-Language" content="en-us">
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<link REL="STYLESHEET" HREF="../../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+<meta charset="utf-8">
+<link REL="STYLESHEET" HREF="../../book.css" TYPE="text/css">
 <title>Eclipse runtime options</title>
+<style>
+  div.center {text-align:center}
+  ul.disc {list-style-type: disc;}
+  tr.left { background-color: #cccccc;}
+  td.top { background-color: #cccccc;}
+  td.left { width: 13%;}
+  td.topleft { width: 9%;}
+  table {
+    width: 100%;
+    border: 0;
+    background-color: white;
+  }
+</style>
 </head>
 
 <body>
@@ -20,7 +32,7 @@
   the command line arguments are simply short cuts for setting the related System
   properties. In fact, there are many more System property settings than command
 line arguments. </p>
-<h2><a name="commandline"></a>Command Line Arguments </h2>
+<h2 id="commandline">Command Line Arguments </h2>
 <p>Listed below are the command line arguments processed by various parts of
   the Eclipse runtime. Many of these values can also be specified using System
   properties either on the command line using -D VM arguments, by specifying
@@ -60,7 +72,7 @@ line arguments. </p>
   <dt>-dev [entries] (OSGi)</dt>
   <dd>equivalent to setting <a href="#osgidev">osgi.dev</a> to [entries] or
     the empty string to simply enable dev mode (i.e., if entries are not specified)</dd>
-  <dt><a name="eclipsekeyring"></a>-eclipse.keyring &lt;file path&gt;    (Equinox)</dt>
+  <dt id="eclipsekeyring">-eclipse.keyring &lt;file path&gt;    (Equinox)</dt>
   <dd>Set to override the location of the default secure storage.
     If specified, this parameter takes precedence over setting the
     <a href="#env.eclipsekeyring"><code>ECLIPSE_KEYRING</code></a> environment variable.</dd>
@@ -81,7 +93,7 @@ line arguments. </p>
   <dt>-install &lt;location&gt; (Main)</dt>
   <dd>equivalent to setting  <a href="#osgiinstallarea">osgi.install.area</a> to
     &lt;location&gt;</dd>
-  <dt><a name="launcherdefaultaction" id="launcherdefaultaction"></a>--launcher.defaultAction &lt;option&gt; (Executable)</dt>
+  <dt id="launcherdefaultaction">--launcher.defaultAction &lt;option&gt; (Executable)</dt>
   <dd>specifies the default action to take when the launcher is started without
   any &quot;-&quot; arguments on the command line.  Currently the only supported
   value is &quot;openFile&quot;.  The &quot;openFile&quot; option tells the
@@ -94,7 +106,7 @@ line arguments. </p>
   &quot;Send To&quot; Eclipse.
   </dd>
 
-  <dt><a name="launcheropenfile" id="launcheropenfile"></a>--launcher.openFile &lt;space separated list of files&gt; (Executable)</dt>
+  <dt id="launcheropenfile">--launcher.openFile &lt;space separated list of files&gt; (Executable)</dt>
   <dd>a space separated list of files to pass to the application.  This option is
   typically used to pass a list of files to be opened by an Eclipse application.
   This option requires SWT in order to fire the necessary SWT_OPENDOC event for
@@ -125,7 +137,7 @@ useful for non-IDE/command-line applications.</dd>
 secondary thread.&nbsp; This should used if a swing application is
 being run. <span style="font-weight: bold;">SWT will NOT work</span>
 if this option is specified.</dd>
-  <dt><a name="launchertimeout" id="launchertimeout"></a>--launcher.timeout &lt;value&gt; (Executable)</dt>
+  <dt id="launchertimeout">--launcher.timeout &lt;value&gt; (Executable)</dt>
   <dd>a timeout value for how long the launcher should spend trying to
   communicate with an already running eclipse before the launcher gives up and
   launches a new eclipse instance. Default is 60 (seconds).
@@ -296,148 +308,148 @@ in <a href="#eclipsevm">eclipse.vm</a>.</dd>
     area</li>
 </ul>
 <dl>
-  <dt><a name="activateRuntimePlugins" id="activateRuntimePlugins"></a>eclipse.activateRuntimePlugins</dt>
+  <dt id="activateRuntimePlugins">eclipse.activateRuntimePlugins</dt>
   <dd>controls activation of runtime plug-ins. RCP applications not requiring services provided by runtime
     plug-ins can set this property to &quot;false&quot; to avoid activation of runtime plug-ins on Eclipse startup</dd>
-  <dt><a name="eclipseallowAppRelaunch" id="eclipseallowAppRelaunch"></a>eclipse.allowAppRelaunch</dt>
+  <dt id="eclipseallowAppRelaunch">eclipse.allowAppRelaunch</dt>
   <dd>if set to &quot;true&quot; then the main thread will continue to  wait for another application descriptor to be
   launched after the currently running application has quit.  Stopping the system.bundle (i.e. the bundle with a
   bundle ID equal to zero) will force the main thread to stop waiting for another application to launch.
   The default value is &quot;false&quot;</dd>
-  <dt><a name="eclipseapplication" id="eclipseapplication"></a>eclipse.application {-application}</dt>
+  <dt id="eclipseapplication">eclipse.application {-application}</dt>
   <dd>the identifier of the application to run. The value given here overrides
     any application defined by the product (see <a href="#eclipseproduct">eclipse.product</a>) being run</dd>
-  <dt><a name="eclipseapplicationlaunchdefault" id="eclipseapplicationlaunchdefault"></a>eclipse.application.launchDefault</dt>
+  <dt id="eclipseapplicationlaunchdefault">eclipse.application.launchDefault</dt>
   <dd>Controls launching the default application automatically once the platform is running.  A default application is identified
   by the <a href="#eclipseproduct">eclipse.product</a> or the <a href="#eclipseapplication">eclipse.application</a>
   options.  The default value is &quot;true&quot;.  Setting this property to &quot;false&quot; will prevent the default
   application from launching automatically.  Once the platform is running the main thread will wait for an application to be
   launched using an application descriptor service.</dd>
-  <dt><a name="eclipseapplicationregisterDescriptors"  id="eclipseapplicationregisterDescriptors"></a>eclipse.application.registerDescriptors</dt>
+  <dt id="eclipseapplicationregisterDescriptors">eclipse.application.registerDescriptors</dt>
   <dd>Controls registration of application descriptor services for all installed applications.  The default value is
   &quot;false&quot;.  If set to &quot;false&quot; only the default application will have an application descriptor service
   registered.  If set to &quot;true&quot; then all installed applications will have an application descriptor service registered.</dd>
-  <dt><a name="eclipseappname"  id="eclipseappname"></a>eclipse.appName</dt>
+  <dt id="eclipseappname">eclipse.appName</dt>
   <dd>Allows to set the application name with which Eclipse is registered in the operating system. This option is helpful to
 	distinguish and group Eclipse instances.</dd>
-  <dt><a name="eclipsecommands" id="eclipsecommands"></a>eclipse.commands</dt>
+  <dt id="eclipsecommands">eclipse.commands</dt>
   <dd>a new-line separated list of all command-line arguments passed in when launching
     Eclipse </dd>
-  <dt><a name="eclipseconsolelog" id="eclipseconsolelog"></a>eclipse.consoleLog</dt>
+  <dt id="eclipseconsolelog">eclipse.consoleLog</dt>
   <dd>if &quot;true&quot;, any log output is also sent to Java's System.out (typically
     back to the command shell if any). Handy when combined with -debug </dd>
-  <dt><a name="eclipsedebugstartuptime" id="eclipsedebugstartuptime"></a>eclipse.debug.startupTime</dt>
+  <dt id="eclipsedebugstartuptime">eclipse.debug.startupTime</dt>
   <dd>the time in milliseconds when the Java VM for this session was started</dd>
-  <dt><a name="eclipseeeinstallverify" id="eclipseeeinstallverify"></a>eclipse.ee.install.verify</dt>
+  <dt id="eclipseeeinstallverify">eclipse.ee.install.verify</dt>
   <dd>if set to &quot;true&quot; then the framework will check the required execution
     environment at bundle install time.  The default value is &quot;false&quot;.</dd>
-  <dt><a name="eclipseexitOnError" id="eclipseexitOnError"></a>eclipse.exitOnError</dt>
+  <dt id="eclipseexitOnError">eclipse.exitOnError</dt>
   <dd>if set to &quot;true&quot; then the platform will exit if an unhandled error occurs.  The default value is
   &quot;true&quot;.</dd>
-  <dt><a name="eclipseignoreApp" id="eclipseignoreApp"></a>eclipse.ignoreApp</dt>
+  <dt id="eclipseignoreApp">eclipse.ignoreApp</dt>
   <dd>if set to &quot;true&quot; then the main launching thread will not start the default application and
   will proceed in shutting down the platform and exiting.
   The default value is &quot;false&quot;.  This is different than the
   <a href="#eclipseapplicationlaunchdefault">eclipse.application.launchDefault</a> option because the main thread will
   not wait for an application descriptor service to be launched.</dd>
-  <dt><a name="eclipseloglevel" id="eclipseloglevel"></a>eclipse.log.level</dt>
+  <dt id="eclipseloglevel">eclipse.log.level</dt>
   <dd>
     sets the level used when logging messages to the eclipse log.
-    <ul type="disc">
+    <ul class="disc">
       <li><b>ERROR</b> - enables logging only ERROR messages.</li>
       <li><b>WARNING</b> - enables logging of ERROR and WARNING messages.</li>
       <li><b>INFO</b> - enables logging of ERROR, WARNING and INFO messages.</li>
       <li><b>ALL</b> - enables logging of all messages (default value)</li>
     </ul>
   </dd>
-  <dt><a name="eclipselogbackupmax" id="eclipselogbackupmax"></a>eclipse.log.backup.max</dt>
+  <dt id="eclipselogbackupmax">eclipse.log.backup.max</dt>
   <dd>the max number of backup log files to allow.  The oldest backup log file will be deleted
      after the max number of backup log files is reached as a result of rotating the log file.
      The default value is &quot;10&quot;.  A negative or zero value will cause the default
      value to be used.</dd>
-  <dt><a name="eclipselogsizemax" id="eclipselogsizemax"></a>eclipse.log.size.max</dt>
+  <dt id="eclipselogsizemax">eclipse.log.size.max</dt>
   <dd>the max size in Kb that the log file is allowed to grow.  The log file is rotated when
      the file size exceeds the max size.  The default value is &quot;1000&quot;.
      A negative value will cause the default value to be used.  A zero value indicates
      no max log size.</dd>
-  <dt><a name="eclipsenoextensionmunging" id="eclipsenoextensionmunging"></a>eclipse.noExtensionMunging</dt>
+  <dt id="eclipsenoextensionmunging">eclipse.noExtensionMunging</dt>
   <dd>if &quot;true&quot;, legacy registry extension are left as-is. By default such extensions
     are updated to use the new extension point ids found in Eclipse 3.0.</dd>
-  <dt><a name="eclipsenolazyregistrycacheloading" id="eclipsenolazyregistrycacheloading"></a>eclipse.noLazyRegistryCacheLoading {-noLazyRegistryCacheLoading}</dt>
+  <dt id="eclipsenolazyregistrycacheloading">eclipse.noLazyRegistryCacheLoading {-noLazyRegistryCacheLoading}</dt>
   <dd>if &quot;true&quot;, the platform's plug-in registry cache loading optimization is
       deactivated. By default, configuration elements are loaded from the registry
       cache (when available)
       only on demand, reducing memory footprint. This option forces the registry
   cache to be fully loaded at startup. </dd>
-  <dt><a name="eclipsenoregistrycache" id="eclipsenoregistrycache"></a>eclipse.noRegistryCache {-noRegistryCache}</dt>
+  <dt id="eclipsenoregistrycache">eclipse.noRegistryCache {-noRegistryCache}</dt>
   <dd>if &quot;true&quot;, the internal extension registry cache is neither read or written</dd>
-  <dt><a name="eclipseplugincustomization" id="eclipseplugincustomization"></a>eclipse.pluginCustomization {-pluginCustomization}</dt>
+  <dt id="eclipseplugincustomization">eclipse.pluginCustomization {-pluginCustomization}</dt>
   <dd>the file system location of a properties file containing default settings
       for plug-in preferences. These default settings override default settings
       specified in the primary feature. Relative paths are interpreted relative
   to the current working directory for Eclipse itself.</dd>
-  <dt><a name="eclipseproduct" id="eclipseproduct"></a>eclipse.product {-product}</dt>
+  <dt id="eclipseproduct">eclipse.product {-product}</dt>
   <dd>the identifier of the product being run. This controls various branding
   information and what application is used.</dd>
-  <dt><a name="registrymultilang" id="registrymultilang"></a>eclipse.registry.MultiLanguage {-registryMultiLanguage}</dt>
+  <dt id="registrymultilang">eclipse.registry.MultiLanguage {-registryMultiLanguage}</dt>
   <dd>if &quot;true&quot;, extension registry supports translation to multiple languages. By default extension registry provides
   translation only to the Eclipse locale specified by the <a href="#osginl">osgi.nl</a>.</dd>
-  <dt><a name="serviceJobs" id="serviceJobs"></a>eclipse.service.jobs</dt>
+  <dt id="serviceJobs">eclipse.service.jobs</dt>
   <dd>controls registration of OSGi services. Set to &quot;false&quot; to suppress registration of OSGi
     services by the <code>org.eclipse.core.jobs</code> plug-in</dd>
-  <dt><a name="servicePref" id="servicePref"></a>eclipse.service.pref</dt>
+  <dt id="servicePref">eclipse.service.pref</dt>
   <dd>Controls registration of OSGi services. Set to &quot;false&quot; to suppress registration of OSGi
      services by the <code>org.eclipse.equinox.preferences</code> plug-in</dd>
-  <dt><a name="eclipsestarttime" id="eclipsestarttime"></a>eclipse.startTime</dt>
+  <dt id="eclipsestarttime">eclipse.startTime</dt>
   <dd>This property is set at the time Eclipse is started.  The value of this property a string
       representation of the value returned by System.currentTimeMillis().  This value is not
       intended to be set by users.</dd>
-  <dt><a name="eclipsestateSaveDelayInterval" id="eclipsestateSaveDelayInterval"></a>eclipse.stateSaveDelayInterval</dt>
+  <dt id="eclipsestateSaveDelayInterval">eclipse.stateSaveDelayInterval</dt>
   <dd>the delay interval (in milliseconds) for persisting state change requests.  The default
     is 30000 ms (30 seconds).  State change requests are delayed to prevent massive amounts
     of disk writes while performing administrative operations (e.g. installing bundles).
     The delay interval is used to wait for a period of inactivity before persisting the
     framework state information.</dd>
-  <dt><a name="eclipsesecurity"></a>eclipse.security</dt>
+  <dt id="eclipsesecurity">eclipse.security</dt>
   <dd>specifies that a security policy and manager should be configured when the framework is launched.  If the launcher is used (org.eclipse.equinox.launcher)
    and this property is set to any value then the launcher will configure a java.security.Policy that grants all permissions to the launcher
    and the framework.  When the framework is launched it will use this property to determine the security manager to use.  If set to <b>osgi</b>
    then the Equinox security manager is used.  This security manager is required to fully support the OSGi Conditional Permission Admin specification.  If
    the property is set to the empty string then java.lang.SecurityManager will be used; otherwise the property specifies a security manager
    class that should be used as the security manager.</dd>
-  <dt><a name="eclipsetracesizemax"></a>eclipse.trace.size.max <span style="font-style: italic;">NEW</span></dt>
+  <dt id="eclipsetracesizemax">eclipse.trace.size.max <span style="font-style: italic;">NEW</span></dt>
   <dd>the max size in Kb that the trace file is allowed to grow. The trace file is rotated when the file size exceeds the max size.
   The default value is "1000". A negative value will cause the default value to be used. A zero value indicates no max trace size.</dd>
-  <dt><a name="eclipsetracebackupmax"></a>eclipse.trace.backup.max <span style="font-style: italic;">NEW</span></dt>
+  <dt id="eclipsetracebackupmax">eclipse.trace.backup.max <span style="font-style: italic;">NEW</span></dt>
   <dd>the max number of backup trace files to allow. The oldest backup trace file will be deleted after the max number of backup trace
   files is reached as a result of rotating the trace file. The default value is "10". A negative or zero value will cause the default value to be used.</dd>
-  <dt><a name="eclipsevm" id="eclipsevm"></a>eclipse.vm {-vm}</dt>
+  <dt id="eclipsevm">eclipse.vm {-vm}</dt>
   <dd>the path to the Java executable used to run Eclipse. This information is
   used to construct relaunch command lines.</dd>
-  <dt><a name="eclipsevmargs" id="eclipsevmargs"></a>eclipse.vmargs {-vmargs}</dt>
+  <dt id="eclipsevmargs">eclipse.vmargs {-vmargs}</dt>
   <dd>lists the VM arguments used to run Eclipse. This
       information is used to construct relaunch command
   lines.</dd>
-  <dt><a name="eclipseorientation" id="eclipseorientation"></a>eclipse.orientation {-dir}</dt>
+  <dt id="eclipseorientation">eclipse.orientation {-dir}</dt>
   <dd>the workbench orientation which can be <b>ltr</b> (left-to-right) or <b>rtl</b> (right-to-left).</dd>
-  <dt><a name="equinoxsecurityvm"></a>equinox.security.vm</dt>
+  <dt id="equinoxsecurityvm">equinox.security.vm</dt>
   <dd>If set to &quot;server&quot;, security modules will not attempt to substitute VM's JAAS processing.</dd>
-  <dt><a name="swtreportNonDisposed"></a>org.eclipse.swt.graphics.Resource.reportNonDisposed</dt>
+  <dt id="swtreportNonDisposed">org.eclipse.swt.graphics.Resource.reportNonDisposed</dt>
   <dd>If set to &quot;true&quot;, <a href="PLUGINS_ROOT/org.eclipse.platform.doc.isv/guide/swt_graphics.htm#swtreportNonDisposed">non-disposed SWT Resources</a> will be logged.</dd>
-  <dt><a name="osgiadaptor"></a>osgi.adaptor</dt>
+  <dt id="osgiadaptor">osgi.adaptor</dt>
   <dd>the class name of the OSGi framework adaptor to use.</dd>
-  <dt><a name="osgiarch"></a>osgi.arch {-arch}</dt>
+  <dt id="osgiarch">osgi.arch {-arch}</dt>
   <dd>the processor architecture value. The value should be one of the processor architecture
   names known to Eclipse (e.g., x86, ppc, sparc, ...). See <tt>org.eclipse.osgi.service.environment.Constants</tt> for known values.</dd>
-  <dt><a name="osgibaseconfigurationarea"></a>osgi.baseConfiguration.area</dt>
+  <dt id="osgibaseconfigurationarea">osgi.baseConfiguration.area</dt>
   <dd>specifies a base configuration that is used when
       <a href="#osgiconfigurationarea">osgi.configuration.area</a> is not specified.</dd>
-  <dt><a name="osgibundlefilelimit"></a>osgi.bundlefile.limit</dt>
+  <dt id="osgibundlefilelimit">osgi.bundlefile.limit</dt>
   <dd>specifies a limit on the number of jar files the framework will keep open.
       The minimum value allowed is 10.  Any value less than 10 will disable the
       bundle file limit, making the the number of jar files the framework
       keeps open unlimited.  By default the value is 100.</dd>
-  <dt><a name="osgibundles"></a>osgi.bundles</dt>
+  <dt id="osgibundles">osgi.bundles</dt>
   <dd>The comma-separated list of bundles which are automatically installed
     and optionally started
      once the system is up and running. Each entry is of the form:<br>
@@ -453,21 +465,21 @@ in <a href="#eclipsevm">eclipse.vm</a>.</dd>
      If the bundle is a directory bundle then using a file: URL without the use of reference: is not
      supported (e.g. file:/path/to/myDirectoryBundle_1.0.0/ must use reference:file:/path/to/myDirectoryBundle_1.0.0/)
     </dd>
-  <dt><a name="osgibundlesdefaultStartLevel"></a>osgi.bundles.defaultStartLevel</dt>
+  <dt id="osgibundlesdefaultStartLevel">osgi.bundles.defaultStartLevel</dt>
   <dd>this is the startlevel that all bundles will be set to if installed by Eclipse Update.
   Bundles which are specified on the <a href="#osgibundles">osgi.bundles</a> list can specify a particular startlevel.
   If they do not specify a startlevel then they default to the value of
   osgi.bundles.defaultStartLevel.  The default value of osgi.bundles.defaultStartLevel is 4.</dd>
-  <dt><a name="osgicompatibilitybootdelegation" id="osgicompatibilitybootdelegation"></a>osgi.compatibility.bootdelegation</dt>
+  <dt id="osgicompatibilitybootdelegation">osgi.compatibility.bootdelegation</dt>
   <dd>if set to &quot;true&quot; then the parent (boot by default) classloader is delegated to as a last resort if a
   class or resource cannot be found.  The default value is &quot;true&quot;.</dd>
-  <dt><a name="osgicompatibilityerrorOnFailedStart" id="osgicompatibilityerrorOnFailedStart"></a>osgi.compatibility.errorOnFailedStart</dt>
+  <dt id="osgicompatibilityerrorOnFailedStart">osgi.compatibility.errorOnFailedStart</dt>
   <dd>A bundle may specify a lazy activation policy using the bundle manifest headers Eclipse-LazyStart or Bundle-ActivationPolicy.  According
   to the OSGi R4.1 specification, if a bundle with a lazy activation policy fails to start then class loads must still succeed.  Before the OSGi
   R4.1 specification Eclipse defined the lazy activation policy such that failed starts would cause class loading errors to be thrown.  If
   osgi.compatibility.errorOnFailedStart is set to &quot;true&quot; then failed starts will result in class loading errors; otherwise the
   activation error is logged and the classes are allowed to load from bundles which failed to start.  The default value is &quot;true&quot;.</dd>
-  <dt><a name="osgicompatibilityeagerStart.LazyActivation" id="osgicompatibilityeagerStart.LazyActivation"></a>osgi.compatibility.eagerStart.LazyActivation</dt>
+  <dt id="osgicompatibilityeagerStart.LazyActivation">osgi.compatibility.eagerStart.LazyActivation</dt>
   <dd>The OSGi R4.1 specification mandates that all bundles must be marked for start before they are allowed to activate.  This includes bundles
   which specify a lazy activation policy.  A new method Bundle.start(options) has been added to allow lazy activated bundles to be activated
   according to their lazy activation policy.  Before the OSGi R4.1 specification Eclipse defined the lazy activation policy such that
@@ -475,19 +487,19 @@ in <a href="#eclipsevm">eclipse.vm</a>.</dd>
   If osgi.compatibility.eagerStart.LazyActivation is set to &quot;true&quot; then bundles with the lazy activation policy will automatically be
   marked for activation; otherwise bundles with the lazy activation policy must be started with the new Bundle.start(options) method before
   being allowed to lazy activate.  The default value is &quot;true&quot;.</dd>
-  <dt><a name="osgicheckConfiguration" id="osgicheckConfiguration"></a>osgi.checkConfiguration</dt>
+  <dt id="osgicheckConfiguration">osgi.checkConfiguration</dt>
   <dd>if set to &quot;true&quot; then timestamps are check in the configuration cache to ensure that the cache
   is up to date with respect to the contents of the installed bundles.  The default value is &quot;false&quot;.</dd>
-  <dt><a name="osgiclassloadersingleThreadLoads" id="osgiclassloadersingleThreadLoads"></a>osgi.classloader.singleThreadLoads</dt>
+  <dt id="osgiclassloadersingleThreadLoads">osgi.classloader.singleThreadLoads</dt>
   <dd>if set to &quot;true&quot; then only one thread is allowed to load a class at a time.  The default value is
    &quot;false&quot;.  This option can be used to work around certain VM bugs which can cause deadlock.
    See <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=121737" target="_blank">bug 121737</a>.  Note that recent
    discussions in <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=227587" target="_blank">bug 227587</a> have shown
    that this option introduces another kind of deadlock.</dd>
-  <dt><a name="osgiclassloaderlock" id="osgiclassloaderlock"></a>osgi.classloader.lock</dt>
+  <dt id="osgiclassloaderlock">osgi.classloader.lock</dt>
   <dd>
     the classloader locking strategy to use when defining classes.  The valid types are the following:
-    <ul type="disc">
+    <ul class="disc">
       <li><b>classname</b> - lock on the classname.</li>
       <li><b>classloader</b> - lock on the classloader (default value).</li>
     </ul>
@@ -498,39 +510,39 @@ in <a href="#eclipsevm">eclipse.vm</a>.</dd>
     class loader natively (e.g. the Sun VM).  When running on these kinds of VMs deadlock can still
     occur because of the VM lock.
   </dd>
-  <dt><a name="osgiclassloadercopynatives" id="osgiclassloadercopynatives"></a>osgi.classloader.copy.natives <span style="font-style: italic;">NEW</span></dt>
+  <dt id="osgiclassloadercopynatives">osgi.classloader.copy.natives <span style="font-style: italic;">NEW</span></dt>
   <dd>
     If set to &quot;true&quot; then native code which is loaded from a bundle will be copied to a unique
     location on disk each time a class loader asks to load the library from the bundle.  This may be needed in
     scenarios where the framework is restarted without shutting down the VM.  The default value is &quot;false&quot;.
   </dd>
-  <dt><a name="osgiclassloadertype" id="osgiclassloadertype"></a>osgi.classloader.type <span style="font-style: italic;">NEW</span></dt>
+  <dt id="osgiclassloadertype">osgi.classloader.type <span style="font-style: italic;">NEW</span></dt>
   <dd>
     If set to &quot;parallel&quot; then a check is done on JavaSE 7 for the ClassLoader#registerAsParallelCapable
     method and if found then it is called to allow for parallel class loads.  On Java SE 7 this is the preferred
     way to avoid class loader deadlock because of cyclic class loaders.
   </dd>
-  <dt><a name="osgiclean"></a>osgi.clean</dt>
+  <dt id="osgiclean">osgi.clean</dt>
   <dd>if set to &quot;true&quot;, any cached data used by the OSGi framework and eclipse runtime
 will be wiped clean.  This will clean the caches used to store bundle
 dependency resolution and eclipse extension registry data.  Using this option
 will force eclipse to reinitialize these caches.</dd>
-  <dt><a name="osgiconfigurationcascaded"></a>osgi.configuration.cascaded</dt>
+  <dt id="osgiconfigurationcascaded">osgi.configuration.cascaded</dt>
   <dd>if set to &quot;true&quot;, this configuration is cascaded to a parent
     configuration.  The parent configuration is specified by the <a href="#osgisharedconfigurationarea">osgi.sharedConfiguration.area</a>.
     See the section on <a href="#locations">locations</a> for more details.</dd>
-  <dt><a name="osgiconfigurationarea"></a>osgi.configuration.area {-configuration}</dt>
+  <dt id="osgiconfigurationarea">osgi.configuration.area {-configuration}</dt>
   <dd>the configuration location for this run of the platform. The configuration
     determines what plug-ins will run as well as various other system settings.
     See the section on <a href="#locations">locations</a>  for
     more details.</dd>
-  <dt><a name="osgiconfigurationareadefault" id="osgiconfigurationareadefault"></a>osgi.configuration.area.default</dt>
+  <dt id="osgiconfigurationareadefault">osgi.configuration.area.default</dt>
   <dd>the default configuration location for this run of the platform. The configuration
     determines what plug-ins will run as well as various other system settings.
     This value (i.e., the default setting) is only used if no value for the osgi.configuration.area
     is set. See the section on <a href="#locations">locations</a>  for
     more details.</dd>
-  <dt><a name="osgiconsole"></a>osgi.console {-console [[host:]port]} </dt>
+  <dt id="osgiconsole">osgi.console {-console [[host:]port]} </dt>
   <dd>if set to a non-null value, the OSGi console (if installed) is enabled.
     This is handy for investigating the state of the system.
     The value syntax is [[host:]port] where the port and optional host name specify which port
@@ -539,10 +551,10 @@ will force eclipse to reinitialize these caches.</dd>
     listen to System.in and direct its output to System.out. In order for this option
     to be supported the Equinox console must be installed.  See <a href="../../guide/console_shell.htm">Console Shell</a>
     for more information.</dd>
-  <dt><a name="osgicontextClassLoaderParent"></a>osgi.contextClassLoaderParent</dt>
+  <dt id="osgicontextClassLoaderParent">osgi.contextClassLoaderParent</dt>
   <dd>the classloader type to use as the parent classloader of the context
     classloader used by the Framework.  The valid types are the following:
-    <ul type="disc">
+    <ul class="disc">
       <li><b>app</b> - the application classloader.</li>
       <li><b>boot</b> - the boot classloader.</li>
       <li><b>ext</b> - the extension classloader.</li>
@@ -551,14 +563,14 @@ will force eclipse to reinitialize these caches.</dd>
      that was set when the framework launched (default value).</li>
     </ul>
   </dd>
-  <dt><a name="osgidataAreaRequiresExplicitInit"></a>osgi.dataAreaRequiresExplicitInit</dt>
+  <dt id="osgidataAreaRequiresExplicitInit">osgi.dataAreaRequiresExplicitInit</dt>
   <dd>if &quot;true&quot;, don't allow clients to initialize instance location if the instance
     area is not explicitly defined yet. This prevents a plug-in that starts early from accessing
     the instance area before it has been configured by the osgi.instance.area setting.
     It is recommended to set osgi.dataAreaRequiresExplicitInit=true.
     See <a href="#osgiinstancearea">osgi.instance.area</a>.
   </dd>
-  <dt><a name="osgidebug"></a>osgi.debug {-debug}</dt>
+  <dt id="osgidebug">osgi.debug {-debug}</dt>
   <dd>if set to a non-null value, the platform is put in debug mode. If the value
     is a string it is interpreted as the location of the
     .options file. This file indicates what debug
@@ -566,7 +578,7 @@ will force eclipse to reinitialize these caches.</dd>
     available
     for a plug-in and whether or not they are enabled. If a location is not specified,
   the platform searches for the .options file under the install directory.</dd>
-  <dt><a name="osgidev"></a>osgi.dev {-dev}</dt>
+  <dt id="osgidev">osgi.dev {-dev}</dt>
   <dd>if set to the empty string, dev mode is simply turned on. This property
     may also be set to a comma-separated class path entries
     which are added to
@@ -577,7 +589,7 @@ will force eclipse to reinitialize these caches.</dd>
     the file will contain an entry of the form<br>
 <pre>    &lt;plug-in id&gt;=&lt;comma separated list of classpath entries to add&gt;</pre>
     where plug-in id &quot;*&quot; matches any plug-in not otherwise mentioned.</dd>
-  <dt><a name="osgifilepermissionscommand"></a>osgi.filepermissions.command</dt>
+  <dt id="osgifilepermissionscommand">osgi.filepermissions.command</dt>
   <dd>specifies an optional OS specific command to set file permissions on extracted
       native code.  On some operating systems it is required that native libraries be
       set to executable.  This optional property allows you to specify the command.
@@ -585,14 +597,14 @@ will force eclipse to reinitialize these caches.</dd>
       <pre>    osgi.filepermissions.command=&quot;chmod +rx [fullpath]&quot;</pre>
       The [fullpath] is used to substitute the actual file path by the framework.
   </dd>
-  <dt><a name="o.pngramework"></a>osgi.framework</dt>
+  <dt id="o.pngramework">osgi.framework</dt>
   <dd>the URL location of the OSGi framework. Useful if the Eclipse install
   is disjoint. See the section on <a href="#locations">locations</a> for more details. </dd>
-  <dt><a name="o.pngrameworkclasspath"></a>osgi.frameworkClassPath</dt>
+  <dt id="o.pngrameworkclasspath">osgi.frameworkClassPath</dt>
   <dd>a comma separated list of classpath entries for the OSGi framework implementation.
     Relative locations are interpreted as relative to the framework location
     (see <a href="#o.pngramework">osgi.framework</a>)</dd>
-  <dt><a name="osgiframeworkextensions"></a>osgi.framework.extensions</dt>
+  <dt id="osgiframeworkextensions">osgi.framework.extensions</dt>
   <dd>a comma-separated list of framework extensions.  Each entry is of the form:<br>
 	 <pre>    &lt;simple bundle location&gt;</pre>
       Simple bundle locations are searched in the parent directory of the
@@ -601,29 +613,29 @@ will force eclipse to reinitialize these caches.</dd>
       system properties.  For example, a framework extension that provides a framework adaptor
       implementation can specify what the adaptor class is by setting the
       <a href="#osgiadaptor">osgi.adaptor</a> property.</dd>
-  <dt><a name="osgiframeworkshape"></a>osgi.framework.shape</dt>
+  <dt id="osgiframeworkshape">osgi.framework.shape</dt>
   <dd>set to the shape of the Eclipse OSGi Framework implementation.  This property is set when
   the Eclipse platform is started and is not intended by be set by the user.  The value
   &quot;jar&quot; indicates that the Eclipse OSGi Framework is contained in a single jar.
   The value &quot;folder&quot; indicates that the Eclipse OSGi Framework is contained in a
   directory.</dd>
-  <dt><a name="osgiframeworklibraryextensions"></a>osgi.framework.library.extensions</dt>
+  <dt id="osgiframeworklibraryextensions">osgi.framework.library.extensions</dt>
   <dd>a comma separated list of additional library file extensions that
     must be searched for.  If not set then only the library name returned by
     System.mapLibraryName(String) will be used to search.  This is needed for
     certain operating systems which allow more than one extension for a library.
     For example AIX allows library extensions of .a and .so, but
     System.mapLibraryName(String) will only return names with the .a extension.</dd>
-  <dt><a name="osgiframeworkParentClassloader"></a>osgi.frameworkParentClassloader</dt>
+  <dt id="osgiframeworkParentClassloader">osgi.frameworkParentClassloader</dt>
   <dd>the classloader type to use as the parent classloader for the the Framework.  The valid types are the following:
-    <ul type="disc">
+    <ul class="disc">
       <li><b>app</b> - the application classloader.</li>
       <li><b>boot</b> - the boot classloader.</li>
       <li><b>ext</b> - the extension classloader.</li>
       <li><b>current</b> - the classloader used to load the equinox launcher.</li>
     </ul>
   </dd>
-  <dt><a name="osgiframeworkactiveThreadType"></a>osgi.framework.activeThreadType</dt>
+  <dt id="osgiframeworkactiveThreadType">osgi.framework.activeThreadType</dt>
   <dd>
    if set to <b>normal</b> then an active framework thread is started when the framework is launched
    that monitors the lifecycle of the framework.  This thread is a non-daemon thread and is used to prevent
@@ -633,13 +645,13 @@ will force eclipse to reinitialize these caches.</dd>
    <b>normal</b>.  Setting this option to any other value besides <b>normal</b> will prevent the
    active framework thread from getting started when the framework is launched.
   </dd>
-  <dt><a name="osgiframeworkuseSystemProperties"></a>osgi.framework.useSystemProperties</dt>
+  <dt id="osgiframeworkuseSystemProperties">osgi.framework.useSystemProperties</dt>
   <dd>controls whether the framework properties are backed by the global System properties
     or held privately for each instance of the framework.  By default the framework properties
     are backed by the System properties (e.g. true).  This property is useful when running
     multiple instances of the OSGi Framework within the same VM and each instance has a separate
     set of configuration properties (e.g. set in the config.ini).</dd>
-  <dt><a name="osgigenericAliases"></a>osgi.genericAliases</dt>
+  <dt id="osgigenericAliases">osgi.genericAliases</dt>
   <dd>a comma separated list of generic aliases that can be used to map existing manifest
     headers onto Eclipse-GenericCapability and Eclipse-GenericRequire manifest headers.  The
     osgi.genericAliases property uses the following syntax:
@@ -651,32 +663,32 @@ will force eclipse to reinitialize these caches.</dd>
     the following value:
     <pre>  osgi.genericAliases=Export-Service:Import-Service:osgi.service</pre>
   </dd>
-  <dt><a name="osgihookconfigurators"></a>osgi.hook.configurators</dt>
+  <dt id="osgihookconfigurators">osgi.hook.configurators</dt>
   <dd>a comma separated list of hook configurators.  If this property is set then the list of
     configurators specified will be the only configurators used.  Any hook configurators
     specified in hookconfigurators.properties files will be ignored.</dd>
-  <dt><a name="osgihookconfiguratorsinclude"></a>osgi.hook.configurators.include</dt>
+  <dt id="osgihookconfiguratorsinclude">osgi.hook.configurators.include</dt>
   <dd>a comma separated list of additional hook configurators.  This is helpful for
     configuring optional hook configurators.  This option is ignored if the
     <a href="#osgihookconfigurators">osgi.hook.configurators</a> option is used.</dd>
-  <dt><a name="osgihookconfiguratorsexclude"></a>osgi.hook.configurators.exclude</dt>
+  <dt id="osgihookconfiguratorsexclude">osgi.hook.configurators.exclude</dt>
   <dd>a comma separated list of hook configurators to exclude.  This is helpful for disabling
     hook configurators that are specified in hook configurator properties files.  This option
     is ignored if the <a href="#osgihookconfigurators">osgi.hook.configurators</a> option is used.</dd>
-  <dt><a name="osgijavaprofile"></a>osgi.java.profile</dt>
+  <dt id="osgijavaprofile">osgi.java.profile</dt>
   <dd>a URL to the JRE profile file to use.  The specified URL is read as a Java properties
      file.  A JRE profile contains values for the properties org.osgi.framework.system.packages,
      org.osgi.framework.bootdelegation and org.osgi.framework.executionenvironment.  If the
      osgi.java.profile is not set then a profile is selected based on the
      java.specification.version value of the running JRE.</dd>
-  <dt><a name="osgijavaprofilebootdelegation"></a>osgi.java.profile.bootdelegation</dt>
+  <dt id="osgijavaprofilebootdelegation">osgi.java.profile.bootdelegation</dt>
   <dd>
     a java profile <a href="#osgijavaprofile">osgi.java.profile</a> may contain a
     &quot;org.osgi.framework.bootdelegation&quot; property.  This value may be used to set the system
 	property &quot;org.osgi.framework.bootdelegation&quot;.  The osgi.java.profile.bootdelegation
 	indicates the policy for bootdelegation to be used.  The following values are valid
 	(default is ignore):
-    <ul type="disc">
+    <ul class="disc">
       <li><b>ignore</b> - indicates that
           the &quot;org.osgi.framework.bootdelegation&quot; value in the java profile should be ignored.
           The system property &quot;org.osgi.framework.bootdelegation&quot; will be used to
@@ -694,17 +706,17 @@ will force eclipse to reinitialize these caches.</dd>
       </li>
     </ul>
   </dd>
-  <dt><a name="osgiinstallarea" id="osgiinstallarea"></a>osgi.install.area {-install}</dt>
+  <dt id="osgiinstallarea">osgi.install.area {-install}</dt>
   <dd>the install location of the platform. This setting indicates the location
     of the basic Eclipse plug-ins and is useful if the Eclipse install is disjoint.
   See the section on <a href="#locations">locations</a> for more details. </dd>
-  <dt><a name="osgiinstancearea"></a>osgi.instance.area {-data}</dt>
+  <dt id="osgiinstancearea">osgi.instance.area {-data}</dt>
   <dd>the instance data location for this session. Plug-ins use this location
     to store their data. For example, the Resources plug-in uses this as the
     default location for projects (aka the workspace). See the section on <a href="#locations">locations</a> for
     more details. Set <a href="#osgidataAreaRequiresExplicitInit">osgi.dataAreaRequiresExplicitInit</a> to ensure
     that data area is explicitly initialized before plug-ins can use it.</dd>
-  <dt><a name="osgiinstanceareadefault" id="osgiinstanceareadefault"></a>osgi.instance.area.default</dt>
+  <dt id="osgiinstanceareadefault">osgi.instance.area.default</dt>
   <dd>the default instance data location for this session. Plug-ins use this
     location to store their data. For example, the Resources plug-in uses this
     as the
@@ -712,68 +724,68 @@ will force eclipse to reinitialize these caches.</dd>
     default setting) is only used if no value for the osgi.instance.area
     is set. See the section on <a href="#locations">locations</a> for
     more details.</dd>
-  <dt><a name="osgilocking"></a>osgi.locking</dt>
+  <dt id="osgilocking">osgi.locking</dt>
   <dd>the locking type to use for this run of the platform.  The valid locking types
   are &quot;java.io&quot;, &quot;java.nio&quot;, and &quot;none&quot;.  The default value is
   &quot;java.nio&quot; unless the JRE does not support &quot;java.nio&quot; then &quot;java.io&quot;
   is the default.</dd>
-  <dt><a name="osgimanifestcache"></a>osgi.manifest.cache</dt>
+  <dt id="osgimanifestcache">osgi.manifest.cache</dt>
   <dd>the location where generated manifests are discovered and generated. The
     default is in the configuration area but the manifest cache can be stored
     separately.</dd>
-  <dt><a name="osginl"></a>osgi.nl {-nl}</dt>
+  <dt id="osginl">osgi.nl {-nl}</dt>
   <dd>the name of the locale on which Eclipse platform will run. NL values should
     follow the standard Java locale naming conventions.</dd>
-  <dt><a name="osginlextensions"></a>osgi.nl.extensions {-nlExtensions}</dt>
+  <dt id="osginlextensions">osgi.nl.extensions {-nlExtensions}</dt>
   <dd>the NL extensions, such as collation rules (sorting, searching, grouping), calendar system (locale)
     and currency format. This is a list of <a href="http://userguide.icu-project.org/locale#TOC-Keywords">keyword</a>=value pairs. For example:
     <pre>-nlExtensions &quot;@collation=phonebook;calendar=hebrew;currency=USD&quot;</pre></dd>
-  <dt><a name="osginluser"></a>osgi.nl.user</dt>
+  <dt id="osginluser">osgi.nl.user</dt>
   <dd>the name of the locale when the user explicitly adds -nl to the command-line arguments.</dd>
-  <dt><a name="osginoshutdown"></a>osgi.noShutdown {-noExit}</dt>
+  <dt id="osginoshutdown">osgi.noShutdown {-noExit}</dt>
   <dd>if &quot;true&quot;, the OSGi Framework will not be shut down after the Eclipse application has ended.  This
       is useful for examining the OSGi Framework after the Eclipse application has ended.  Note that the VM will terminate
       if no active non-daemon threads exists. See <a href="#osgiframeworkactiveThreadType">osgi.framework.activeThreadType</a>.</dd>
-  <dt><a name="osgios"></a>osgi.os {-os}</dt>
+  <dt id="osgios">osgi.os {-os}</dt>
   <dd>the operating system value. The value should be one of the operating system
   names known to Eclipse (e.g., win32, linux, ...). See <tt>org.eclipse.osgi.service.environment.Constants</tt> for known values.</dd>
-  <dt><a name="osgiparentclassloader"></a>osgi.parentClassloader</dt>
+  <dt id="osgiparentclassloader">osgi.parentClassloader</dt>
   <dd>the classloader type to use as the parent classloader for all bundles installed
   in the Framework.  The valid types are the following:
-    <ul type="disc">
+    <ul class="disc">
       <li><b>app</b> - the application classloader.</li>
       <li><b>boot</b> - the boot classloader.</li>
       <li><b>ext</b> - the extension classloader.</li>
       <li><b>fwk</b> - the framework classloader.</li>
     </ul>
   </dd>
-  <dt><a name="osgirequiredjavaversion"></a>osgi.requiredJavaVersion</dt>
+  <dt id="osgirequiredjavaversion">osgi.requiredJavaVersion</dt>
   <dd>The minimum java version that is required to launch Eclipse.  The default value is
       &quot;1.4.1&quot;.</dd>
-  <dt><a name="osgiresolvermode"></a>osgi.resolverMode</dt>
+  <dt id="osgiresolvermode">osgi.resolverMode</dt>
   <dd>the mode used to resolve bundles installed in the Framework.  The default resolver
       mode is not strict.  The following options are available.
-    <ul type="disc">
+    <ul class="disc">
       <li><b>strict</b> - the resolver is in strict mode and will enforce access restriction rules when loading classes and resources from exported packages which specify the x-internal or x-friends directives.</li>
       <li><b>development</b> - used for development time resolution.  This mode disables certain resolver rules that are not needed at development time.  For example, singleton selection is disabled to allow the development of multiple versions of a singleton bundle</li>
     </ul>
   </dd>
-  <dt><a name="osgi.resolver.usesMode"></a>osgi.resolver.usesMode</dt>
+  <dt id="osgi.resolver.usesMode">osgi.resolver.usesMode</dt>
   <dd>
     the resolver mode used to resolve <b>uses</b> directives on Export-Package statements.
-     <ul type="disc">
+     <ul class="disc">
       <li><b>aggressive</b> - aggressively seeks a solution with no class space inconsistencies (default value).  This mode may be very expensive depending on the number of bundles and number of duplicate exports in the system.</li>
       <li><b>tryFirst</b> - only tries the first solution selected by the resolver.  This mode is very fast but may result in unresolved bundles because of class space inconsistencies.</li>
       <li><b>ignore</b> - ignores all uses directives on exports.  This mode is very fast by may result in inconsistent class spaces in resolved bundles.</li>
     </ul>
   </dd>
-  <dt><a name="osgisharedconfigurationarea"></a>osgi.sharedConfiguration.area</dt>
+  <dt id="osgisharedconfigurationarea">osgi.sharedConfiguration.area</dt>
   <dd>the shared configuration location for this run of the platform.  If the
   <a href="#osgiconfigurationcascaded">osgi.configuration.cascaded</a> property is set
   to &quot;true&quot; then shared configuration area is used as the parent configuration.</dd>
-  <dt><a name="osgisignedcontentsupport"></a>osgi.signedcontent.support</dt>
+  <dt id="osgisignedcontentsupport">osgi.signedcontent.support</dt>
   <dd>A comma separated list of options for signed content support.  The valid types are the following:
-    <ul type="disc">
+    <ul class="disc">
       <li><b>certificate</b> - enables parsing and verification of certificates.</li>
       <li><b>trust</b> - enables verification of certificate trust.  This option implies
       &quot;certificate&quot;.</li>
@@ -783,7 +795,7 @@ will force eclipse to reinitialize these caches.</dd>
       <li><b>all</b> - same as &quot;certificate,trust,runtime,authority&quot;.</li>
     </ul>
   </dd>
-  <dt><a name="osgisignedcontenttrustengine"></a>osgi.signedcontent.trust.engine</dt>
+  <dt id="osgisignedcontenttrustengine">osgi.signedcontent.trust.engine</dt>
   <dd>
   A service property key used to identify an implementation of the <b>org.eclipse.osgi.service.security.TrustEngine</b> service.
   A TrustEngine service should be registered with a unique value for this property to allow selection of the TrustEngine
@@ -791,15 +803,15 @@ will force eclipse to reinitialize these caches.</dd>
   property to select particular TrustEngine service implementations at runtime.  If this property is not set then
   all available TrustEngine services are used at runtime.
   </dd>
-  <dt><a name="osgisplashlocation"></a>osgi.splashLocation</dt>
+  <dt id="osgisplashlocation">osgi.splashLocation</dt>
   <dd>the absolute URL location of the splash screen (.bmp file) to to show while
     starting Eclipse. This property overrides any value set in <a href="#osgisplashpath">osgi.splashPath</a>.</dd>
-  <dt><a name="osgisplashpath"></a>osgi.splashPath</dt>
+  <dt id="osgisplashpath">osgi.splashPath</dt>
   <dd>a comma separated list of URLs to search for a file called splash.bmp.
   This property is overriden by any value set in <a href="#osgisplashlocation">osgi.splashLocation</a>.</dd>
-  <dt><a name="osgistartlevel"></a>osgi.startLevel</dt>
+  <dt id="osgistartlevel">osgi.startLevel</dt>
   <dd>the start level value the framework will be set to at startup.  The default value is 6.</dd>
-  <dt><a name="osgistrictbundleentrypath"></a>osgi.strictBundleEntryPath</dt>
+  <dt id="osgistrictbundleentrypath">osgi.strictBundleEntryPath</dt>
   <dd>
     On some operating systems Equinox may return a bundle entry that is requested with a path that does not
     correspond to an actual bundle entry path. For example, on Windows file name comparison operations are
@@ -808,53 +820,53 @@ will force eclipse to reinitialize these caches.</dd>
     of Equinox. This property is relevant only when the bundle is installed from a folder (not jarred) and is
     ignored otherwise.
   </dd>
-  <dt><a name="osgisupportmultipleHosts"></a>osgi.support.multipleHosts <span style="font-style: italic;">NEW</span></dt>
+  <dt id="osgisupportmultipleHosts">osgi.support.multipleHosts <span style="font-style: italic;">NEW</span></dt>
   <dd>
     if set to <b>true</b> then the framework will attempt to attach a fragment to all available host
     bundles which satisfy the fragment bundle's Fragment-Host constraint.  The default value is <b>false</b>.
   </dd>
-  <dt><a name="osgisupportsignatureverify"></a>osgi.support.signature.verify</dt>
+  <dt id="osgisupportsignatureverify">osgi.support.signature.verify</dt>
   <dd>This option has been deprecated.  Use <a href="#osgisignedcontentsupport">osgi.signedcontent.support</a> instead.
   </dd>
-  <dt><a name="osgisupportclasscertificate"></a>osgi.support.class.certificate</dt>
+  <dt id="osgisupportclasscertificate">osgi.support.class.certificate</dt>
   <dd>
    if set to <b>true</b> then the certificates available from a signed bundle are used when defining the classes from
    the signed bundle.  The default value is <b>true</b>.
    This option only takes effect when <a href="#osgisignedcontentsupport">osgi.signedcontent.support</a> is set
    to <b>certificate</b>.
   </dd>
-  <dt><a name="osgisyspath"></a>osgi.syspath</dt>
+  <dt id="osgisyspath">osgi.syspath</dt>
   <dd>set to the path where the eclipse OSGi Framework (org.eclipse.osgi) implementation
   is located.  For example, &quot;&lt;eclipse install path&gt;/eclipse/plugins&quot;.
   This property is set when the Eclipse platform is started and is not intended by be
   set by the user.</dd>
-  <dt><a name="osgiuserarea"></a>osgi.user.area {-user}</dt>
+  <dt id="osgiuserarea">osgi.user.area {-user}</dt>
   <dd>the location of the user area. The user area contains data (e.g., preferences)
     specific to the OS user and independent of any Eclipse install, configuration
     or instance. See the section on <a href="#locations">locations</a> for more
     details.</dd>
-  <dt><a name="osgiuserareadefault" id="osgiuserareadefault"></a>osgi.user.area.default</dt>
+  <dt id="osgiuserareadefault">osgi.user.area.default</dt>
   <dd>the default location of the user area. The user area contains data (e.g.,
     preferences) specific to the OS user and independent of any Eclipse install,
     configuration
     or instance. This value (i.e., the default setting) is only used if no value
     for the osgi.user.area is set. See the section on <a href="#locations">locations</a> for
     more details.</dd>
-  <dt><a name="osgiws"></a>osgi.ws {-ws}</dt>
+  <dt id="osgiws">osgi.ws {-ws}</dt>
   <dd>the window system value. The value should be one of the Eclipse window
     system names known to Eclipse (e.g., win32, motif, ...).</dd>
 </dl>
-<h2><a name="environment"></a>Environment Variables</h2>
+<h2 id="environment">Environment Variables</h2>
 <p>The following environment variables are used by the Eclipse runtime. They may have
   command line equivalents (see the <a href="#commandline">command line arguments</a>
   section). Users are free to use either command line or environment variables to specify
   a value.</p>
 <dl>
-  <dt><a name="env.eclipsekeyring"></a>ECLIPSE_KEYRING</dt>
+  <dt id="env.eclipsekeyring">ECLIPSE_KEYRING</dt>
   <dd>Set to override the location of the default secure storage. See the
     <a href="#eclipsekeyring">-eclipse.keyring</a> command line option.</dd>
 </dl>
-<h2><a name="locations"></a>Locations
+<h2 id="locations">Locations
 </h2>
 <p>The Eclipse runtime defines a number of <i>locations</i> which give plug-in
   developers context for reading/storing data and Eclipse users a control over
@@ -950,92 +962,92 @@ will force eclipse to reinitialize these caches.</dd>
 results in a value of <br>
 &nbsp;&nbsp;&nbsp;&nbsp;file:/usr/share/eclipse/myWorkspace</dd>
 </dl>
-<table width="100%" border="0" bgcolor="#FFFFFF">
-  <tr bgcolor="#CCCCCC">
-    <td width="9%">location/value</td>
-    <td width="13%"><div align="center">supports default</div></td>
-    <td width="13%"><div align="center">file/URL</div>
+<table>
+  <tr class="left">
+    <td class="topleft">location/value</td>
+    <td class="left"><div class="center">supports default</div></td>
+    <td class="left"><div class="center">file/URL</div>
     </td>
-    <td width="13%"><div align="center">@none</div>
+    <td class="left"><div class="center">@none</div>
     </td>
-    <td width="13%"><div align="center">@noDefault</div>
+    <td class="left"><div class="center">@noDefault</div>
     </td>
-    <td width="13%"><div align="center">@launcher.dir</div>
+    <td class="left"><div class="center">@launcher.dir</div>
     </td>
-    <td width="13%"><div align="center">@user.home</div>
+    <td class="left"><div class="center">@user.home</div>
     </td>
-    <td width="13%"><div align="center">@user.dir</div>
-    </td>
-  </tr>
-  <tr>
-    <td bgcolor="#CCCCCC"><div align="center">instance</div>
-    </td>
-    <td><div align="center">yes</div></td>
-    <td><div align="center">yes</div>
-    </td>
-    <td><div align="center">yes</div>
-    </td>
-    <td><div align="center">yes</div>
-    </td>
-    <td><div align="center">no</div>
-    </td>
-    <td><div align="center">yes</div>
-    </td>
-    <td><div align="center">yes (default)</div>
+    <td class="left"><div class="center">@user.dir</div>
     </td>
   </tr>
   <tr>
-    <td bgcolor="#CCCCCC"><div align="center">configuration</div>
+    <td class="top"><div class="center">instance</div>
     </td>
-    <td><div align="center">yes</div>
+    <td><div class="center">yes</div></td>
+    <td><div class="center">yes</div>
     </td>
-    <td><div align="center">yes</div>
+    <td><div class="center">yes</div>
     </td>
-    <td><div align="center">yes*</div>
+    <td><div class="center">yes</div>
     </td>
-    <td><div align="center">yes*</div>
+    <td><div class="center">no</div>
     </td>
-    <td><div align="center">no</div>
+    <td><div class="center">yes</div>
     </td>
-    <td><div align="center">yes</div>
-    </td>
-    <td><div align="center">yes</div>
-    </td>
-  </tr>
-  <tr>
-    <td bgcolor="#CCCCCC"><div align="center">install</div>
-    </td>
-    <td><div align="center">no</div>
-    </td>
-    <td><div align="center">yes</div>
-    </td>
-    <td><div align="center">no</div>
-    </td>
-    <td><div align="center">no</div>
-    </td>
-    <td><div align="center">yes</div>
-    </td>
-    <td><div align="center">yes</div>
-    </td>
-    <td><div align="center">yes</div>
+    <td><div class="center">yes (default)</div>
     </td>
   </tr>
   <tr>
-    <td bgcolor="#CCCCCC"><div align="center">user</div>
+    <td class="top"><div class="center">configuration</div>
     </td>
-    <td><div align="center">yes</div>
+    <td><div class="center">yes</div>
     </td>
-    <td><div align="center">yes</div>
+    <td><div class="center">yes</div>
     </td>
-    <td><div align="center">yes</div>
+    <td><div class="center">yes*</div>
     </td>
-    <td><div align="center">yes</div>
+    <td><div class="center">yes*</div>
     </td>
-    <td><div align="center">no</div>
+    <td><div class="center">no</div>
     </td>
-    <td><div align="center">yes</div>
+    <td><div class="center">yes</div>
     </td>
-    <td><div align="center">yes</div>
+    <td><div class="center">yes</div>
+    </td>
+  </tr>
+  <tr>
+    <td class="top"><div class="center">install</div>
+    </td>
+    <td><div class="center">no</div>
+    </td>
+    <td><div class="center">yes</div>
+    </td>
+    <td><div class="center">no</div>
+    </td>
+    <td><div class="center">no</div>
+    </td>
+    <td><div class="center">yes</div>
+    </td>
+    <td><div class="center">yes</div>
+    </td>
+    <td><div class="center">yes</div>
+    </td>
+  </tr>
+  <tr>
+    <td class="top"><div class="center">user</div>
+    </td>
+    <td><div class="center">yes</div>
+    </td>
+    <td><div class="center">yes</div>
+    </td>
+    <td><div class="center">yes</div>
+    </td>
+    <td><div class="center">yes</div>
+    </td>
+    <td><div class="center">no</div>
+    </td>
+    <td><div class="center">yes</div>
+    </td>
+    <td><div class="center">yes</div>
     </td>
   </tr>
 </table>
@@ -1049,7 +1061,7 @@ results in a value of <br>
 A location may be specified as a read-only location by appending &quot;.readOnly&quot;
 to the location property and setting it to the value &quot;true&quot;.  The following properties
 can be used to specify their corresponding locations as read-only:</p>
-    <ul type="disc">
+    <ul class="disc">
       <li>
           osgi.configuration.area.readOnly <a href="#osgiconfigurationarea">osgi.configuration.area</a>
       </li>
@@ -1063,7 +1075,7 @@ can be used to specify their corresponding locations as read-only:</p>
           osgi.user.area.readOnly <a href="#osgiuserarea">osgi.user.area</a>
       </li>
     </ul>
-<h2><a name="variable.substitution"></a>Variable Substitution in config.ini</h2>
+<h2 id="variable.substitution">Variable Substitution in config.ini</h2>
 <p>
 The config.ini file located in the configuration area can be used to define configuration property values.
 This file is a simple properties file with key=value pairs.  The values contained in the config.ini file may
@@ -1072,7 +1084,7 @@ properties.  A variable which is to be substituted in the configuration value is
 For example, the following uses a windows environment variable LOCALAPPDATA to configure the instance area location:
 </p>
 <pre>    osgi.instance.area.default=$LOCALAPPDATA$/eclipse/workspace</pre>
-<h2><a name="launcher"></a>Launcher ini File</h2>
+<h2 id="launcher">Launcher ini File</h2>
 <p>
 The eclipse.exe and more generally executables for RCP applications now read their parameters from an associated
 ini file. This file offers a platform independent way to pass in arguments that previously had to be specified directly on

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/terminology.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/terminology.html
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"><html lang="en">
+<!DOCTYPE HTML><html lang="en">
 <HEAD>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2006. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
-<META HTTP-EQUIV="Content-Style-Type" CONTENT="text/css">
-<link REL="STYLESHEET" HREF="../../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+<meta charset="utf-8">
+<link REL="STYLESHEET" HREF="../../book.css" TYPE="text/css">
    <title>Glossary of terms</title>
 </head>
 <body>
@@ -23,7 +22,7 @@ a collection of related <a href="http://www.eclipse.org/projects/main.html">proj
 that include the <a href="#Platform"> Eclipse Platform,</a> the <a href="#JDT"> Java development tools
   (JDT)</a>, and
 the <a href="#PDE"> Plug-in Development Environment (PDE)</a>.</blockquote>
-<a NAME="Eclipse Platform"></a><b>Eclipse Platform</b>
+<b id="Eclipse_Platform">Eclipse Platform</b>
 <blockquote>Eclipse Platform is the name for&nbsp; the core frameworks
 and services upon which plug-in extensions are created. It provides the
 runtime in which plug-ins are loaded and run. In order to use the term
@@ -44,60 +43,58 @@ So the Eclipse Platform is just the nucleus around which tool builders
 build tool plug-ins.
 </blockquote>
 <b>Eclipse SDK</b>
-<blockquote>The Eclipse SDK is the <a href="#Eclipse Platform">Eclipse
+<blockquote>The Eclipse SDK is the <a href="#Eclipse_Platform">Eclipse
 Platform</a>, <a href="#JDT">JDT</a>, and <a href="#PDE">PDE</a>.
 In addition to the Platform, the SDK provides the development tools required
 to, among other things, enable Eclipse to be a development environment
 for itself.</blockquote>
-<p><a NAME="Platform"></a><b>Platform - </b>Short for "<a href="#Eclipse Platform">Eclipse
+<p><b id="Platform">Platform - </b>Short for "<a href="#Eclipse_Platform">Eclipse
 Platform</a>".</p>
-<a NAME="RCP"></a><b>Rich Client Platform (RCP)</b>
-<blockquote>A subset of the <a href="#Eclipse Platform">Eclipse
+<b id="RCP">Rich Client Platform (RCP)</b>
+<blockquote>A subset of the <a href="#Eclipse_Platform">Eclipse
 Platform</a> that forms a generic application framework,
 rather than a framework for building development tools.  This subset does
 not contain the Resources plug-in, or any UI relating to resources.
 </blockquote>
-<p><a NAME="Workbench"></a><b>Workbench</b> - Short for "Eclipse Platform
+<p><b id="Workbench">Workbench</b> - Short for "Eclipse Platform
 UI".</p>
 <blockquote>The Workbench is a high-level UI framework for building products
 with sophisticated UIs built from pluggable components. The Workbench is
 built atop <a href="#JFace">JFace</a>, <a href="#SWT">SWT</a>, and the
 <a href="#Core">Platform
 Core</a>.</blockquote>
-<a NAME="Core"></a><b>Core</b> - Short for "Eclipse Platform Core".
-<blockquote>All the UI-free infrastructure of the <a href="#Eclipse Platform">Eclipse
+<b id="Core">Core</b> - Short for "Eclipse Platform Core".
+<blockquote>All the UI-free infrastructure of the <a href="#Eclipse_Platform">Eclipse
 Platform</a>. The major divisions are: platform runtime and plug-in management,
 workspaces and resource management, and version and configuration management.</blockquote>
-<a NAME="Runtime"></a><b>Runtime</b> - Short for "Eclipse Platform Core
+<b id="Runtime">Runtime</b> - Short for "Eclipse Platform Core
 Runtime".
 <blockquote>The lowest level part of the <a href="#Core">Platform Core</a>,
 responsible for the plug-in registry and plug-ins. Note that the Platform
 Core Runtime does not include workspaces and resources (they're in the
 Resources plug-in).</blockquote>
-<a NAME="Workspace"></a><b>Workspace</b>
+<b id="Workspace">Workspace</b>
 <blockquote>A workspace is the general umbrella for managing resources
 in the Eclipse Platform. Note that workspaces and resources are an optional
 part of the Platform; some configurations of the Platform will not have
 a workspace.</blockquote>
-<a NAME="UI"></a><b>UI</b> - Short for "Eclipse Platform UI".
-<blockquote>All-inclusive term for the UI portion of the <a href="#Eclipse Platform">Eclipse
+<b id="UI">UI</b> - Short for "Eclipse Platform UI".
+<blockquote>All-inclusive term for the UI portion of the <a href="#Eclipse_Platform">Eclipse
 Platform</a>.</blockquote>
-<a NAME="JFace"></a><b>JFace</b>
+<b id="JFace">JFace</b>
 <blockquote>JFace is the mid-level UI framework useful for building complex
 UI pieces such as property viewers. JFace works in conjunction with <a href="#SWT">SWT</a>.</blockquote>
-<a NAME="SWT"></a><b>SWT</b>
+<b id="SWT">SWT</b>
 <blockquote>SWT (Standard Widget Toolkit) is a small, fast widget toolkit
 with a portable API and a native implementation. Currently, SWT is available on
 Windows, Linux (GTK), AIX (GTK), Solaris (GTK),
 HP-UX (GTK), and Mac OS X (Cocoa).</blockquote>
-<a name="JDT"><b>JDT</b>
-</a>
+<b id="JDT">JDT</b>
 <blockquote>Java development tools (n.b. &quot;development tools&quot; in
   lowercase, for legal reasons) adds Java program development capability to the
   Eclipse Platform.</blockquote>
 
-<a name="PDE"><b>PDE</b>
-</a>
+<b id="PDE">PDE</b>
 <blockquote>The Plug-in Development Environment adds specialized tools for
   developing Eclipse plug-ins.</blockquote>
 </body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/ui_accessibility_tips.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/misc/ui_accessibility_tips.html
@@ -1,12 +1,15 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2006. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<link REL="STYLESHEET" HREF="../../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+<meta charset="utf-8">
+<link REL="STYLESHEET" HREF="../../book.css" TYPE="text/css">
 <title>Tips For making user interfaces accessible</title>
+<style>
+  span.c1 { font-size: smaller; }
+</style>
 </head>
 <body>
 <h1>Tips for Making User Interfaces Accessible </h1>
@@ -94,7 +97,7 @@ that good accessibility is crucial, and is willing to give the person their full
 <dt><b>Test for accessibility.</b></dt>
 <dd>Have your team hold an occasional &quot;unplug your mouse day&quot; where they
 try to use the product using keyboard only. If you are developing on Window, get a copy of
-<a href="http://www.freedomscientific.com/">JAWS<font size="-1"><sup>TM</sup></font></a>
+<a href="http://www.freedomscientific.com/">JAWS<span class="c1"><sup>TM</sup></span></a>
 and ensure that your UI is usable with it<br>&nbsp;</dd>
 </dl>
 

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/services/index.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/services/index.html
@@ -1,16 +1,14 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <meta name="copyright" content=
     "Copyright (c) 2021 Red Hat Inc. Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta charset="utf-8">
     <title>
       OSGi services used by Platform and open to extensibility
     </title>
-    <link rel="STYLESHEET" href="../../book.css" charset="ISO-8859-1" type=
-    "text/css" />
-    <style type="text/css">
+    <link rel="STYLESHEET" href="../../book.css" type="text/css">
+    <style>
 /*<![CDATA[*/
     :link { color: #0000FF }
     :visited { color: #800080 }
@@ -25,8 +23,8 @@
     </h1>
     The Platform can be extended and customized by providing some implementation of OSGi services (for example using Declarative Services).
     <p>This document lists the service interfaces extenders can provide to the Platform and that Platform will consume as extensions:</p>
-    <h3>
-      <a name="runtime" id="runtime"></a>Platform Runtime
+    <h3 id="runtime">
+      Platform Runtime
     </h3>
     <ul>
       <li>
@@ -34,8 +32,8 @@
         contribute adapt strategies, similarly to extensions of <a href="../extension-points/org_eclipse_core_runtime_adapters.html">org.eclipse.core.runtime.adapter</a>.
       </li>
     </ul>
-    <h3>
-      <a name="ui" id="ui"></a>Platform UI
+    <h3 id="ui">
+      Platform UI
     </h3>
     <ul>
       <li>
@@ -43,8 +41,8 @@
         contribute model processors, similarly to extensions of <a href="../extension-points/org_eclipse_e4_workbench_model.html">org.eclipse.e4.workbench.model</a>.
       </li>
     </ul>
-    <h3>
-      <a name="workspace" id="workspace"></a>Workspace
+    <h3 id="workspace">
+      Workspace
     </h3>
     <ul>
       <li>
@@ -52,8 +50,8 @@
         contribute a resource change listener to the workspace.
       </li>
     </ul>
-    <h3>
-      <a name="text" id="text"></a>Platform Text
+    <h3 id="text">
+      Platform Text
     </h3>
     <ul>
       <li>


### PR DESCRIPTION
This change includes:

- Changing the doctype to "html".

- Simplifying the "Content-Type" meta element to only retain the encoding. The remaining attributes match the default settings and can be omitted.

- Removing the obsolete "charset attribute of the "link" element. The encoding is specified via the "Content-Type" header of the linked document.

- Removing the redundant "type" attribute for the "style" element. CSS is the default type and can therefore be omitted.

- Removing the obsolete "Content-Style-Type" meta element. Styles use CSS by default, so there is no need to set it globally for the document.

- Removing the obsolete "Content-Language" meta element. The document language is specified at the root element.

- Converting the obsolete "name" attribute of anchor points to "id" attributes of their nearest container and removing the "a" element all-together.

- Translating the styling of HTML elements to CSS.

- Cleanup of broken HTML or broken references.