### PR TITLE
Exclude junit-platform-launcher from analyzed bundles

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
@@ -19,6 +19,7 @@ junit-jupiter-api
 junit-jupiter-params
 junit-platform-commons
 junit-platform-engine
+junit-platform-launcher
 org.commonmark
 
 ## SPECIAL CASE FOR SWT: THE FRAGMENT IS ANALYZED AS PART OF THE HOST


### PR DESCRIPTION
Deprecations in it are outside of project control so shouldn't be reported. (https://download.eclipse.org/eclipse/downloads/drops4/I20251002-1800/apitools/deprecation/apideprecation.html )