### PR TITLE
Cleanup and migrate remaining "User Assistance" documents to HTML5

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>User assistance support</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_cheatsheet.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_cheatsheet.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Cheat sheets</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_cheatsheet_composite.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_cheatsheet_composite.htm
@@ -1,23 +1,25 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <meta name="copyright" content=
-    "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta http-equiv="Content-Style-Type" content="text/css" />
-    <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type=
-    "text/css" />
-    <script language="JavaScript" src=
-    "PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript">
-</script>
+    "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+    <meta charset="utf-8">
+    <link rel="STYLESHEET" href="../book.css" type="text/css">
+    <script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
     <title>
       Composite cheat sheets
     </title>
 
-    <style type="text/css">
+    <style>
 /*<![CDATA[*/
-    table.c1 {border-collapse: collapse}
+    table.c1 {
+       border-collapse: collapse;
+       border-spacing: 0;
+    }
+    table, tr, td { border: 1px solid; }
+    td { padding: 0 }
+    td.name { width: 10%; }
+    td.desc { width: 29%; }
     /*]]>*/
     </style>
   </head>
@@ -84,21 +86,21 @@
       task is started, There are three possible parameters to a cheat sheet
       task.
     </p>
-    <table border="1" cellpadding="0" cellspacing="0" class="c1">
+    <table class="c1">
       <tr>
-        <td width="10%">
+        <td class="name">
           Parameter name
         </td>
 
-        <td width="29%">
+        <td class="desc">
           &nbsp;Description
         </td>
       </tr>
       <tr>
-        <td width="10%">
+        <td class="name">
           id
         </td>
-        <td width="29%">
+        <td class="desc">
           The id of a cheat sheet which has been registered using the extension
           point org.eclipse.ui.cheatsheets.cheatSheetContent. This identifies
           the cheatsheet which will be associated with this task. Either the id
@@ -107,10 +109,10 @@
 
       </tr>
       <tr>
-        <td width="10%">
+        <td class="name">
           path
         </td>
-        <td width="29%">
+        <td class="desc">
           The URL of a cheat sheet content file. This may be an absolute URL,
           or relative to the content file for the composite cheat sheet. If
           both id and path are specified the path will be used to locate the
@@ -119,10 +121,10 @@
       </tr>
       <tr>
 
-        <td width="10%">
+        <td class="name">
           showIntro
         </td>
-        <td width="29%">
+        <td class="desc">
           A boolean parameter with default value of true. If "false" the cheat
           sheet when started will initially show the first step rather than the
           introduction..
@@ -222,18 +224,18 @@
     <p>
       <a href=
       "../../org.eclipse.platform.doc.user/reference/ref-cheatsheets.htm">Working
-      with cheat sheets</a><br />
+      with cheat sheets</a><br>
       <a href=
       "../../org.eclipse.platform.doc.user/reference/ref-composite-cheatsheets.htm">
-      Working with composite cheat sheets</a><br />
-      <a href="ua_cheatsheet_simple.htm">Creating cheat sheets</a><br />
+      Working with composite cheat sheets</a><br>
+      <a href="ua_cheatsheet_simple.htm">Creating cheat sheets</a><br>
 
-      <a href="ua_cheatsheet_guidelines.htm">Authoring guidelines</a><br />
+      <a href="ua_cheatsheet_guidelines.htm">Authoring guidelines</a><br>
       <a href="ua_cheatsheet_composite_content.htm">Composite cheat sheet
-      content file specification</a><br />
+      content file specification</a><br>
       <a href=
       "../reference/extension-points/org_eclipse_ui_cheatsheets_cheatSheetContent.html">
-      org.eclipse.ui.cheatsheets.cheatSheetContent extension point</a><br />
+      org.eclipse.ui.cheatsheets.cheatSheetContent extension point</a><br>
     </p>
   </body>
 </html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_cheatsheet_composite_content.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_cheatsheet_composite_content.htm
@@ -1,12 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<link rel="stylesheet" href="../schema.css" charset="utf-8" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<link rel="stylesheet" href="../schema.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Composite cheat sheet content file XML format</title>
 </head>
 <body>
@@ -18,7 +17,7 @@
 
 <h6 class="CaptionFigColumn">Description: </h6><p>The schema definition for a composite cheat sheet content file. A composite cheat sheet consists of a set of tasks organized into task groups. Each task can be a simple cheat sheet or a user contributed task kind.</p>
 <h6 class="CaptionFigColumn">Configuration Markup:</h6>
