### PR TITLE
Add com.github.weisj.jsvg version 2.0.0 to target platform

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -97,6 +97,12 @@
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
+				  <groupId>com.github.weisj</groupId>
+				  <artifactId>jsvg</artifactId>
+				  <version>2.0.0</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
 				  <groupId>com.google.code.gson</groupId>
 				  <artifactId>gson</artifactId>
 				  <version>2.13.2</version>


### PR DESCRIPTION
This change adds JSVG version 2.0.0 to the target platform while temporarily keeping the existing version 1.7.2.

This is necessary as there are breaking changes between the two versions. This affects our SWT adoption, as we use a class (`FloatSize`) that was moved between packages.

Once SWT has been migrated to use the new version, the 1.7.2 version will be removed from the target platform.
