### PR TITLE
[RelEng] Move Maven staging behind build-update in release promotion

### DIFF
--- a/JenkinsJobs/Releng/promoteBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/promoteBuild.jenkinsfile
@@ -184,16 +184,6 @@ pipeline {
 				}
 			}
 		}
-		stage('Stage for Maven-Central') {
-			when {
-				environment name: 'DL_TYPE', value: 'R'
-			}
-			steps {
-				build job: 'Releng/deployToMaven', wait: true, propagate: true, parameters: [
-					string(name: 'sourceRepository', value: "https://download.eclipse.org/eclipse/updates/${BUILD_MAJOR}.${BUILD_MINOR}/${DL_DROP_ID}/")
-				]
-			}
-		}
 		stage('Update build configurations') {
 			when {
 				environment name: 'DL_TYPE', value: 'R'
@@ -294,6 +284,16 @@ pipeline {
 							""".stripIndent(),"update-${MAINTENANCE_BRANCH}", "${MAINTENANCE_BRANCH}")
 					}}
 				}
+			}
+		}
+		stage('Stage to Maven-Central') {
+			when {
+				environment name: 'DL_TYPE', value: 'R'
+			}
+			steps {
+				build job: 'Releng/deployToMaven', wait: true, propagate: true, parameters: [
+					string(name: 'sourceRepository', value: "https://download.eclipse.org/eclipse/updates/${BUILD_MAJOR}.${BUILD_MINOR}/${DL_DROP_ID}/")
+				]
 			}
 		}
 		stage('Update acknowledgements') {


### PR DESCRIPTION
The Staging to Maven-Central is just triggering the Maven-deployment job and is therefore easier to do manually in case something fails before. It should therefore happen later, as it's also a stage that's not much tested in advance.