-<p class="SchemaDtd">&lt;!ELEMENT <a name="e.compositeCheatsheet">compositeCheatsheet</a> (<a href="#e.taskGroup">taskGroup</a> | <a href="#e.task">task</a>)&gt;</p>
+<p class="SchemaDtd" id="e.compositeCheatsheet">&lt;!ELEMENT compositeCheatsheet (<a href="#e.taskGroup">taskGroup</a> | <a href="#e.task">task</a>)&gt;</p>
 <p class="SchemaDtd">&lt;!ATTLIST compositeCheatsheet</p>
 <p class="SchemaDtdAttlist">name&nbsp;CDATA #REQUIRED&gt;</p>
 <p class="ConfigMarkupElementDesc">
@@ -27,7 +26,7 @@ The root element of a composite cheatsheet</p>
 <ul class="ConfigMarkupAttlistDesc">
 <li><b>name</b> - The name of the composite cheat sheet which will be displayed in large font when the composite cheat sheet is opened.</li>
 </ul>
-<br><p class="SchemaDtd">&lt;!ELEMENT <a name="e.taskGroup">taskGroup</a> ((<a href="#e.task">task</a> | <a href="#e.taskGroup">taskGroup</a>) , <a href="#e.intro">intro</a>? , <a href="#e.onCompletion">onCompletion</a>? , <a href="#e.dependency">dependency</a>*)&gt;</p>
+<br><p class="SchemaDtd" id="e.taskGroup">&lt;!ELEMENT taskGroup ((<a href="#e.task">task</a> | <a href="#e.taskGroup">taskGroup</a>) , <a href="#e.intro">intro</a>? , <a href="#e.onCompletion">onCompletion</a>? , <a href="#e.dependency">dependency</a>*)&gt;</p>
 <p class="SchemaDtd">&lt;!ATTLIST taskGroup</p>
 <p class="SchemaDtdAttlist">kind&nbsp;CDATA "set"</p><p class="SchemaDtdAttlist">name&nbsp;CDATA #REQUIRED</p><p class="SchemaDtdAttlist">id&nbsp;&nbsp;&nbsp;CDATA #IMPLIED</p><p class="SchemaDtdAttlist">skip&nbsp;(true | false) "false"&gt;</p>
 <p class="ConfigMarkupElementDesc">
@@ -39,7 +38,7 @@ A task group represents a collection of related tasks. If the kind is "choice" o
 <li><b>id</b> - An id for this task group which is required if this task group is referenced by a dependency element.</li>
 <li><b>skip</b> - If true this group of tasks may be skipped.</li>
 </ul>
-<br><p class="SchemaDtd">&lt;!ELEMENT <a name="e.task">task</a> (<a href="#e.intro">intro</a>? , <a href="#e.onCompletion">onCompletion</a>? , <a href="#e.param">param</a>* , <a href="#e.dependency">dependency</a>*)&gt;</p>
+<br><p class="SchemaDtd" id="e.task">&lt;!ELEMENT task (<a href="#e.intro">intro</a>? , <a href="#e.onCompletion">onCompletion</a>? , <a href="#e.param">param</a>* , <a href="#e.dependency">dependency</a>*)&gt;</p>
 <p class="SchemaDtd">&lt;!ATTLIST task</p>
 <p class="SchemaDtdAttlist">kind&nbsp;CDATA #REQUIRED</p><p class="SchemaDtdAttlist">name&nbsp;CDATA #REQUIRED</p><p class="SchemaDtdAttlist">id&nbsp;&nbsp;&nbsp;CDATA #IMPLIED</p><p class="SchemaDtdAttlist">skip&nbsp;(true | false) "false"&gt;</p>
 <p class="ConfigMarkupElementDesc">
@@ -51,7 +50,7 @@ A leaf task within a composite cheat sheet. A task does not have children, but i
 <li><b>id</b> - An id for this task group which is required if this task group is referenced by a dependency element.</li>
 <li><b>skip</b> - If true this task may be skipped.</li>
 </ul>
-<br><p class="SchemaDtd">&lt;!ELEMENT <a name="e.param">param</a> EMPTY&gt;</p>
+<br><p class="SchemaDtd" id="e.param">&lt;!ELEMENT param EMPTY&gt;</p>
 <p class="SchemaDtd">&lt;!ATTLIST param</p>
 <p class="SchemaDtdAttlist">name&nbsp;&nbsp;CDATA #REQUIRED</p><p class="SchemaDtdAttlist">value&nbsp;CDATA #REQUIRED&gt;</p>
 <p class="ConfigMarkupElementDesc">
