### PR TITLE
[Build] Remove unused JAVA_DOC_TOOL/eclipse.javadoc build property

### DIFF
--- a/cje-production/buildproperties.txt
+++ b/cje-production/buildproperties.txt
@@ -49,6 +49,3 @@ BUILDTOOLS_REPO="https://download.eclipse.org/eclipse/updates/buildtools/snapsho
 WEBTOOLS_REPO="https://download.eclipse.org/webtools/downloads/drops/R3.37.0/R-3.37.0-20250303081219/repositoryunittests/"
 BASEBUILDER_DIR="tmp/org.eclipse.releng.basebuilder"
 ECLIPSE_RUN_REPO="https://download.eclipse.org/eclipse/updates/4.38-I-builds/"
-
-#Maven parameters
-JAVA_DOC_TOOL="-Declipse.javadoc=/opt/tools/java/openjdk/jdk-17/latest/bin/javadoc"

--- a/cje-production/mbscripts/mb220_buildSdkPatch.sh
+++ b/cje-production/mbscripts/mb220_buildSdkPatch.sh
@@ -47,5 +47,4 @@ mvn clean verify -DskipTests=true ${MVN_ARGS} \
   -DbuildId=$BUILD_ID \
   -Dcbi-ecj-version=99.99 \
   -e \
-  -T 1C \
-  ${JAVA_DOC_TOOL}
+  -T 1C

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/templateFiles/buildproperties.phpHoldForLocalTests
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/templateFiles/buildproperties.phpHoldForLocalTests
@@ -37,7 +37,6 @@ $CBI_JDT_REPO_URL_ARG = "";
 $CBI_JDT_VERSION = "";
 $CBI_JDT_VERSION_ARG = "";
 $ALT_POM_FILE = "";
-$JAVA_DOC_TOOL = "-Declipse.javadoc=/shared/common/jdk1.8.0_x64-latest/bin/javadoc";
 $BUILD_ENV_FILE = "/shared/eclipse/builds/4N/siteDir/eclipse/downloads/drops4/N20140707-2000/buildproperties.shsource";
 $BUILD_ENV_FILE_PHP = "/shared/eclipse/builds/4N/siteDir/eclipse/downloads/drops4/N20140707-2000/buildproperties.php";
 $BUILD_ENV_FILE_PROP = "/shared/eclipse/builds/4N/siteDir/eclipse/downloads/drops4/N20140707-2000/buildproperties.properties";


### PR DESCRIPTION
When searching for `JAVA_DOC_TOOL` or `eclipse.javadoc` I couldn't find any reference to it (except for the modified build-script) in the entire SDK code base. And that it still points to Java-17 while everything else requires Java-21 in the build is also suspicions.

Or is anybody ware of any user of these properties?