### PR TITLE
[Build] Remove java-24 test configuration after Java-25 release

### DIFF
--- a/JenkinsJobs/AutomatedTests/I_unit_tests.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_tests.groovy
@@ -2,7 +2,6 @@ def config = new groovy.json.JsonSlurper().parseText(readFileFromWorkspace('Jenk
 
 def TEST_CONFIGURATIONS = [
 	[os: 'linux' , ws:'gtk'  , arch: 'x86_64' , javaVersion: 21, agentLabel: 'ubuntu-2404'        , javaHome: "tool(type:'jdk', name:'temurin-jdk21-latest')" ],
-	[os: 'linux' , ws:'gtk'  , arch: 'x86_64' , javaVersion: 24, agentLabel: 'ubuntu-2404'        , javaHome: "tool(type:'jdk', name:'temurin-jdk24-latest')" ],
 	[os: 'linux' , ws:'gtk'  , arch: 'x86_64' , javaVersion: 25, agentLabel: 'ubuntu-2404'        , javaHome: "tool(type:'jdk', name:'openjdk-jdk25-latest')" ],
 	[os: 'macosx', ws:'cocoa', arch: 'aarch64', javaVersion: 21, agentLabel: 'nc1ht-macos11-arm64', javaHome: "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11-arm64/Contents/Home'" ],
 	[os: 'macosx', ws:'cocoa', arch: 'x86_64' , javaVersion: 21, agentLabel: 'nc1ht-macos11-arm64', javaHome: "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11/Contents/Home'" ],

--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -1,7 +1,6 @@
 
 def I_TEST_CONFIGURATIONS = [
   [ os: 'linux' , ws: 'gtk'  , arch: 'x86_64' , javaVersion: 21],
-  [ os: 'linux' , ws: 'gtk'  , arch: 'x86_64' , javaVersion: 24],
   [ os: 'linux' , ws: 'gtk'  , arch: 'x86_64' , javaVersion: 25],
   [ os: 'macosx', ws: 'cocoa', arch: 'aarch64', javaVersion: 21],
   [ os: 'macosx', ws: 'cocoa', arch: 'x86_64' , javaVersion: 21],


### PR DESCRIPTION
Java-24 is not the latest version anymore and tests for Java-25 are already set up.