### PR TITLE
Update Bouncycastle and commons-fileupload version

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -112,7 +112,7 @@
 			  <dependency>
 				  <groupId>commons-fileupload</groupId>
 				  <artifactId>commons-fileupload</artifactId>
-				  <version>1.5</version>
+				  <version>1.6</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
@@ -154,19 +154,19 @@
 			  <dependency>
 				  <groupId>org.bouncycastle</groupId>
 				  <artifactId>bcpg-jdk18on</artifactId>
-				  <version>1.78.1</version>
+				  <version>1.82</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
 				  <groupId>org.bouncycastle</groupId>
 				  <artifactId>bcprov-jdk18on</artifactId>
-				  <version>1.78.1</version>
+				  <version>1.82</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
 +				  <groupId>org.bouncycastle</groupId>
 +				  <artifactId>bcutil-jdk18on</artifactId>
-+				  <version>1.78.1</version>
++				  <version>1.82</version>
  				  <type>jar</type>
  			  </dependency>
 			  <dependency>


### PR DESCRIPTION
Update Bouncycastle 1.82 and commons-fileupload 1.6 version for CVE-2025-48976 and CVE-2025-8916