### PR TITLE
Cleanup and migrate "User Assistance Help" documents to HTML5

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Help</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_abstract_scope.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_abstract_scope.htm
@@ -1,16 +1,11 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <meta name="copyright" content=
-    "Copyright (c) IBM Corporation and others 2010, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta http-equiv="Content-Style-Type" content="text/css" />
-    <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type=
-    "text/css" />
-    <script language="JavaScript" src=
-    "PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript">
-</script>
+    "Copyright (c) IBM Corporation and others 2010, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+    <meta charset="utf-8">
+    <link rel="STYLESHEET" href="../book.css" type="text/css">
+    <script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
     <title>
       Using AbstractHelpScope to filter an information center
     </title>
@@ -39,7 +34,7 @@
       by opening an infocenter with a url of this form:
     </p>
     <pre>
-http://&lt;host&gt;:&lt;port&gt;/help/index.jsp?scope=myId
+https://&lt;host&gt;:&lt;port&gt;/help/index.jsp?scope=myId
 </pre>This will present an infocenter which shows only those topics which fall
 within the scope myId.
     <p>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Help content</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_active.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_active.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2021. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Active help</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_active_action.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_active_action.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Writing the help action</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_active_debug.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_active_debug.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Tips for debugging active help</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_active_invoke.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_active_invoke.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Invoking the action from HTML</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_child_links.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_child_links.htm
@@ -1,13 +1,10 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <meta name="copyright" content=
-    "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta http-equiv="Content-Style-Type" content="text/css" />
-    <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type=
-    "text/css" />
+    "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+    <meta charset="utf-8">
+    <link rel="STYLESHEET" href="../book.css" type="text/css">
     <title>
       Adding Child Links to Help Pages
     </title>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_command.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_command.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Embedding commands in help</title>
 </head>
 <body>
@@ -121,9 +120,9 @@ or expecting a certain type of selection).</i>
 
 <p>
 If you want to define your own commands, refer to the documentation for the
-<a href="../reference/api/org/eclipse/core/commands/package-summary.html"><tt>org.eclipse.core.commands</tt></a> API package
-and the <a href="../reference/extension-points/org_eclipse_ui_commands.html"><tt>org.eclipse.ui.commands</tt></a> and
-<a href="../reference/extension-points/org_eclipse_ui_handlers.html"><tt>org.eclipse.ui.handlers</tt></a> extension-points.
+<a href="../reference/api/org/eclipse/core/commands/package-summary.html"><code>org.eclipse.core.commands</code></a> API package
+and the <a href="../reference/extension-points/org_eclipse_ui_commands.html"><code>org.eclipse.ui.commands</code></a> and
+<a href="../reference/extension-points/org_eclipse_ui_handlers.html"><code>org.eclipse.ui.handlers</code></a> extension-points.
 </p>
 
 </body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_command_authoring.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_command_authoring.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Authoring a command link</title>
 </head>
 <body>
@@ -42,7 +41,7 @@ See the
 <P>
 The example above shows the bare minimum required to embed a command in an HTML link.
 The Eclipse documentation supplements this with two extra pieces of information.
-First a <tt>class</tt> attribute is specified to allow for tuning the look of the link
+First a <code>class</code> attribute is specified to allow for tuning the look of the link
 via CSS.  Second, an image tag is included before the link text.  The image serves
 to distinguish command links from ordinary links to other HTML pages.  Supplementing
 our initial example with these two extra features will look like this:
@@ -54,7 +53,7 @@ Open the About dialog&lt;/a&gt;</pre>
 
 <P>
 In the examples above, the About dialog command does not require any parameters, so the
-serialization is merely its command id: <tt>org.eclipse.ui.help.aboutAction</tt>.
+serialization is merely its command id: <code>org.eclipse.ui.help.aboutAction</code>.
 Below is another example showing a command with a parameter.  Note the command id is
 followed by the parameter id and value in parentheses:
 </P>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_criteria.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_criteria.htm
@@ -1,10 +1,9 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2010. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
 <title>Adding criteria to help content</title> 	
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_files.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_files.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2012. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Help server and file locations</title>
 </head>
 <body>
@@ -86,7 +85,7 @@ locale directory structure inside the doc.zip file.)</p>
   resource, like images which differ between system, should be placed under ws
   or os directories for specific platform.</p>
   
-<h4 ><a name="help_plugin_files_xref">Cross Plug-in Referencing</a></h4>
+<h4 id="help_plugin_files_xref">Cross Plug-in Referencing</h4>
 
 <P >The <b>href</b> argument can also refer to content from another
 plug-in.&nbsp; This is done by using a special cross plug-in referencing

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_manifest.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_manifest.htm
@@ -1,12 +1,14 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Completing the plug-in manifest</title>
+<style>
+	img { border: 0; }
+</style>
 </head>
 <body>
 
