### PR TITLE
[RelEng] Support individual updates in release preparation pipeline

### DIFF
--- a/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
+++ b/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
@@ -152,6 +152,16 @@ pipeline {
 				commitAllChangesExcludingSubmodules("Move previous version to ${PREVIOUS_RELEASE_CANDIDATE_TAG} in build scripts")
 			}
 		}
+		stage('Apply individual updates') {
+			environment {
+				UPDATE_SCRIPT = 'prepareNextDevCycle.sh'
+			}
+			steps {
+				sh '''
+					git submodule foreach 'if [ -f ${UPDATE_SCRIPT} ]; then chmod +x ./${UPDATE_SCRIPT} && ./${UPDATE_SCRIPT}; fi'
+				'''
+			}
+		}
 		stage('Validate and list changes') {
 			steps {
 				sh '''

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -184,8 +184,6 @@ Previously they were created in ther own job:
   - Running the [`Prepare Next Development Cycle`](https://ci.eclipse.org/releng/job/Releng/job/prepareNextDevCycle/) job will update pom and product versions for the Eclipse repositories and submit pull requests for the changes.  
   This is still a work in progress so if there are any issues or a repo gets missed you can fall back to the old process below:   
   Once that's done it's easiest to just grep for the previous release version or stream number to find the remaining instances that need to be updated, then commit the changes in a new branch for each repo.   
-  - **Update version number in mac's Eclipse.app**
-    - In [eclipse-equinox/equinox](https://github.com/eclipse-equinox/equinox) update the versions in the Info.plist for both architectures under `eclipse-equinox/equinox/features/org.eclipse.equinox.executable.feature/bin/cocoa/macosx`
   - **Update comparator repo and eclipse run repo**
     - Update the ECLIPSE_RUN_REPO in the [cje-production](cje-production) buildproperties.txt files
   - **Set Previous Version to RC2** 

--- a/scripts/newReleasePrep.sh
+++ b/scripts/newReleasePrep.sh
@@ -31,7 +31,6 @@ BODY="This preparation work involves the following tasks. For previous bug pleas
 - - [ ] Update "Brances" in JobDSL.json to move ${PREV_MAJOR}.${PREV_MINOR}-I builds to R${PREV_MAJOR}_${PREV_MINOR}_maintenance branch
 - - [ ] Add R${PREV_MAJOR}_${PREV_MINOR}_maintenance branch to parent pom and target sdk deployment jobs
 - - [ ] Update I-build triggers with dates for ${NEXT_STREAM} milestone
-- [ ] Configure SWT build scripts for ${NEXT_STREAM}
 - [ ] Splash Screen for ${NEXT_STREAM} (${NEXT_TRAIN})
 - [ ] Create ${NEXT_STREAM}-I-builds repo
 - [ ] Run [`Prepare Next Development Cycle`](https://ci.eclipse.org/releng/job/Releng/job/prepareNextDevCycle/) job and submit the created changes


### PR DESCRIPTION
Introduce the possibility to perform custom changes in each sub-module to prepare it for a new development cycle.
Projects that require additional custom changes can implement them in a script named exactly `prepareNextDevCycle.sh`.