### PR TITLE
Correct common-fileupload dependency version to 1.6.0

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -112,7 +112,7 @@
 			  <dependency>
 				  <groupId>commons-fileupload</groupId>
 				  <artifactId>commons-fileupload</artifactId>
-				  <version>1.6</version>
+				  <version>1.6.0</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>


### PR DESCRIPTION
Previously updated it to 1.6 by mistake; this change fixes the version to the proper 1.6.0 release.