### PR TITLE
[Y-build] Refine test configs for Java-26 BETA and restore schedule

### DIFF
--- a/JenkinsJobs/buildConfigurations.json
+++ b/JenkinsJobs/buildConfigurations.json
@@ -74,8 +74,7 @@
 		"streams": {
 			"4.38": {
 				"branch": "master",
-				"disabled": "false",
-				"schedule": "0 10 * * 2,4,6"
+				"schedule": "0 10 * 8-10 2,4,6\n0 10 1-26 11 2,4,6"
 			}
 		},
 		"branches": {
@@ -112,33 +111,22 @@
 				"os": "macosx",
 				"ws": "cocoa",
 				"arch": "aarch64",
-				"javaVersion": 21,
+				"javaVersion": 26,
 				"agent": "nc1ht-macos11-arm64",
 				"jdk": {
-					"type": "local",
-					"path": "/Library/Java/JavaVirtualMachines/jdk-21.0.5+11-arm64/Contents/Home"
-				}
-			},
-			{
-				"os": "macosx",
-				"ws": "cocoa",
-				"arch": "x86_64",
-				"javaVersion": 21,
-				"agent": "nc1ht-macos11-arm64",
-				"jdk": {
-					"type": "local",
-					"path": "/Library/Java/JavaVirtualMachines/jdk-21.0.5+11/Contents/Home"
+					"type": "install",
+					"url": "https://download.java.net/java/early_access/jdk26/23/GPL/openjdk-26-ea+23_macos-aarch64_bin.tar.gz"
 				}
 			},
 			{
 				"os": "win32",
 				"ws": "win32",
 				"arch": "x86_64",
-				"javaVersion": 21,
+				"javaVersion": 26,
 				"agent": "qa6xd-win11",
 				"jdk": {
-					"type": "local",
-					"path": "C:\\Program Files\\Eclipse Adoptium\\jdk-21.0.5.11-hotspot"
+					"type": "install",
+					"url": "https://download.java.net/java/early_access/jdk26/23/GPL/openjdk-26-ea+23_windows-x64_bin.zip"
 				}
 			}
 		]


### PR DESCRIPTION
Move tests to targeted Java version Java-26.

Also drop the second MacOS test configuration and add Y-build tests for Windows instead.

Additionally fix the computation of the temurin download URL and fix installing tools on Windows.

@stephan-herrmann as you requested it in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3315#issuecomment-3276694151.

This helps to reduce the load on the only working Mac node as discussed in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3315

This is currently a draft as it requires the removal of an old ANT installation from the build/test node first, which isn't working well with Java-25:
- https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6653