@@ -61,15 +60,15 @@ A parameter to a task within a composite cheatsheet. Each parameter has a name a
 <li><b>name</b> - The name of this parameter.</li>
 <li><b>value</b> - The value of this parameter.</li>
 </ul>
-<br><p class="SchemaDtd">&lt;!ELEMENT <a name="e.intro">intro</a> (#PCDATA)&gt;</p>
+<br><p class="SchemaDtd" id="e.intro">&lt;!ELEMENT intro (#PCDATA)&gt;</p>
 <p class="ConfigMarkupElementDesc">
 Contains the text which will be displayed before this task has been started. May contain form text markup.</p>
 <br><br>
-<p class="SchemaDtd">&lt;!ELEMENT <a name="e.onCompletion">onCompletion</a> (#PCDATA)&gt;</p>
+<p class="SchemaDtd" id="e.onCompletion">&lt;!ELEMENT onCompletion (#PCDATA)&gt;</p>
 <p class="ConfigMarkupElementDesc">
 Contains the text which will be displayed in the completion panel for this task. May contain form text markup.</p>
 <br><br>
-<p class="SchemaDtd">&lt;!ELEMENT <a name="e.dependency">dependency</a> EMPTY&gt;</p>
+<p class="SchemaDtd" id="e.dependency">&lt;!ELEMENT dependency EMPTY&gt;</p>
 <p class="SchemaDtd">&lt;!ATTLIST dependency</p>
 <p class="SchemaDtdAttlist">task&nbsp;CDATA #REQUIRED&gt;</p>
 <p class="ConfigMarkupElementDesc">

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_cheatsheet_guidelines.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_cheatsheet_guidelines.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Cheat sheet authoring guidelines</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_cheatsheet_simple.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_cheatsheet_simple.htm
@@ -1,12 +1,15 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Simple cheat sheets</title>
+<style>
+	img { border: 0; }
+	p.center { text-align: center; }
+</style>
 </head>
 <body>
 
@@ -52,20 +55,20 @@ sheet.  The name and description are shown when the user accesses the
 list.  A category for the cheat sheet can also be defined if you want 
 to place several cheat sheets into a logical grouping.  If no category is specified, the cheat sheet will
 appear in the <b>Other</b> category.
-<p align="center">
-<img border="0" src="images/cheatsheets.png" alt="Cheat sheet dialog"></p>
+<p class="center">
+<img src="images/cheatsheets.png" alt="Cheat sheet dialog"></p>
 <h4>Cheat Sheet Items</h4>
 <p>
 The real work for cheat sheets is done in the content file.  The content file is an XML file whose name and location
 are specified in the <b>contentFile</b> attribute.  The path for the file is relative to the plug-in's directory.  (Note
-the use of the <tt>$nl$</tt> variable in the directory name, which means the file will be located in a directory specific
+the use of the <code>$nl$</code> variable in the directory name, which means the file will be located in a directory specific
 to the national language of the target environment.)
 </p>
 <p>The file format itself includes overview information about the cheat sheet followed
 by a description of each step (called an <i>item</i>) that
 the user will perform.  At its simplest, an item is just a detailed description of the step that the user should
 take.  However, an item can also specify an action that can be run to perform the step on behalf of the
-user.  Let's look at the first part of the content file (<tt>HelloWorld.xml</tt>) 
+user.  Let's look at the first part of the content file (<code>HelloWorld.xml</code>) 
 for the Java cheat sheet.
 </p>
 <pre>&lt;?xml version="1.0" encoding="UTF-8" ?&gt; 
@@ -93,8 +96,8 @@ You can click the "Click to Perform" button to have the "Java" perspective opene
 &lt;/item&gt;
 ...
 </pre>
-<p align="center">
-<img border="0" src="images/javacheatsheet.png" alt="Simple java cheat sheet">
+<p class="center">
+<img src="images/javacheatsheet.png" alt="Simple java cheat sheet">
 </p>
 <p>
 The title and intro information are shown at the top of the cheat sheet.  Then, the items are described. 
@@ -150,7 +153,7 @@ Conditional expressions can be used to define cheat sheet elements whose content
 particular condition being true.  Conditions are described in the <b>condition</b> element of a subitem
 using arbitrary string values that are matched
 against the <b>when</b> attribute for each choice.  Conditions typically reference cheat sheet
-variables using the form  <tt>${<i>var</i>}</tt>, where <i>var</i> refers to the name of a cheet sheet variable.
+variables using the form  <code>${<i>var</i>}</code>, where <i>var</i> refers to the name of a cheet sheet variable.
 A few simple examples will help demonstrate how conditional expressions work.
 </p>
 <p>
@@ -165,9 +168,9 @@ cheat sheet.  For example:
 	&lt;/conditional-subitem&gt;
 &lt;/item&gt;
 </pre>
-This item specifies two possible subitems that depend on the value of the variable <tt>v1</tt>.
-If the variable value is <tt>a</tt>, then the first subitem will be included.  If the variable value
-is <tt>b</tt>, then the second subitem will be included.  If the variable is neither value, it is considered
+This item specifies two possible subitems that depend on the value of the variable <code>v1</code>.
+If the variable value is <code>a</code>, then the first subitem will be included.  If the variable value
+is <code>b</code>, then the second subitem will be included.  If the variable is neither value, it is considered
 an error.
 <p>
 <b>Conditional actions</b> are similar to conditional subitems.  The <b>perform-when</b> element specifies
@@ -182,11 +185,11 @@ matches the condition is the one that will be performed.   For example:
 	&lt;/perform-when&gt;
 &lt;/item&gt;
 </pre>
-The action to be performed is chosen based on the value of the <tt>v1</tt> variable.  If the variable
-value is neither <tt>a</tt> or <tt>b</tt>, it is considered an error.
+The action to be performed is chosen based on the value of the <code>v1</code> variable.  If the variable
+value is neither <code>a</code> or <code>b</code>, it is considered an error.
 <h4>Repeated Subitems</h4>
 <p>Repeated subitems describe a subitem that can can expand into 0, 1, or more similar substeps.  The
-substeps are individualized using the special variable <tt>${this}</tt>.  This variable will be replaced by
+substeps are individualized using the special variable <code>${this}</code>.  This variable will be replaced by
 the values specified in the <b>values</b> attribute.  The values attribute is a string of values that are separated
 by commas.  A variable that expands into a list of values may be used in the values attribute.
 For example:
@@ -197,7 +200,7 @@ For example:
 	&lt;/repeated-subitem&gt;
 &lt;/item&gt;
 </pre>
-If the value of the variable is <tt>1,b,three</tt>, then three subitems will appear in the cheat sheet, each
+If the value of the variable is <code>1,b,three</code>, then three subitems will appear in the cheat sheet, each
 having a unique label ("Step 1," "Step b," "Step three").  The variable can be used in the label or the
 action paramater value.  It can also be accessed from the 
 <a href="../reference/api/org/eclipse/ui/cheatsheets/ICheatSheetManager.html"><b>ICheatSheetManager</b></a>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_dynamic.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_dynamic.htm
@@ -1,14 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2006. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Dynamic content</title>
 
-<style type="text/css">
+<style>
 	.highlight {
 		color: blue;
 	}

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_dynamic_extensions.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_dynamic_extensions.htm
@@ -1,21 +1,16 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <meta name="copyright" content=
-    "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta http-equiv="Content-Style-Type" content="text/css" />
-    <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type=
-    "text/css" />
-    <script language="JavaScript" src=
-    "PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript">
-</script>
+    "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+    <meta charset="utf-8">
+    <link rel="STYLESHEET" href="../book.css" type="text/css">
+    <script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
     <title>
       Content extensions
     </title>
 
-    <style type="text/css">
+    <style>
 /*<![CDATA[*/
     span.c1 {color: blue}
     /*]]>*/

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_dynamic_filters.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_dynamic_filters.htm
@@ -1,14 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Filters</title>
 
-<style type="text/css">
+<style>
 	.deprecated {
 		color: #444444;
 	}
@@ -17,6 +16,15 @@
 	}
 	.highlight {
 		color: blue;
+	}
+	table, tr, td {
+		border: 1px;
+	}
+	table {
+		border-style: outset;
+	}
+	tr, td {
+		border-style: inset;
 	}
 </style>
 </head>
@@ -45,7 +53,7 @@ a system property against an expected value. Some common system properties to te
 below:
 </p>
 
-<table border="1">
+<table>
    <tr>
       <td>
          <strong>Property</strong>
@@ -165,7 +173,7 @@ that is used to minimize the chances of duplicate properties being defined by tw
 components. The table below shows some common properties you can test by:
 </p>
 
-<table border="1">
+<table>
    <tr>
       <td>
          <strong>Property</strong>
@@ -320,7 +328,7 @@ above) instead.
 their possible values for use with filter elements and attributes.</p>
 
 <span class="warning">(deprecated)</span>
-<table class="deprecated" border="1">
+<table class="deprecated">
    <tr>
       <td>
          <b>Property</b>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_dynamic_includes.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_dynamic_includes.htm
@@ -1,21 +1,17 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <meta name="copyright" content=
-    "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta http-equiv="Content-Style-Type" content="text/css" />
-    <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type=
-    "text/css" />
-    <script language="JavaScript" src=
-    "PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript">
+    "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+    <meta charset="utf-8">
+    <link rel="STYLESHEET" href="../book.css" type="text/css">
+    <script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js">
 </script>
     <title>
       Includes
     </title>
 
-    <style type="text/css">
+    <style>
 /*<![CDATA[*/
     span.c1 {color: blue}
     /*]]>*/

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Welcome</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_cust_intro_part.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_cust_intro_part.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Using the CustomizableIntroPart</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_cust_static.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_cust_static.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Displaying static HTML content in a CustomizableIntroPart</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_define_content.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_define_content.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Defining intro content</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_defining.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_defining.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Defining an intro part</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_defining_config.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_defining_config.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Defining an intro config</title>
 </head>
 <body>
@@ -47,7 +46,7 @@ intro config should be defined for a given <a href="../reference/api/org/eclipse
 </pre>
 
 The path for the file is relative to the plug-in's directory.  (Note
-the use of the <tt>$nl$</tt> variable in the directory name, which means the file will be located in a directory specific
+the use of the <code>$nl$</code> variable in the directory name, which means the file will be located in a directory specific
 to the national language of the target environment.)
 <p>
 The config extension allows you to specify both the content and the presentation of the content.

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_ext_custom_url.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_ext_custom_url.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Defining a custom IntroURL action</title>
 </head>
 <body>
