### PR TITLE
Run htmlvalidator on *.htm files too

### DIFF
--- a/.github/workflows/htmlvalidator.yml
+++ b/.github/workflows/htmlvalidator.yml
@@ -15,3 +15,4 @@ jobs:
       with:
         root: /github/workspace/eclipse.platform.common/bundles
         blacklist: about.html notices.html
+        extra: --match *.html  --match *.htm


### PR DESCRIPTION
Taken from
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3342