### PR TITLE
Make Java 25 available in github actions

### DIFF
--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -64,11 +64,13 @@ jobs:
           8
           11
           17
+          25
           21
         mvn-toolchain-id: |
           JavaSE-1.8
           JavaSE-11
           JavaSE-17
+          JavaSE-25
           JavaSE-21
         distribution: 'temurin'
         cache: maven


### PR DESCRIPTION
Since it is the next LTS release and JDK 25 reached General Availability on 16 September 2025 we should make is available so bundles can use it to test compatibility and new features.