@@ -17,7 +16,7 @@ Using the <b><a href="../reference/extension-points/org_eclipse_ui_intro_configE
 extension point, plug-ins can contribute their own custom actions that can be used as a <b>url</b> value for a link element in a page.
 For example, consider the following link:
 </p>
-<p><tt>http://org.eclipse.ui.intro/runAction?pluginId=org.eclipse.pde.ui&amp;amp;class=org.eclipse.pde.ui.internal.samples.ShowSampleAction&amp;amp;id=org.eclipse.sdk.samples.swt.examples</tt></p>
+<p><code>http://org.eclipse.ui.intro/runAction?pluginId=org.eclipse.pde.ui&amp;amp;class=org.eclipse.pde.ui.internal.samples.ShowSampleAction&amp;amp;id=org.eclipse.sdk.samples.swt.examples</code></p>
 <p>This IntroURL will run an action class called <b>ShowSampleAction</b>, which is in a package "org.eclipse.pde.ui.internal.samples" in the plug-in
 "org.eclipse.pde.ui".  The id of the sample to run is "org.eclipse.sdk.samples.swt.examples".
 </p>
@@ -33,11 +32,11 @@ For example, consider the following link:
 </pre>
 
 With the above extension you can now use the following URL to run the same action:
-<p><tt>http://org.eclipse.ui.intro/myCommand?id=org.eclipse.sdk.samples.swt.examples</tt></p>
+<p><code>http://org.eclipse.ui.intro/myCommand?id=org.eclipse.sdk.samples.swt.examples</code></p>
 <p>
 The action "myCommand" will be replaced by the value of the <b>replaces</b> attribute and any remaining URL
 parameters will be appended to the end.  Once the substitution is made, the resulting URL will be expanded back into:</p>
