### PR TITLE
[RelEng] Move previous release's I-build job to maintenance branch

### DIFF
--- a/JenkinsJobs/AutomatedTests/I_unit_tests.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_tests.groovy
@@ -1,5 +1,4 @@
 def config = new groovy.json.JsonSlurper().parseText(readFileFromWorkspace('JenkinsJobs/JobDSL.json'))
-def STREAMS = config.Streams
 
 def TEST_CONFIGURATIONS = [
 	[os: 'linux' , ws:'gtk'  , arch: 'x86_64' , javaVersion: 21, agentLabel: 'ubuntu-2404'        , javaHome: "tool(type:'jdk', name:'temurin-jdk21-latest')" ],
@@ -10,7 +9,7 @@ def TEST_CONFIGURATIONS = [
 	[os: 'win32' , ws:'win32', arch: 'x86_64' , javaVersion: 21, agentLabel: 'qa6xd-win11'        , javaHome: "'C:\\\\Program Files\\\\Eclipse Adoptium\\\\jdk-21.0.5.11-hotspot'" ],
 ]
 
-for (STREAM in STREAMS){
+for (STREAM in config.Branches.keySet()){
 	def MAJOR = STREAM.split('\\.')[0]
 	def MINOR = STREAM.split('\\.')[1]
 	for (TEST_CONFIG in TEST_CONFIGURATIONS){

--- a/JenkinsJobs/Builds/FOLDER.groovy
+++ b/JenkinsJobs/Builds/FOLDER.groovy
@@ -4,8 +4,9 @@ folder('Builds') {
   description('Eclipse periodic build jobs.')
 }
 
-for (STREAM in config.Streams){
-	def BRANCH = config.Branches[STREAM]
+for (entry in config.Branches.entrySet()){
+	def STREAM = entry.key
+	def BRANCH = entry.value
 
 	pipelineJob('Builds/I-build-' + STREAM){
 		description('Daily Eclipse Integration builds.')

--- a/JenkinsJobs/JobDSL.json
+++ b/JenkinsJobs/JobDSL.json
@@ -1,8 +1,5 @@
 {
-    "Streams": [
-        "4.38"
-    ],
-	"Branches": {
-		"4.38": "master"
-	}
+    "Branches": {
+        "4.38": "master"
+    }
 }

--- a/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
+++ b/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
@@ -156,9 +156,12 @@ pipeline {
 				replaceInFile('production/testScripts/configuration/streamSpecific.properties', [
 					"for ${PREVIOUS_RELEASE_VERSION}.0 builds" : "for ${NEXT_RELEASE_VERSION}.0 builds",
 				])
-				replaceInFile('JenkinsJobs/JobDSL.json', [
-					/"${PREVIOUS_RELEASE_VERSION}"/ : /"${NEXT_RELEASE_VERSION}"/,
-				])
+				script {
+					utilities.modifyJSON('JenkinsJobs/JobDSL.json') { jobs ->
+						jobs.Branches["${PREVIOUS_RELEASE_VERSION}"] = env.MAINTENANCE_BRANCH
+						jobs.Branches["${NEXT_RELEASE_VERSION}"] = 'master'
+					}
+				}
 				replaceAllInFile('JenkinsJobs/Builds/FOLDER.groovy', [
 					"(?<prefix># Schedule:.*\\R)(?s).*(?<suffix>\\R'''\\))" : "\${prefix}${I_BUILD_SCHEDULE}\${suffix}",
 				])
@@ -228,9 +231,11 @@ pipeline {
 				// Apply the following changes at a preparation branch, starting at the maintenance branch (to create a PR later)
 				sh 'git checkout -b prepareMaintenance ${MAINTENANCE_BRANCH}'
 				
-				replaceInFile('JenkinsJobs/JobDSL.json', [
-					"\"${PREVIOUS_RELEASE_VERSION}\": \"master\"" : "\"${PREVIOUS_RELEASE_VERSION}\": \"${MAINTENANCE_BRANCH}\"",
-				])
+				script {
+					utilities.modifyJSON('JenkinsJobs/JobDSL.json') { jobs ->
+						jobs.Branches["${PREVIOUS_RELEASE_VERSION}"] = env.MAINTENANCE_BRANCH
+					}
+				}
 				replaceInFile('JenkinsJobs/Builds/build.jenkinsfile', [
 					"typeName: 'Integration' , branchLabel: 'master'" : "typeName: 'Integration' , branchLabel: '${MAINTENANCE_BRANCH}'",
 				])

--- a/JenkinsJobs/Releng/promoteBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/promoteBuild.jenkinsfile
@@ -218,6 +218,9 @@ pipeline {
 							'previousReleaseVersion=.*' : "previousReleaseVersion=${BUILD_MAJOR}.${BUILD_MINOR}",
 							'previousReleaseVersionRepo=.*' : "previousReleaseVersionRepo=${BUILD_MAJOR}.${BUILD_MINOR}",
 						])
+						utilities.modifyJSON('JenkinsJobs/JobDSL.json') { jobs -> // Remove old I-build job for this release
+							jobs.Branches.remove("${BUILD_MAJOR}.${BUILD_MINOR}")
+						}
 						
 						utilities.gitCommitAllExcludingSubmodules("Update previous release version to ${BUILD_MAJOR}.${BUILD_MINOR} GA across build scripts")
 					}

--- a/JenkinsJobs/YBuilds/FOLDER.groovy
+++ b/JenkinsJobs/YBuilds/FOLDER.groovy
@@ -5,8 +5,9 @@ folder('YPBuilds') {
   description('Builds and tests for the beta java builds.')
 }
 
-for (STREAM in config.Streams){
-	def BRANCH = config.Branches[STREAM]
+for (entry in config.Branches.entrySet()){
+	def STREAM = entry.key
+	def BRANCH = entry.value
 
 	pipelineJob('YPBuilds/Y-build-' + STREAM){
 		description('Daily Maintenance Builds.')

--- a/JenkinsJobs/YBuilds/Y_unit_tests.groovy
+++ b/JenkinsJobs/YBuilds/Y_unit_tests.groovy
@@ -1,5 +1,4 @@
 def config = new groovy.json.JsonSlurper().parseText(readFileFromWorkspace('JenkinsJobs/JobDSL.json'))
-def STREAMS = config.Streams
 
 def TEST_CONFIGURATIONS = [
 	[os: 'linux' , ws:'gtk'  , arch: 'x86_64' , javaVersion: 21, agentLabel: 'ubuntu-2404'        , javaHome: "tool(type:'jdk', name:'temurin-jdk21-latest')" ],
@@ -9,7 +8,7 @@ def TEST_CONFIGURATIONS = [
 	[os: 'win32' , ws:'win32', arch: 'x86_64' , javaVersion: 21, agentLabel: 'qa6xd-win11'        , javaHome: "'C:\\\\Program Files\\\\Eclipse Adoptium\\\\jdk-21.0.5.11-hotspot'" ],
 ]
 
-for (STREAM in STREAMS){
+for (STREAM in config.Branches.keySet()){
 	def MAJOR = STREAM.split('\\.')[0]
 	def MINOR = STREAM.split('\\.')[1]
 	for (TEST_CONFIG in TEST_CONFIGURATIONS){

--- a/JenkinsJobs/shared/utilities.groovy
+++ b/JenkinsJobs/shared/utilities.groovy
@@ -1,3 +1,4 @@
+import groovy.json.JsonOutput
 
 @groovy.transform.Field
 def boolean IS_DRY_RUN = true
@@ -20,6 +21,13 @@ def replaceAllInFile(String filePath, Map<String,String> replacements) {
 		content = newContent
 	}
 	writeFile(file:filePath, text: content)
+}
+
+def modifyJSON(String jsonFilePath, Closure transformation) {
+	def json = readJSON(file: jsonFilePath)
+	transformation.call(json)
+	// This leads to prettier results than using the writeJSON() step, even with the pretty parameter set.
+	writeFile(file: jsonFilePath, text: JsonOutput.prettyPrint(JsonOutput.toJson(json)), encoding :'UTF-8')
 }
 
 def runHereAndForEachGitSubmodule(Closure task) {

--- a/eclipse.platform.releng/features/org.eclipse.test-feature/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.test-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.test"
       label="%featureName"
-      version="3.9.300.qualifier"
+      version="3.9.400.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
when preparing a new dev cycle. This used to be done in the past but was forgotten or just stopped to be done and was then done manually. On the master keep the old and new job until the old job is finally removed when the release is promoted.