### PR TITLE
Migrate "Ant" Guides to HTML5

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ant.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ant.htm
@@ -1,12 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"><html lang="en">
+<!DOCTYPE HTML><html lang="en">
 <HEAD>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2005. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
-<META HTTP-EQUIV="Content-Style-Type" CONTENT="text/css">
+<META charset="utf-8">
 
-<LINK REL="STYLESHEET" HREF="../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+<LINK REL="STYLESHEET" HREF="../book.css" TYPE="text/css">
 <TITLE>
 Platform Ant support
 </TITLE>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ant_contributing_task.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ant_contributing_task.htm
@@ -1,12 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"><html lang="en">
+<!DOCTYPE HTML><html lang="en">
 <HEAD>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2005. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
-<META HTTP-EQUIV="Content-Style-Type" CONTENT="text/css">
+<META charset="utf-8">
 
-<LINK REL="STYLESHEET" HREF="../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+<LINK REL="STYLESHEET" HREF="../book.css" TYPE="text/css">
 <TITLE>
 Contributing tasks and types
 </TITLE>
@@ -20,7 +19,7 @@ Contributing Tasks and Types</h2>
 of the classes inside the contributing plug-in. For example, the <b>eclipse.refreshLocal</b> task 
 contributed by <b>org.eclipse.core.resources</b> plug-in is 
 a wrapper for the
-<a href="../reference/api/org/eclipse/core/resources/IResource.html#refreshLocal(int, org.eclipse.core.runtime.IProgressMonitor)">
+<a href="../reference/api/org/eclipse/core/resources/IResource.html#refreshLocal(int,org.eclipse.core.runtime.IProgressMonitor)">
 <b>
 IResource.refreshLocal()</b></a> method.</p>
 
@@ -38,8 +37,7 @@ a new task
 in the <b>plugin.xml</b> file.</p>
 
 
-<A NAME="monitor"></A><h3>
-Progress Monitors</h3>
+<h3 id="monitor">Progress Monitors</h3>
 <P >
 The Eclipse Ant support provides access to an <a href="../reference/api/org/eclipse/core/runtime/IProgressMonitor.html">
 <b>
@@ -86,8 +84,7 @@ The following should work as a checklist for plug-in developers:</p>
 </ul>
 
 
-<A NAME="jar"></A>
-<h3>Why a Separate JAR for Tasks and Types?</h3>
+<h3 id="jar">Why a Separate JAR for Tasks and Types?</h3>
 <p>
 There are basically two requirements for running Ant in Eclipse that do not fit
 the plug-in model very well:</p>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ant_developing.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ant_developing.htm
@@ -1,12 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"><html lang="en">
+<!DOCTYPE HTML><html lang="en">
 <HEAD>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2006. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
-<META HTTP-EQUIV="Content-Style-Type" CONTENT="text/css">
+<META charset="utf-8">
 
-<LINK REL="STYLESHEET" HREF="../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+<LINK REL="STYLESHEET" HREF="../book.css" TYPE="text/css">
 <TITLE>
 Developing tasks and types
 </TITLE>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ant_eclipse_tasks.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ant_eclipse_tasks.htm
@@ -1,12 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"><html lang="en">
+<!DOCTYPE HTML><html lang="en">
 <HEAD>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2005. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
-<META HTTP-EQUIV="Content-Style-Type" CONTENT="text/css">
+<META charset="utf-8">
 
-<LINK REL="STYLESHEET" HREF="../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+<LINK REL="STYLESHEET" HREF="../book.css" TYPE="text/css">
 <TITLE>
 Ant tasks provided by the platform
 </TITLE>
@@ -20,10 +19,9 @@ Ant Tasks Provided by the Platform</h2>
 interact with the workspace. They can be used with buildfiles that are set to build within the same JRE as the workspace.</p>
 
 
-<A NAME="monitor"></A><h3>
-eclipse.refreshLocal</h3>
+<h3 id="monitor">eclipse.refreshLocal</h3>
 <p>
-This task is a wrapper to the <a href="../reference/api/org/eclipse/core/resources/IResource.html#refreshLocal(int, org.eclipse.core.runtime.IProgressMonitor)">
+This task is a wrapper to the <a href="../reference/api/org/eclipse/core/resources/IResource.html#refreshLocal(int,org.eclipse.core.runtime.IProgressMonitor)">
 <b>
 IResource.refreshLocal()</b></a> method. Example:</p>
 <pre>&lt;eclipse.refreshLocal resource=&quot;MyProject/MyFolder&quot; depth=&quot;infinite&quot;/&gt;</pre>
@@ -37,9 +35,9 @@ eclipse.incrementalBuild</h3>
 
 <p>
 When the <b>project</b> attribute is supplied, this task is a wrapper to<b>
-<a href="../reference/api/org/eclipse/core/resources/IProject.html#build(int, org.eclipse.core.runtime.IProgressMonitor)">
+<a href="../reference/api/org/eclipse/core/resources/IProject.html#build(int,org.eclipse.core.runtime.IProgressMonitor)">
 IProject.build()</a></b>.  Otherwise, this task is a wrapper to the method:<b>
-<a href="../reference/api/org/eclipse/core/resources/IWorkspace.html#build(int, org.eclipse.core.runtime.IProgressMonitor)">
+<a href="../reference/api/org/eclipse/core/resources/IWorkspace.html#build(int,org.eclipse.core.runtime.IProgressMonitor)">
 IWorkspace.build()</a></b>.
 </p>
 <p>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ant_expanding_classpath.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ant_expanding_classpath.htm
@@ -1,12 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"><html lang="en">
+<!DOCTYPE HTML><html lang="en">
 <HEAD>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2005. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
-<META HTTP-EQUIV="Content-Style-Type" CONTENT="text/css">
+<META charset="utf-8">
 
-<LINK REL="STYLESHEET" HREF="../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+<LINK REL="STYLESHEET" HREF="../book.css" TYPE="text/css">
 <TITLE>
 Expanding the Ant classpath
 </TITLE>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ant_running_buildfiles_programmatically.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/ant_running_buildfiles_programmatically.htm
@@ -1,12 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"><html lang="en">
+<!DOCTYPE HTML><html lang="en">
 <HEAD>
 
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2005. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
-<META HTTP-EQUIV="Content-Style-Type" CONTENT="text/css">
+<META charset="utf-8">
 
-<LINK REL="STYLESHEET" HREF="../book.css" CHARSET="ISO-8859-1" TYPE="text/css">
+<LINK REL="STYLESHEET" HREF="../book.css" TYPE="text/css">
 <TITLE>
 Running Ant buildfiles programmatically
 </TITLE>


### PR DESCRIPTION
This cleanup up the metadata and fixes broken links.
Contributes to
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3275