-<p><tt>http://org.eclipse.ui.intro/runAction?pluginId=org.eclipse.pde.ui&amp;amp;class=org.eclipse.pde.ui.internal.samples.ShowSampleAction&amp;amp;id=org.eclipse.sdk.samples.swt.examples</tt></p>
+<p><code>http://org.eclipse.ui.intro/runAction?pluginId=org.eclipse.pde.ui&amp;amp;class=org.eclipse.pde.ui.internal.samples.ShowSampleAction&amp;amp;id=org.eclipse.sdk.samples.swt.examples</code></p>
 
 </body>
 </html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_ext_standbypart.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_ext_standbypart.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Contributing a standby content part</title>
 </head>
 <body>
@@ -16,7 +15,7 @@
 Plug-ins can also implement a part for displaying alternative content when the intro page is in standby mode.  For
 example, the platform defines a standby part that will show a cheat sheet for related intro content.  The part is launched using a page
 link with a specialized URL.  Standby parts are launched using a URL containing a special command for showing
-a standby part, such as <tt>http://org.eclipse.ui.intro/showStandby?partId=somePartId</tt>.
+a standby part, such as <code>http://org.eclipse.ui.intro/showStandby?partId=somePartId</code>.
 The part is defined in the <b>standbyContentPart</b> subelement in the 
 <b><a href="../reference/extension-points/org_eclipse_ui_intro_configExtension.html">org.eclipse.ui.intro.configExtension</a></b>
 extension. An <b>id</b>, <b>pluginId</b>, and <b>class</b> must be specified for the part.  The class must implement
