### PR TITLE
[RelEng] Make read of releaseName more robust in publication pipeline

### DIFF
--- a/JenkinsJobs/Releng/publishPromotedBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/publishPromotedBuild.jenkinsfile
@@ -44,11 +44,14 @@ pipeline {
 							cd eclipse.platform.releng.aggregator
 							git sparse-checkout set --no-cone eclipse-platform-parent/pom.xml
 							git checkout
-							
-							mvn -f eclipse-platform-parent help:evaluate -Dexpression=releaseName '-Doutput=${WORKSPACE}/releaseName-value.txt' \
-								--batch-mode --no-transfer-progress --no-snapshot-updates
 					"""
-					assignEnvVariable('TRAIN_NAME', readFile('releaseName-value.txt').trim())
+					def eclipseParentPOM = readFile('eclipse.platform.releng.aggregator/eclipse-platform-parent/pom.xml')
+					def yearMatcher = eclipseParentPOM =~ /<releaseYear>(?<year>\d+)<\/releaseYear>/
+					def monthMatcher = eclipseParentPOM =~ /<releaseMonth>(?<month>\d+)<\/releaseMonth>/
+					if (!yearMatcher.find() || !monthMatcher.find()) {
+						error "Eclipse Parent POM does not contain releaseYear or releaseMonth"
+					}
+					assignEnvVariable('TRAIN_NAME', yearMatcher.group('year') + '-' + monthMatcher.group('month'))
 					if (!env.TRAIN_NAME) {
 						error "TRAIN_NAME is empty."
 					}


### PR DESCRIPTION
Don't launch Maven to output the interpolated `releaseName` property, but instead read the `releaseYear` and `releaseMonth` properties from the raw (`eclipse-platform-parent/pom.xml`) file.
This avoids problems if at the time of the release (candidate) build a snapshot version was used, e.g. of Tycho, that's not available anymore at the time of the publication (because e.g. that Tycho version was released in the meantime).