### PR TITLE
[Build] Use Tycho 5 release on R4_37_maintenance

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -4,6 +4,6 @@
 	<extension>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-build</artifactId>
-		<version>4.0.13</version>
+		<version>5.0.0</version>
 	</extension>
 </extensions>

--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -65,7 +65,7 @@
     <releaseNumberSDK>${releaseVersion}</releaseNumberSDK>
     <releaseNumberPlatform>${releaseVersion}</releaseNumberPlatform>
 
-    <tycho.version>5.0.0-SNAPSHOT</tycho.version>
+    <tycho.version>5.0.0</tycho.version>
 
     <cbi-plugins.version>1.5.2</cbi-plugins.version>
     <surefire.version>3.5.3</surefire.version>


### PR DESCRIPTION
This back-ports
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3266

to un-break the build on the maintenance branch as the snapshot repository is gone in the meantime.