### PR TITLE
Remove images repository from Oomph setup

### DIFF
--- a/oomph/Platform.setup
+++ b/oomph/Platform.setup
@@ -666,67 +666,6 @@
     </project>
     <description>The Platform dependencies</description>
   </project>
-  <project name="images"
-      label="Images">
-    <setupTask
-        xsi:type="git:GitCloneTask"
-        id="github.clone.platform.images"
-        remoteURI="eclipse-platform/eclipse.platform.images">
-      <annotation
-          source="http://www.eclipse.org/oomph/setup/InducedChoices">
-        <detail
-            key="inherit">
-          <value>github.remoteURIs</value>
-        </detail>
-        <detail
-            key="label">
-          <value>Platform Images Github Repository</value>
-        </detail>
-        <detail
-            key="target">
-          <value>remoteURI</value>
-        </detail>
-      </annotation>
-      <configSections
-          name="branch">
-        <properties
-            key="autoSetupRebase"
-            value="always"/>
-      </configSections>
-      <description>Platform Images</description>
-    </setupTask>
-    <setupTask
-        xsi:type="setup.targlets:TargletTask">
-      <targlet
-          name="Platform Images">
-        <requirement
-            name="*"/>
-        <sourceLocator
-            rootFolder="${github.clone.platform.images.location}"
-            locateNestedProjects="true">
-          <excludedPath>org.eclipse.images/eclipse-svg/org.eclipse.m2e.core.ui</excludedPath>
-          <excludedPath>org.eclipse.images.renderer</excludedPath>
-        </sourceLocator>
-      </targlet>
-    </setupTask>
-    <setupTask
-        xsi:type="setup.workingsets:WorkingSetTask"
-        id="platform.images.workingsets">
-      <workingSet
-          name="Platform Images">
-        <predicate
-            xsi:type="predicates:AndPredicate">
-          <operand
-              xsi:type="predicates:RepositoryPredicate"
-              project="org.eclipse.images"/>
-        </predicate>
-      </workingSet>
-    </setupTask>
-    <stream
-        name="master"
-        label="Master"/>
-    <description>The Platform Images</description>
-  </project>
   <project name="releng.aggregator"
       label="Releng Aggregator">
     <setupTask

--- a/oomph/PlatformSDKConfiguration.setup
+++ b/oomph/PlatformSDKConfiguration.setup
@@ -204,8 +204,6 @@
     <stream
         href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='platform']/@projects[name='dependencies']/@projects[name='emf']/@streams[name='master']"/>
     <stream
-        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='platform']/@projects[name='images']/@streams[name='master']"/>
-    <stream
         href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='platform']/@projects[name='swt']/@streams[name='master']"/>
     <stream
         href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='platform']/@projects[name='ui']/@streams[name='master']"/>


### PR DESCRIPTION
The images repository has been archived. This also removes it form the SDK Oomph setup.