### PR TITLE
Switch Debian docker image to 11

### DIFF
--- a/cje-production/dockerfiles/debian/swtgtk3nativebuild/Dockerfile
+++ b/cje-production/dockerfiles/debian/swtgtk3nativebuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10
+FROM debian:11
 
 ### user name recognition at runtime w/ an arbitrary uid - for OpenShift deployments
 COPY scripts/uid_entrypoint /usr/local/bin/uid_entrypoint


### PR DESCRIPTION
Debian 10 is EOL and image can no longer be rebuilt. Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3223