### PR TITLE
[Build] Further refine test result collection to consider reruns

### DIFF
--- a/JenkinsJobs/Releng/collectTestResults.jenkinsfile
+++ b/JenkinsJobs/Releng/collectTestResults.jenkinsfile
@@ -50,14 +50,6 @@ pipeline {
 						testResultsDir="${buildDirectory}/testresults"
 						mkdir -p "${testResultsDir}"
 						
-						# Fetch previously collected test results and already generated files (that would otherwise be re-generated)
-						allTestResultsXMLDirectory="${EP_ECLIPSE_DROPS}/${buildID}/testresults/xml"
-						if ssh genie.releng@projects-storage.eclipse.org "[ -d '${allTestResultsXMLDirectory}' ]"; then
-							rsync -avzh --exclude="*_${triggeringJob}_*" genie.releng@projects-storage.eclipse.org:${allTestResultsXMLDirectory} ${buildDirectory}/testresults
-						else
-							echo 'Test results of other configurations not yet published.'
-						fi
-						
 						# ==========================================
 						# Collect results and overview from test-job
 						pushd "${testResultsDir}"
@@ -65,10 +57,20 @@ pipeline {
 						curl -L -o "${triggeringJob}.xml" "${buildURL}/testReport/api/xml?tree=failCount,passCount,skipCount,duration"
 						curl -L -o results.zip "${buildURL}/artifact/workarea/${buildID}/eclipse-testing/results/*zip*/results.zip"
 						unzip results.zip
-						# copy them to the expected location (from the subfolder of the zip) (mv can't merge directories) and remove all download artifacts. 
-						cp -r results/* .
+						# copy them to the expected location (from the subfolder of the zip) and remove all download artifacts.
+						mv results/* .
 						rm -rf results results.zip
 						popd
+						
+						# Fetch previously collected test results and already generated files (that would otherwise be re-generated)
+						allTestResultsDirectory="${EP_ECLIPSE_DROPS}/${buildID}/testresults"
+						if ssh genie.releng@projects-storage.eclipse.org "[ -d '${allTestResultsDirectory}' ]"; then
+							# First delete result files from a previous run of the same configuration (in case that test configuration was run again).
+							ssh genie.releng@projects-storage.eclipse.org rm -rfv ${allTestResultsDirectory}/${triggeringJob}* ${allTestResultsDirectory}/*/*${triggeringJob}*
+							rsync -avzh genie.releng@projects-storage.eclipse.org:${allTestResultsDirectory}/xml ${buildDirectory}/testresults
+						else
+							echo 'Test results of other configurations not yet published.'
+						fi
 						
 						#triggering ant runner
 						devworkspace=${WORKSPACE}/workspace-updateTestResults


### PR DESCRIPTION
Delete the test results of previous runs of the same test configurations for the same build, i.e. if a test was run again.