@@ -64,7 +66,7 @@ toc. </P>
 <b> Help-&gt;Help Contents</b>, you should see your example appear in the list
 of books. If you click on the "Online Help Sample", you'll see your toc structure:</P>
 
-<p><img src="images/help_contents.png" alt="On-line help browser with sample book structure" border="0" ></p>
+<p><img src="images/help_contents.png" alt="On-line help browser with sample book structure"></p>
 
 </body>
 </html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_nested.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_nested.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Building nested documentation structures</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_process.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_process.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Processing Help Content</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_remote.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_remote.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Remote Help</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_toc.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_toc.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Table of contents (toc) files</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_xhtml.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_content_xhtml.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Contributing XHTML help documents</title>
 </head>
 <body>
@@ -30,7 +29,7 @@ XHTML help documents are contributed in exactly the same way as HTML documents b
 Since Eclipse 3.4 it is no longer necessary to bind the "org.eclipse.help.base.xhtml&quot; search participant to your
          doc plugin.</p> 
 
-<p><a name="include_format"><b>XHTML include format</b></a></p>
+<p id="include_format"><b>XHTML include format</b></p>
 
 <p>
 If you wish to use <a href="ua_dynamic_includes.htm">includes</a> in your XHTML,

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_context.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_context.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Context-sensitive help</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_context_dynamic.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_context_dynamic.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Dynamic context help</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_context_id.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_context_id.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Declaring a context id</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_context_infopops.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_context_infopops.htm
@@ -1,12 +1,15 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Infopops</title>
+<style>
+	p.center { text-align: center; }
+	img { border: 0;  }
+</style>
 </head>
 <body>
 
@@ -21,8 +24,8 @@ key (<code>Ctrl+F1</code> on GTK, and <code>Help</code> key on Carbon).</p>
 window. However, it is still possible to configure context help presentation to 
 use infopops in the Help preferences. For example, here is an infopop that has been defined on 
 the General/Search page: </p>
-<p align="center">
-<img border="0" src="images/infopops.png" alt="Image showing an infopop">
+<p class="center">
+<img src="images/infopops.png" alt="Image showing an infopop">
 </p>
 
 <p>Since Eclipse 3.1, infopops have a link to show the currently displayed 

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_context_xml.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_context_xml.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Describing and packaging context-sensitive help content</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_infocenter_preferences.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_infocenter_preferences.htm
@@ -1,10 +1,9 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
 <title>Information center customization</title>
 
 </head>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_menu.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_menu.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Help content</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_placeholders.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_placeholders.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Help Placeholders</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_search.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_search.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2006. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Help search</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_search_types.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_search_types.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Plugging in search engines</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_setup.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_setup.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Configuration/setup</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_setup_about.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_setup_about.htm
@@ -1,10 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<meta charset="utf-8">
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 <title>Using about.html to debug information centers</title>
-<link rel="stylesheet" href="../book.css" charset="utf-8" type="text/css">
+<link rel="stylesheet" href="../book.css" type="text/css">
 </head>
 <body>
 
@@ -14,8 +14,8 @@
 When developing an information center sometimes not all of the books show as expected or 
 customizations do not have the desired effect. The about.html page can be used to get information 
 about installed plug-ins and help system preferences. If the home page of the help system is</p> 
-<pre>http://&lt;hostname&gt;:&lt;port&gt;/help/index.jsp</pre> <p>the about page has a url of</p> 
-<pre>http://&lt;hostname&gt;:&lt;port&gt;/help/about.html</pre> 
+<pre>https://&lt;hostname&gt;:&lt;port&gt;/help/index.jsp</pre> <p>the about page has a url of</p> 
+<pre>https://&lt;hostname&gt;:&lt;port&gt;/help/about.html</pre> 
 <p>Without any parameters the about page shows a list of all plug-ins installed on the system. 
 Parameters can be added to show other kinds of information as follows:</p>
 <ul>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_setup_help_data.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_setup_help_data.htm
@@ -1,18 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <meta name="copyright" content=
-    "Copyright (c) IBM Corporation and others 2006, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    "Copyright (c) IBM Corporation and others 2006, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+    <meta charset="utf-8">
     <title>
       Help Data
     </title>
