### PR TITLE
[Build] Update submodules to remote tip only on non-maintenance branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,14 @@ pipeline {
 		MAVEN_OPTS = '-Xmx4000m'
 	}
 	stages {
+		stage('Update submodules to latest') {
+			when {
+				not { branch 'R*_maintenance' }
+			}
+			steps {
+				sh 'git submodule update --remote'
+			}
+		}
 		stage('Deploy parent-pom and SDK-target') {
 			when {
 				anyOf {


### PR DESCRIPTION
This prevents maintenance branches from fetching the latest changes on the master branches of all submodules and therefore failing all builds early (because the sub-module expect a newer parent-pom version).

The multi-branch pipeline of this repo must then be configured to `not` have `Update tracking submodules to tip of branch` enabled.

<img width="1298" height="512" alt="grafik" src="https://github.com/user-attachments/assets/028cbb02-3d81-4893-b535-9c10b0648f61" />


Follow-up on:
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3000