### PR TITLE
[RelEng] Skip already existing build update PR in release promotion

### DIFF
--- a/JenkinsJobs/Releng/promoteBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/promoteBuild.jenkinsfile
@@ -272,7 +272,7 @@ pipeline {
 							Update the the `${MAINTENANCE_BRANCH}` branch with final ${BUILD_MAJOR}.${BUILD_MINOR} release version.
 							
 							**This should not be submitted before ${BUILD_MAJOR}.${BUILD_MINOR} is finally released.**
-							""".stripIndent(),"update-build-to-R${BUILD_MAJOR}.${BUILD_MINOR}", 'master')
+							""".stripIndent(),"update-build-to-R${BUILD_MAJOR}.${BUILD_MINOR}", 'master', /*skipExistingPR*/ true)
 						
 						githubAPI.createPullRequest('eclipse-platform/eclipse.platform.releng.aggregator',
 							"Update ${MAINTENANCE_BRANCH} branch with release version for ${BUILD_MAJOR}_${BUILD_MINOR}+ changes", """\
@@ -281,7 +281,7 @@ pipeline {
 							- ${masterPR}
 							
 							**This should not be submitted before ${BUILD_MAJOR}.${BUILD_MINOR} is finally released.**
-							""".stripIndent(),"update-${MAINTENANCE_BRANCH}", "${MAINTENANCE_BRANCH}")
+							""".stripIndent(),"update-${MAINTENANCE_BRANCH}", "${MAINTENANCE_BRANCH}", /*skipExistingPR*/ true)
 					}}
 				}
 			}

--- a/JenkinsJobs/shared/githubAPI.groovy
+++ b/JenkinsJobs/shared/githubAPI.groovy
@@ -37,11 +37,15 @@ def createMilestone(String orga, String repo, String msTitle, String msDescripti
 /**
  * Create a PR in the specified repo, from a branch that is expected to reside in the same repository.
  */
-def createPullRequest(String orgaSlashRepo, String prTitle, String prBody, String headBranch, String baseBranch = 'master') {
+def createPullRequest(String orgaSlashRepo, String prTitle, String prBody, String headBranch, String baseBranch = 'master', boolean skipExistingPR = false) {
 	echo "In ${orgaSlashRepo} create PR: '${prTitle}' on branch ${headBranch}"
 	def params = [title: prTitle, body: prBody, head: headBranch, base: baseBranch]
 	def response = queryGithubAPI('-X POST',"repos/${orgaSlashRepo}/pulls", params)
 	if (response?.errors || (response?.status && response.status != 201)) {
+		if (skipExistingPR && response.errors[0]?.message?.contains('pull request already exists')) {
+			echo "Ignoring failure to create pull request: ${response.errors[0].message}"
+			return null; // PR already exists and the caller asked to ignore this error
+		}
 		error "Response contains errors:\n${response}"
 	}
 	return response?.html_url


### PR DESCRIPTION
This is missing in:
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3291