@@ -34,7 +33,7 @@ The following snippet shows how the platform defines a standby part for showing 
 </pre>
 
 This cheat sheet could be launched from an intro page using a <b>link</b> subelement whose
-URL is <tt>http://org.eclipse.ui.intro/showStandby?partId=org.eclipse.platform.cheatsheet&amp;input=org.eclipse.pde.helloworld</tt>.
+URL is <code>http://org.eclipse.ui.intro/showStandby?partId=org.eclipse.platform.cheatsheet&amp;input=org.eclipse.pde.helloworld</code>.
 This IntroURL would launch the org.eclipse.platform.cheatsheet standby content part and set its input to
 "org.eclipse.pde.helloworld".  The detailed mechanics for implementing a standby part are beyond the scope
 of this discussion.   See <a href="../reference/api/org/eclipse/ui/intro/config/IStandbyContentPart.html"><b>IStandbyContentPart</b></a>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_ext_theme.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_ext_theme.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2006, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Defining intro themes</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_extending.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_extending.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Extending an intro config</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_extending_content.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_extending_content.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Extending the content of an intro config</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_hello_world.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_hello_world.htm
@@ -1,12 +1,15 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Contributing a HelloWorld intro Part</title>
+<style>
+	p.center { text-align: center; }
+	img { border: 0;  }
+</style>
 </head>
 <body>
 
@@ -57,7 +60,7 @@
 
 <p> The third and last step is to make sure you run the correct product. For example, if you are self hosting, create a new runtime-workbench launch configuration, choose the "Run a product" option, and select <em>org.eclipse.ui.intro.HelloWorld_product </em>from the dropdown. <br>
 This is what you will see if you run the above HelloWorld sample:</p>
-<p align="center">	 <img src="images/basicIntro.png" border="0" alt="Image of a basic intro part"></p>
+<p class="center">	 <img src="images/basicIntro.png" alt="Image of a basic intro part"></p>
 <p>Note that the intro part is in control of the full real-estate of the window. A more elaborate intro part can be created that interacts with the workbench and progressively reveals the functionality of the product. <br>
   <br>
 </p>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_minimal.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_minimal.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2007, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Defining intro content</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_swt_properties.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_swt_properties.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2010, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>SWT Properties for Intro</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_universal.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_universal.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Universal intro</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_universal_contributing.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_universal_contributing.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2016. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Contributing to universal intro</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_universal_defaults.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_universal_defaults.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Configuring product defaults</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_universal_extending.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_universal_extending.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Extending the universal intro</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_universal_links.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_universal_links.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Managing links</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_universal_preference.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_universal_preference.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Adding the preference page</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_xhtml.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_intro_xhtml.htm
@@ -1,10 +1,9 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
 <title>Using XHTML as intro content</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_statushandling.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_statushandling.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Status handling</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_statushandling_defining.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_statushandling_defining.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Defining a product status handler</title>
 </head>
 <body>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_statushandling_sample.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ua_statushandling_sample.htm
@@ -1,11 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2017. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
-<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<script src="PLUGINS_ROOT/org.eclipse.help/livehelp.js"></script>
 <title>Contributing a sample handler</title>
 </head>
 <body>


### PR DESCRIPTION
This updates and modernizes document elements and translates the styling to CSS.

Contributes to
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3275