### PR TITLE
Migrate "Common Navigator Framework" Guides to HTML5

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/cnf.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/cnf.htm
@@ -1,15 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <HEAD>
 
 <meta name="copyright"
 	content="Copyright (c) Oakland Software and others 2008, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
 
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
-<META HTTP-EQUIV="Content-Style-Type" CONTENT="text/css">
+<META charset="utf-8">
 
-<LINK REL="STYLESHEET" HREF="../book.css" CHARSET="ISO-8859-1"
-	TYPE="text/css">
+<LINK REL="STYLESHEET" HREF="../book.css" TYPE="text/css">
 <TITLE>Common Navigator Framework</TITLE>
 
 <link rel="stylesheet" type="text/css" HREF="../book.css">

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/cnf_config.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/cnf_config.htm
@@ -1,15 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <HEAD>
 
 <meta name="copyright"
 	content="Copyright (c) Oakland Software and others 2008, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
 
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
-<META HTTP-EQUIV="Content-Style-Type" CONTENT="text/css">
+<META charset="utf-8">
 
-<LINK REL="STYLESHEET" HREF="../book.css" CHARSET="ISO-8859-1"
-	TYPE="text/css">
+<LINK REL="STYLESHEET" HREF="../book.css" TYPE="text/css">
 <TITLE>Configuring the Common Navigator</TITLE>
 </HEAD>
 <BODY>
@@ -114,8 +112,7 @@ setting the isRoot() property on the viewerContentBinding.</p>
 	</a> </b></li>
 </ol>
 
-<a name="contentExtension"></a>
-<h2>Navigator Content Extension (NCE)</h2>
+<h2 id="contentExtension">Navigator Content Extension (NCE)</h2>
 
 <p>A navigator content extension, specified with <b><a
 	href="../reference/extension-points/org_eclipse_ui_navigator_navigatorContent.html">org.eclipse.ui.navigator.navigatorContent/navigatorContent</a></b>
@@ -193,8 +190,7 @@ defines wizard that is to be shown in the new, import, or export menu.</p>
 <p>The common wizard is bound to the view using the <b>viewerContentBinding</b>
 element of the viewer configuration.</p>
 
-<h3>Action Providers</h3>
-<a name="actionProviders"></a>
+<h3 id="actionProviders">Action Providers</h3>
 
 <p>An action provider, specified with <b><a
 	href="../reference/extension-points/org_eclipse_ui_navigator_navigatorContent.html">org.eclipse.ui.navigator.navigatorContent/actionProvider</a></b>
@@ -212,8 +208,7 @@ in which case they are active with the content extension. This is done
 by including the action provider inside of the <b>org.eclipse.ui.navigator.navigatorContent/navigatorContent</b>
 extension point.</p>
 
-<h3>Link Helpers</h3>
-<a name="linkHelpers"></a>
+<h3 id="linkHelpers">Link Helpers</h3>
 
 <p>A link helper, specified with <b><a
 	href="../reference/extension-points/org_eclipse_ui_navigator_linkHelper.html">org.eclipse.ui.navigator.linkHelper</a></b>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/cnf_operation.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/cnf_operation.htm
@@ -1,15 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <HTML lang="en">
 <HEAD>
 
 <meta name="copyright"
 	content="Copyright (c) Oakland Software and others 2009, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
 
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
-<META HTTP-EQUIV="Content-Style-Type" CONTENT="text/css">
+<META charset="utf-8">
 
-<LINK REL="STYLESHEET" HREF="../book.css" CHARSET="ISO-8859-1"
-	TYPE="text/css">
+<LINK REL="STYLESHEET" HREF="../book.css" TYPE="text/css">
 <TITLE>Operational Topics</TITLE>
 </HEAD>
 <BODY>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/cnf_rcp.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/cnf_rcp.htm
@@ -1,15 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="en">
 <HEAD>
 
 <meta name="copyright"
 	content="Copyright (c) Oakland Software and others 2008, 2014. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
 
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
-<META HTTP-EQUIV="Content-Style-Type" CONTENT="text/css">
+<META charset="utf-8">
 
-<LINK REL="STYLESHEET" HREF="../book.css" CHARSET="ISO-8859-1"
-	TYPE="text/css">
+<LINK REL="STYLESHEET" HREF="../book.css" TYPE="text/css">
 <TITLE>Common Navigator in an RCP Application</TITLE>
 
 <link rel="stylesheet" type="text/css" HREF="../book.css">

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/cnf_steps.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/cnf_steps.htm
@@ -1,15 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <HTML  lang="en">
 <HEAD>
 
 <meta name="copyright"
 	content="Copyright (c) Oakland Software and others 2009, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
 
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
-<META HTTP-EQUIV="Content-Style-Type" CONTENT="text/css">
+<META charset="utf-8">
 
