### PR TITLE
add riscv64 native fragment for Terminal feature.

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -70,16 +70,17 @@
       If one wants to use the terminal console feature in a product (e.g. EPP) one needs to include the bundle org.eclipse.debug.terminal.
      -->
     <location includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-       <repository location="https://download.eclipse.org/tools/cdt/releases/12.1/cdt-12.1.0"/>
-       <unit id="org.eclipse.cdt.core.native" version="6.4.0.202505200054"/>
+       <repository location="https://download.eclipse.org/tools/cdt/releases/12.2/cdt-12.2.0"/>
+       <unit id="org.eclipse.cdt.core.native" version="6.5.0.202506201841"/>
        <unit id="org.eclipse.cdt.core.linux" version="6.1.100.202402230238"/>
-       <unit id="org.eclipse.cdt.core.linux.x86_64" version="12.1.0.202506041907"/>
-       <unit id="org.eclipse.cdt.core.linux.ppc64le" version="12.1.0.202506041907"/>
-       <unit id="org.eclipse.cdt.core.linux.aarch64" version="12.1.0.202506041907"/>
-       <unit id="org.eclipse.cdt.core.macosx" version="12.1.0.202506041907"/>
+       <unit id="org.eclipse.cdt.core.linux.x86_64" version="12.2.0.202509030008"/>
+       <unit id="org.eclipse.cdt.core.linux.ppc64le" version="12.2.0.202509030008"/>
+       <unit id="org.eclipse.cdt.core.linux.aarch64" version="12.2.0.202509030008"/>
+       <unit id="org.eclipse.cdt.core.linux.riscv64" version="12.2.0.202509030008"/>
+       <unit id="org.eclipse.cdt.core.macosx" version="12.2.0.202509030008"/>
        <unit id="org.eclipse.cdt.core.win32" version="6.1.200.202505191828"/>
-       <unit id="org.eclipse.cdt.core.win32.x86_64" version="12.1.0.202506041907"/>
-       <unit id="org.eclipse.cdt.core.win32.aarch64" version="12.1.0.202506041907"/>
+       <unit id="org.eclipse.cdt.core.win32.x86_64" version="12.2.0.202509030008"/>
+       <unit id="org.eclipse.cdt.core.win32.aarch64" version="12.2.0.202509030008"/>
     </location>
 
     <!-- uncomment 'eclipse_home' location, with text editor, for use in Eclipse IDE


### PR DESCRIPTION
The references to CDT p2 site are updated to 12.2.0 release, to include the Terminal feature's native fragment for Linux riscv64.

A separate PR for the platform module is eclipse-platform/eclipse.platform#2170

Fixes #3352 