### PR TITLE
[RelEng] Consider next java release date for Y-build schedule

### DIFF
--- a/JenkinsJobs/Releng/FOLDER.groovy
+++ b/JenkinsJobs/Releng/FOLDER.groovy
@@ -88,6 +88,7 @@ Useful for debugging and to very that the pipeline behaves as intended.
 		stringParam('RC1_DATE', null, 'Release-Candidate 1 end date in the format yyyy-mm-dd, for example: 2025-08-22')
 		stringParam('RC2_DATE', null, 'Release-Candidate 2 end date in the format yyyy-mm-dd, for example: 2025-08-29')
 		stringParam('GA_DATE', null, 'Final general availability release date in the format yyyy-mm-dd, for example: 2025-09-10')
+		stringParam('NEXT_JAVA_RELEASE_DATE', null, 'Release date of the next nww Java version, if it is released shortly after the Eclipse release (i.e. shortly after the <em>GA_DATE</em> specified above, usually for odd release versions), else left blank (usually for even releases). Value is in the format yyyy-mm-dd, for example: 2025-09-16')
 	}
 	definition {
 		cpsScm {

--- a/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
+++ b/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
@@ -72,13 +72,26 @@ pipeline {
 					// Compute new build schedule
 					def now = java.time.LocalDate.now()
 					def rcEnd = rc2Date.minusDays(2) // Wednesday before RC2 is the last planned I-build and the cron-triggers should stop after
-					def lastCompleteMonth = rcEnd.monthValue - 1
-					// Consider end-of-year overflows
-					def completeMonths = (now.monthValue < lastCompleteMonth) ? "${now.monthValue}-${lastCompleteMonth}" : "${now.monthValue}-12,1-${lastCompleteMonth}"
-					assignEnvVariable('I_BUILD_SCHEDULE', """\
-						0 18 * ${completeMonths} *
-						0 18 1-${rcEnd.dayOfMonth} ${rcEnd.monthValue} *
-					""".stripIndent().trim())
+					assignEnvVariable('I_BUILD_SCHEDULE', createCronPattern(now, rcEnd, 18, '*').trim())
+					
+					env.NEXT_JAVA_RELEASE_DATE = readParameter('NEXT_JAVA_RELEASE_DATE')
+					def yBuildSchedule = null
+					if ("${NEXT_JAVA_RELEASE_DATE}".isEmpty()) {
+						yBuildSchedule = createCronPattern(now, rcEnd, 10, '2,4,6')
+					} else {
+						// Java releases soon after the Eclipse release, therefore schedule Y-builds daily within the 'Java RC phase'
+						def javaReleaseDate = parseDate("${NEXT_JAVA_RELEASE_DATE}")
+						def javaRCStart = javaReleaseDate.minusDays(7)
+						def javaRCEnd = javaReleaseDate.plusDays(2)
+						if (javaRCStart.monthValue != javaRCEnd.monthValue) {
+							// If this is encountered, enhance the logic to handle 'java RC' phases ranging more than one month
+							error "Java release is not in the middle of a month"
+						}
+						yBuildSchedule = createCronPattern(now, javaRCStart, 10, '2,4,6') + """\
+						0 10 ${javaRCStart.dayOfMonth}-${javaRCEnd.dayOfMonth} ${javaRCStart.monthValue} *
+						""".stripIndent()
+					}
+					assignEnvVariable('Y_BUILD_SCHEDULE', yBuildSchedule.trim())
 				}
 			}
 		}
@@ -164,6 +177,9 @@ pipeline {
 				}
 				replaceAllInFile('JenkinsJobs/Builds/FOLDER.groovy', [
 					"(?<prefix># Schedule:.*\\R)(?s).*(?<suffix>\\R'''\\))" : "\${prefix}${I_BUILD_SCHEDULE}\${suffix}",
+				])
+				replaceAllInFile('JenkinsJobs/YBuilds/FOLDER.groovy', [
+					"(?<prefix># Schedule:.*\\R)(?s).*(?<suffix>\\R'''\\))" : "\${prefix}${Y_BUILD_SCHEDULE}\${suffix}",
 				])
 				
 				gitCommitAllExcludingSubmodules("Update versions to ${NEXT_RELEASE_VERSION} in build scripts")
@@ -460,6 +476,16 @@ def assignEnvVariable(String name, String value) {
 @NonCPS
 def parseDate(String dateString) {
 	return java.time.LocalDate.parse(dateString.trim()) // expects format 'yyyy-MM-dd'
+}
+
+private String createCronPattern(java.time.LocalDate start, java.time.LocalDate end, int hour, String daysOfWeek = '*') {
+	def lastCompleteMonth = end.monthValue - 1
+	// Consider end-of-year overflows
+	def completeMonths = (start.monthValue < lastCompleteMonth) ? "${start.monthValue}-${lastCompleteMonth}" : "${start.monthValue}-12,1-${lastCompleteMonth}"
+	return """\
+		0 ${hour} * ${completeMonths} ${daysOfWeek}
+		0 ${hour} 1-${end.dayOfMonth} ${end.monthValue} ${daysOfWeek}
+	""".stripIndent()
 }
 
 def replaceInFile(String filePath, Map<String,String> replacements) {

--- a/JenkinsJobs/Releng/promoteBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/promoteBuild.jenkinsfile
@@ -239,7 +239,10 @@ pipeline {
 						utilities.replaceAllInFile('cje-production/buildproperties.txt', [
 							'ECLIPSE_RUN_REPO="https://download.eclipse.org/eclipse/updates/.*"' : "ECLIPSE_RUN_REPO=\"${RELEASE_P2_REPOSITORY}\"",
 						])
-						
+						// Disable Y-build schedule only after the previous releases job is not updated (on the master) anymore, because Y-build jobs run beyond the Eclipse release if a new java release is imminent
+						utilities.replaceAllInFile('JenkinsJobs/YBuilds/FOLDER.groovy', [
+							"spec\\('''(?s).+?'''\\)" : "spec('')",
+						])
 						utilities.gitCommitAllExcludingSubmodules("Update ${MAINTENANCE_BRANCH} branch with release version for ${BUILD_MAJOR}_${BUILD_MINOR}+ changes")
 					}
 					// Switch back to master for subsequent parts of this pipeline

--- a/JenkinsJobs/YBuilds/FOLDER.groovy
+++ b/JenkinsJobs/YBuilds/FOLDER.groovy
@@ -18,8 +18,9 @@ for (entry in config.Branches.entrySet()){
 						spec('''TZ=America/Toronto
 # Format: Minute Hour Day Month Day-of-week (1-7)
 # - - - Beta Java Eclipse SDK builds - - - 
-# Schedule: 10 AM every second day
-0 10 * * 2,4,6
+# Schedule: 10 AM every second day (and every day in Java RC phase)
+0 10 * 8-10 2,4,6
+0 10 1-26 11 2,4,6
 ''')
 					}
 				}


### PR DESCRIPTION
Explicitly specify a limited cron based schedule for Y-builds too that is either aligned with the Eclipse release or a Java-release. If no Java release happens soon after the Eclipse release the schedule ends two days before RC2 (similar to I-builds).
If a Java release happens soon after the Eclipse release (and a JDT patch is provided after the Eclipse release), the Y-build schedule is extended until the java release date and the schedule and the Y-build cadence is increased in the 'RC-phase'.