-<LINK REL="STYLESHEET" HREF="../book.css" CHARSET="ISO-8859-1"
-	TYPE="text/css">
+<LINK REL="STYLESHEET" HREF="../book.css" TYPE="text/css">
 <TITLE>Procedures and Examples Using the CNF</TITLE>
 </HEAD>
 <BODY>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/cnf_steps_content.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/cnf_steps_content.htm
@@ -1,15 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <HTML lang="en">
 <HEAD>
 
 <meta name="copyright"
 	content="Copyright (c) Simon Zambrovski and others 2009, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
 
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
-<META HTTP-EQUIV="Content-Style-Type" CONTENT="text/css">
+<META charset="utf-8">
 
-<LINK REL="STYLESHEET" HREF="../book.css" CHARSET="ISO-8859-1"
-	TYPE="text/css">
+<LINK REL="STYLESHEET" HREF="../book.css" TYPE="text/css">
 <TITLE>Content and Action Binding</TITLE>
 </HEAD>
 <BODY>
@@ -23,7 +21,7 @@ Binding</a> are described. As described <a href="cnf_config.htm">previously</a>,
 in order to render content the viewer selects the corresponding NCEs
 based on the evaluation of the expressions on the selected objects.</p>
 
-<h2><a name="resource">Usage of Resource Content</a></h2>
+<h2 id="resource">Usage of Resource Content</h2>
 <p>One of the use cases of usage of the Common Navigator is the
 manipulation of the workspace resources. The resources-related content
 is defined by the <code>org.eclipse.ui.navigator.resources</code>
@@ -85,7 +83,7 @@ additional steps.</p>
 	}
 </pre></li>
 </ol>
-<h2><a name="definition">Own Content Definition</a></h2>
+<h2 id="definition">Own Content Definition</h2>
 <p>Along with resource content provided by the <code>org.eclipse.ui.navigator.resources</code>
 plugin, application-specific content can be defined and presented in the
 CNF-based viewer. In order to define and use application specific you
@@ -140,7 +138,7 @@ need to:</p>
 	attribute, so <code>org.eclipse.ui.examples.navigator.*</code> would
 	also work.</li>
 </ol>
-<h2><a name="action">Action Binding</a></h2>
+<h2 id="action">Action Binding</h2>
 <p>The usage of actions in the viewer follows the same pattern as the content binding. For usage of existing 
 actions on resources defined in the <code>org.eclipse.ui.navigator.resources</code> plugin:</p>
 <ol>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/cnf_steps_general.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/cnf_steps_general.htm
@@ -1,13 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <HTML lang="en">
 <HEAD>
 <meta name="copyright"
 	content="Copyright (c) Simon Zambrovski and others 2008, 2014. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
-<META HTTP-EQUIV="Content-Style-Type" CONTENT="text/css">
+<META charset="utf-8">
 
-<LINK REL="STYLESHEET" HREF="../book.css" CHARSET="ISO-8859-1"
-	TYPE="text/css">
+<LINK REL="STYLESHEET" HREF="../book.css" TYPE="text/css">
 <TITLE>Creation of Common Navigator View</TITLE>
 <link rel="stylesheet" type="text/css" HREF="../book.css">
 </HEAD>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/cnf_steps_rn_migration.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/cnf_steps_rn_migration.htm
@@ -1,15 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <HTML lang="en">
 <HEAD>
 
 <meta name="copyright"
 	content="Copyright (c) Oakland Software and others 2008, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
 
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
-<META HTTP-EQUIV="Content-Style-Type" CONTENT="text/css">
+<META charset="utf-8">
 
-<LINK REL="STYLESHEET" HREF="../book.css" CHARSET="ISO-8859-1"
-	TYPE="text/css">
+<LINK REL="STYLESHEET" HREF="../book.css" TYPE="text/css">
 <TITLE>Migrating from the ResourceNavigator</TITLE>
 
 <link rel="stylesheet" type="text/css" HREF="../book.css">

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/cnf_troubleshooting.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/cnf_troubleshooting.htm
@@ -1,15 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <HTML lang="en">
 <HEAD>
 
 <meta name="copyright"
 	content="Copyright (c) Oakland Software and others 2009, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
 
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
-<META HTTP-EQUIV="Content-Style-Type" CONTENT="text/css">
+<META charset="utf-8">
 
-<LINK REL="STYLESHEET" HREF="../book.css" CHARSET="ISO-8859-1"
-	TYPE="text/css">
+<LINK REL="STYLESHEET" HREF="../book.css" TYPE="text/css">
 <TITLE>Troubleshooting</TITLE>
 </HEAD>
 <BODY>


### PR DESCRIPTION
This cleans up the metadata and simplifies anchors.

Contributes to
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3275