### PR TITLE
Remove com.github.weisj.jsvg version 1.7.2 from target platform

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -93,12 +93,6 @@
 			  <dependency>
 				  <groupId>com.github.weisj</groupId>
 				  <artifactId>jsvg</artifactId>
-				  <version>1.7.2</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>com.github.weisj</groupId>
-				  <artifactId>jsvg</artifactId>
 				  <version>2.0.0</version>
 				  <type>jar</type>
 			  </dependency>


### PR DESCRIPTION
⚠️ To be merged after https://github.com/eclipse-platform/eclipse.platform.swt/pull/2597 as SWT still depends on JSVG 1.x until that PR is processed.