### PR TITLE
[RelEng] Remove non-production warning in release announcement mail

### DIFF
--- a/JenkinsJobs/Releng/publishPromotedBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/publishPromotedBuild.jenkinsfile
@@ -111,7 +111,7 @@ pipeline {
 						New and Noteworthy:
 						https://www.eclipse.org/eclipse/news/${RELEASE_VERSION_MAJOR}.${RELEASE_VERSION_MINOR}/
 						
-						Update existing (non-production) installs:
+						Update existing ${ RELEASE_TYPE != 'R' ? '(non-production) ' : ''}installations:
 						https://download.eclipse.org/eclipse/updates/${REPOSITORY_PATH.substring(0, REPOSITORY_PATH.lastIndexOf('/'))}/
 						
 						Specific repository good for building against:


### PR DESCRIPTION
For releases this warning doesn't seem suitable for me, does it?
I assume it became a copy-past fact at some point in the past.