### PR TITLE
[Build] Fix collection of the first test results

### DIFF
--- a/JenkinsJobs/Releng/collectTestResults.jenkinsfile
+++ b/JenkinsJobs/Releng/collectTestResults.jenkinsfile
@@ -64,7 +64,7 @@ pipeline {
 						
 						# Fetch previously collected test results and already generated files (that would otherwise be re-generated)
 						allTestResultsDirectory="${EP_ECLIPSE_DROPS}/${buildID}/testresults"
-						if ssh genie.releng@projects-storage.eclipse.org "[ -d '${allTestResultsDirectory}' ]"; then
+						if ssh genie.releng@projects-storage.eclipse.org "[ -d '${allTestResultsDirectory}/xml' ]"; then
 							# First delete result files from a previous run of the same configuration (in case that test configuration was run again).
 							ssh genie.releng@projects-storage.eclipse.org rm -rfv ${allTestResultsDirectory}/${triggeringJob}* ${allTestResultsDirectory}/*/*${triggeringJob}*
 							rsync -avzh genie.releng@projects-storage.eclipse.org:${allTestResultsDirectory}/xml ${buildDirectory}/testresults


### PR DESCRIPTION
The `testresults` folder of a build drop already exists, even if no test results are published yet.

Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3386