-    <link rel="stylesheet" href="../schema.css" charset="utf-8" type=
-    "text/css" />
-    <link rel="stylesheet" href="../book.css" charset="utf-8" type=
-    "text/css" />
-    <style type="text/css">
+    <link rel="stylesheet" href="../schema.css" type="text/css">
+    <link rel="stylesheet" href="../book.css" type="text/css">
+    <style>
 /*<![CDATA[*/
     span.c3 {color: #008000}
     span.c2 {color: #0000FF}
@@ -46,18 +43,18 @@
       Configuration Markup:
     </h6>
 
-    <p class="SchemaDtd">
-      &lt;!ELEMENT <a name="e.extensions" id="e.extensions">extensions</a>
+    <p class="SchemaDtd" id="e.extensions">
+      &lt;!ELEMENT extensions
       (<a href="#e.tocOrder">tocOrder</a>? , <a href=
       "#e.hidden">hidden</a>?)&gt;
     </p>
     <p class="">
 
       The extension data for Help.
-    </p><br />
-    <br />
-    <p class="SchemaDtd">
-      &lt;!ELEMENT <a name="e.tocOrder" id="e.tocOrder">tocOrder</a> (<a href=
+    </p><br>
+    <br>
+    <p class="SchemaDtd" id="e.tocOrder">
+      &lt;!ELEMENT tocOrder (<a href=
       "#e.toc">toc</a> | <a href="#e.category">category</a>)*&gt;
 
     </p>
@@ -67,10 +64,10 @@
       the items listed is not available, it is ignored. If there are items
       available that are not listed and not hidden, they will be displayed
       after the ones listed here.
-    </p><br />
-    <br />
-    <p class="SchemaDtd">
-      &lt;!ELEMENT <a name="e.toc" id="e.toc">toc</a> EMPTY&gt;
+    </p><br>
+    <br>
+    <p class="SchemaDtd" id="e.toc">
+      &lt;!ELEMENT toc EMPTY&gt;
 
     </p>
     <p class="SchemaDtd">
@@ -83,7 +80,7 @@
 
       A reference to a top-level table of contents (TOC) entry, also called a
       "book".
-    </p><br />
+    </p><br>
     <ul class="ConfigMarkupAttlistDesc">
       <li>
         <b>id</b> - The unique identifier for this book. For XML file TOC
@@ -94,9 +91,9 @@
         originating <code>AbstractTocProvider</code>.
       </li>
 
-    </ul><br />
-    <p class="SchemaDtd">
-      &lt;!ELEMENT <a name="e.category" id="e.category">category</a> EMPTY&gt;
+    </ul><br>
+    <p class="SchemaDtd" id="e.category">
+      &lt;!ELEMENT category EMPTY&gt;
     </p>
     <p class="SchemaDtd">
       &lt;!ATTLIST category
@@ -112,25 +109,25 @@
       specifying a <code>category</code> attribute for the <code>toc</code>
 
       element in the <code>org.eclipse.help.toc</code> extension point.
-    </p><br />
+    </p><br>
     <ul class="ConfigMarkupAttlistDesc">
       <li>
         <b>id</b> - The unique id of the category.
       </li>
-    </ul><br />
+    </ul><br>
 
-    <p class="SchemaDtd">
-      &lt;!ELEMENT <a name="e.hidden" id="e.hidden">hidden</a> (<a href=
+    <p class="SchemaDtd" id="e.hidden">
+      &lt;!ELEMENT hidden (<a href=
       "#e.toc">toc</a> | <a href="#e.category">category</a> | <a href=
       "#e.index">index</a>)*&gt;
     </p>
 
     <p class="ConfigMarkupElementDesc">
       Contains a set of help items that should be hidden from the user.
-    </p><br />
-    <br />
-    <p class="SchemaDtd">
-      &lt;!ELEMENT <a name="e.index" id="e.index">index</a> EMPTY&gt;
+    </p><br>
+    <br>
+    <p class="SchemaDtd" id="e.index">
+      &lt;!ELEMENT index EMPTY&gt;
     </p>
 
     <p class="SchemaDtd">
@@ -141,7 +138,7 @@
     </p>
     <p class="ConfigMarkupElementDesc">
       A reference to a contribution of help index keywords.
-    </p><br />
+    </p><br>
 
     <ul class="ConfigMarkupAttlistDesc">
       <li>
@@ -153,7 +150,7 @@
         originating <code>AbstractIndexProvider</code>.
       </li>
 
-    </ul><br />
+    </ul><br>
     <h6 class="CaptionFigColumn">
       Examples:
     </h6>
@@ -225,7 +222,7 @@
     <code>org.eclipse.help</code>, including the default help implementation
     provided by Eclipse.
     <p class="SchemaCopyright">
-      Copyright (c) 2006, 2011 IBM Corporation and others.<br />
+      Copyright (c) 2006, 2011 IBM Corporation and others.<br>
       All rights reserved. This program and the accompanying materials are made
       available under the terms of the Eclipse Public License v1.0 which
       accompanies this distribution, and is available at <a href=

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_setup_infocenter.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_setup_infocenter.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Information Center</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_setup_nav.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_setup_nav.htm
@@ -1,8 +1,8 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
-<head><meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<head><meta charset="utf-8">
 <title>Generated navigation topics</title>
-<link rel="stylesheet" href="../book.css" charset="utf-8" type="text/css">
+<link rel="stylesheet" href="../book.css" type="text/css">
 </head>
 <body>
 

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_setup_preferences.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_setup_preferences.htm
@@ -1,18 +1,26 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
 <title>Help system customization</title>
 
-<style type="text/css">
+<style>
 	.deprecated {
 		color: #444444;
 	}
 	.warning {
 		color: red;
+	}
+	table, td {
+		border: 1px solid;
+	}
+	table {
+		border-style: outset;
+	}
+	td {
+		border-style: inset;
 	}
 </style>
 
@@ -33,7 +41,7 @@ defines them.
 
 <h3>org.eclipse.help Plug-in:</h3>
 
-<table border="1">
+<table>
   <tbody>
     <tr>
       <td style="font-weight: bold;">Preference key</td>
@@ -94,7 +102,7 @@ appear in the index view. For index XML files, use the path to the file in the f
 
 <h3>org.eclipse.help.base Plug-in:</h3>
 
-<table border="1">
+<table>
   <tbody>
     <tr>
       <td style="font-weight: bold;">Preference key</td>
@@ -377,7 +385,7 @@ Accepted values:<br>
       <td>false</td>
     </tr>
     <tr>
-      <td><a name="remoteHelp"></a>
+      <td id="remoteHelp">
       <code>remoteHelpOn</code><br>
       </td>
       <td>Controls whether or not remote help is enabled.<br>
@@ -490,7 +498,7 @@ Accepted values:<br>
 <h3 class="deprecated">org.eclipse.help.appserver Plug-in:</h3>
 <span class="warning">Deprecated: This plug-in is no longer used by help. See table for alternative usage.</span>
 
-<table border="1">
+<table>
   <tbody>
     <tr>
       <td style="font-weight: bold;"><span class="deprecated">Preference key</span></td>
@@ -524,7 +532,7 @@ port is picked by the system.</p>
 <h3 class="deprecated">org.eclipse.tomcat Plug-in:</h3>
 <span class="warning">Deprecated: This plug-in is no longer used by help. No alternative commands available.</span>
 
-<table border="1">
+<table>
   <tbody>
     <tr>
       <td style="font-weight: bold;"><span class="deprecated">Preference key</span></td>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_setup_preindex.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_setup_preindex.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Pre-indexing documentation</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_setup_rcp.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_setup_rcp.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Rich Client Platform (RCP) help</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_setup_standalone.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_setup_standalone.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2015. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Standalone help</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_war.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_help_war.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2020. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Deploying the information center as a Web Archive</title>
 </head>
 <body>
@@ -18,30 +17,30 @@ The instructions below assume a Tomcat server has been installed, but with minor
 </p>
 
 <ul>
-<li>Clone the <tt>eclipse.platform.ua</tt> repository
+<li>Clone the <code>eclipse.platform.ua</code> repository
 <pre>git clone https://git.eclipse.org/r/platform/eclipse.platform.ua.git</pre>
 </li>
-<li>In the Git repository locate the <tt>infocenter-web</tt> directory and underneath that there will be two directories titled <tt>infocenter-app</tt> and <tt>infocenter-product</tt>.</li>
+<li>In the Git repository locate the <code>infocenter-web</code> directory and underneath that there will be two directories titled <code>infocenter-app</code> and <code>infocenter-product</code>.</li>
 <li>Make sure you have the "m2e - Maven Integration for Eclipse" feature installed in your Eclipse IDE.</li>
-<li>Import the <tt>infocenter-web</tt> Maven project using <i>File->Import->Existing Project</i>.</li>
-<li>Add some documentation plugins to the <tt>infocenter-web/infocenter-app/src/main/webapp/WEB-INF/plugins directory</tt>.</li>
-<li>Register the plugins in <tt>infocenter-web/infocenter-app/src/main/webapp/WEB-INF/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info</tt></li>
+<li>Import the <code>infocenter-web</code> Maven project using <i>File->Import->Existing Project</i>.</li>
+<li>Add some documentation plugins to the <code>infocenter-web/infocenter-app/src/main/webapp/WEB-INF/plugins directory</code>.</li>
+<li>Register the plugins in <code>infocenter-web/infocenter-app/src/main/webapp/WEB-INF/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info</code></li>
 <li>Install required Maven POMs from Eclipse Platform:
 <pre>
 git clone -q --depth 1 https://git.eclipse.org/r/platform/eclipse.platform.releng.aggregator &amp;&amp; mvn install -N -f eclipse.platform.releng.aggregator/eclipse-platform-parent &amp;&amp; mvn install -N -f eclipse.platform.releng.aggregator/eclipse.platform.releng.prereqs.sdk
 </pre>
-<li>Execute a Maven build in <tt>infocenter-web</tt><br/>
+<li>Execute a Maven build in <code>infocenter-web</code><br/>
   <ul>
-  <li>Either within Eclipse, right-click on <tt>infocenter-build.launch</tt> and select <i>Run As -> infocenter-build</i><br/></li>
-  <li>Or from command-line using the command <tt>mvnw</tt></li>
+  <li>Either within Eclipse, right-click on <code>infocenter-build.launch</code> and select <i>Run As -> infocenter-build</i><br/></li>
+  <li>Or from command-line using the command <code>mvnw</code></li>
   </ul>
 </li>
-<li>For Tomcat only. In <tt>conf/server.xml</tt> add <tt>URIEncoding="UTF-8"</tt> to the <tt>connector</tt> element, for example <pre>&lt;Connector port="8080" URIEncoding="UTF-8" etc.&gt;</pre> 
+<li>For Tomcat only. In <code>conf/server.xml</code> add <code>URIEncoding="UTF-8"</code> to the <code>connector</code> element, for example <pre>&lt;Connector port="8080" URIEncoding="UTF-8" etc.&gt;</pre> 
 If this step is not performed search will fail if the search term contains non ASCII characters.</li>
 <li>Start Tomcat and see the help system start up. The default URL is <a href="http://localhost:8080/help/">http://localhost:8080/help/</a>.</li>
 </ul>
 
-Notes: If you look in the <tt>config.ini</tt> the <tt>help.war</tt> file under directory <tt>help/WEB_INF/configuration</tt> you will notice the line <tt>eclipse.product=org.eclipse.productname</tt>.
+Notes: If you look in the <code>config.ini</code> the <code>help.war</code> file under directory <code>help/WEB_INF/configuration</code> you will notice the line <code>eclipse.product=org.eclipse.productname</code>.
 If your product has help system customizations in a product plugin you can activate these by changing this line to point to your product plugin.
 
 <h3>Troubleshooting</h3>
@@ -49,14 +48,14 @@ If your product has help system customizations in a product plugin you can activ
 <h4>HTTP 404 With Message "BridgeServlet: /help/"</h4>
 
 <p>
-In the <tt>web.xml</tt> activate the init parameter <tt>enableFrameworkControls</tt>. This enables endpoints to control the embedded OSGi container. Call <a href="http://localhost:8080/help/sp_test">http://localhost:8080/help/sp_test</a>.
+In the <code>web.xml</code> activate the init parameter <code>enableFrameworkControls</code>. This enables endpoints to control the embedded OSGi container. Call <a href="http://localhost:8080/help/sp_test">http://localhost:8080/help/sp_test</a>.
 </p>
 <p>
-You should see the message "<tt>Servlet delegate registered - org.eclipse.equinox.http.servlet.HttpServiceServlet</tt>". You may instead see the message "<tt>Servlet delegate not registered.</tt>". 
-This indicates that bundle activator from bundle <tt>org.eclipse.equinox.http.servletbridge</tt> was not started or that it accesses a different instance of class <tt>org.eclipse.equinox.servletbridge.BridgeServlet</tt>.
+You should see the message "<code>Servlet delegate registered - org.eclipse.equinox.http.servlet.HttpServiceServlet</code>". You may instead see the message "<code>Servlet delegate not registered.</code>". 
+This indicates that bundle activator from bundle <code>org.eclipse.equinox.http.servletbridge</code> was not started or that it accesses a different instance of class <code>org.eclipse.equinox.servletbridge.BridgeServlet</code>.
 </p>
 <p>
-For all available framework control endpoints refer to <tt>org.eclipse.equinox.servletbridge.BridgeServlet.serviceFrameworkControls(HttpServletRequest, HttpServletResponse)</tt>.
+For all available framework control endpoints refer to <code>org.eclipse.equinox.servletbridge.BridgeServlet.serviceFrameworkControls(HttpServletRequest, HttpServletResponse)</code>.
 </p>
 
 </body>


### PR DESCRIPTION
This primarily cleans up the document header and migrates some of the deprecated elements.

Contributes to
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3275