### PR TITLE
[RelEng] Fix access to empty DRY_RUN_PREFIX in promotion pipeline

### DIFF
--- a/JenkinsJobs/Releng/promoteBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/promoteBuild.jenkinsfile
@@ -319,7 +319,7 @@ pipeline {
 
 def renameBuildDrop(String baseDropPath, String oldDropID, String oldBuildLabel, String newDropID, String newBuildLabel, Closure extraTasks=null) {
 	def sourcePath="${EP_ROOT}/${baseDropPath}/${oldDropID}"
-	def targetPath="${EP_ROOT}/${DRY_RUN_PREFIX}${baseDropPath}/${newDropID}"
+	def targetPath="${EP_ROOT}/${env.DRY_RUN_PREFIX ?: ''}${baseDropPath}/${newDropID}"
 	
 	sh """#!/bin/bash -xe
 		


### PR DESCRIPTION
If an environment variable is defined with an empty value (as it's the case for 'DRY_RUN_PREFIX' if a build is not a dry-run) it's effectively discarded, not passed to scripts and is not available as environment variable binding respectively in the special 'env' map/variable.

Implement corresponding special handling for that case of a non-dry-run.

Refers to
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3305#discussion_r2403771309

CC @MohananRahul 