### PR TITLE
[RelEng] Archive deployment bundles staged for Maven-Central

### DIFF
--- a/JenkinsJobs/Releng/deployToMaven.jenkinsfile
+++ b/JenkinsJobs/Releng/deployToMaven.jenkinsfile
@@ -213,8 +213,8 @@ pipeline {
 	post {
 		always {
 			archiveArtifacts allowEmptyArchive: true, artifacts: '\
-				repo/**, \
-				coordinates*.txt, artifacts*.txt, deploymentId-*.txt'
+				repo/**, coordinates-*.txt, artifacts-*.txt, \
+				deploymentId-*.txt, */*-artifacts.zip'
 		}
 		failure {
 			emailext subject: "Publication of Maven artifacts failed",


### PR DESCRIPTION
If a release is deployed by the Maven-deployment pipeline, a deplyoment bundle is transfered to the Central-Portal via the Publisher API. Archiving that bundle/zip simplifies subsequent investigations if necessary.

FYI @merks, this might be useful sometimes.