### PR TITLE
[RelEng] Unify GH-Bot token access in promotion/preparation pipelines

### DIFF
--- a/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
+++ b/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
@@ -362,9 +362,6 @@ pipeline {
 			}
 		}
 		stage('Create preparation Pull-Requests') {
-			environment {
-				GITHUB_BOT_TOKEN = credentials('github-bot-token')
-			}
 			steps {
 				script {
 					def prHeadline = "Prepare ${NEXT_RELEASE_VERSION} development"
@@ -410,9 +407,6 @@ pipeline {
 			}
 		}
 		stage('Create Github milestones') {
-			environment {
-				GITHUB_BOT_TOKEN = credentials('github-bot-token')
-			}
 			steps {
 				script {
 					def organisations = [ 'eclipse-platform', 'eclipse-jdt', 'eclipse-pde', 'eclipse-equinox' ]

--- a/JenkinsJobs/Releng/promoteBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/promoteBuild.jenkinsfile
@@ -265,8 +265,7 @@ pipeline {
 							git push --force ${pushURL} "updateMaintenance:refs/heads/update-${MAINTENANCE_BRANCH}"
 						'''
 					}
-					// Create PRs agains the master and maintenance branch
-					script { withEnv(['GITHUB_BOT_TOKEN=' + credentials('github-bot-token')]) {
+					script { // Create PRs agains the master and maintenance branch
 						def masterPR = githubAPI.createPullRequest('eclipse-platform/eclipse.platform.releng.aggregator',
 							"Update previous release version to ${BUILD_MAJOR}.${BUILD_MINOR} GA across build scripts", """\
 							Update the the `${MAINTENANCE_BRANCH}` branch with final ${BUILD_MAJOR}.${BUILD_MINOR} release version.
@@ -282,7 +281,7 @@ pipeline {
 							
 							**This should not be submitted before ${BUILD_MAJOR}.${BUILD_MINOR} is finally released.**
 							""".stripIndent(),"update-${MAINTENANCE_BRANCH}", "${MAINTENANCE_BRANCH}", /*skipExistingPR*/ true)
-					}}
+					}
 				}
 			}
 		}
@@ -297,9 +296,6 @@ pipeline {
 			}
 		}
 		stage('Update acknowledgements') {
-			environment {
-				GITHUB_BOT_TOKEN = credentials('github-bot-token')
-			}
 			steps {
 				script {
 					githubAPI.triggerWorkflow('eclipse-platform/www.eclipse.org-eclipse', 'generateAcknowledgements.yml', [ 'eclipse-version': "${BUILD_MAJOR}.${BUILD_MINOR}" ])

--- a/JenkinsJobs/shared/githubAPI.groovy
+++ b/JenkinsJobs/shared/githubAPI.groovy
@@ -73,13 +73,12 @@ def queryGithubAPI(String method, String endpoint, Map<String, Object> queryPara
 		query += "-d '" + params + "'"
 	}
 	if (IS_DRY_RUN && !method.isEmpty()) {
-		if (!env.GITHUB_BOT_TOKEN) {
-			error 'Required GITHUB_BOT_TOKEN not set'
-		}
 		echo "Query (not send): ${query}"
 		return null
 	}
-	def response = sh(script: query, returnStdout: true)
+	def response = withCredentials([string(credentialsId: 'github-bot-token', variable: 'GITHUB_BOT_TOKEN')]) {
+		return sh(script: query, returnStdout: true)
+	}
 	if (response == null || response.isEmpty()) {
 		if (allowEmptyReponse) {
 			return null


### PR DESCRIPTION
This also fixes the PR creation in release promotions, because the previous approach to access the GitHub bot token was not working. It was introduced in:
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3284