### PR TITLE
[Build] Remove P-build reference from Y-Builds Jenkins folder

### DIFF
--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -22,7 +22,7 @@ def BUILD = {
 				mailingList: 'platform-releng-dev@eclipse.org', testJobFolder:'AutomatedTests', testConfigurations: I_TEST_CONFIGURATIONS]
 			case 'Y': return [*:buildConfig,
 				typeName: 'Beta Java 25', branchLabel: 'java25',
-				mailingList: 'jdt-dev@eclipse.org'            , testJobFolder:'YPBuilds'      , testConfigurations: Y_TEST_CONFIGURATIONS]
+				mailingList: 'jdt-dev@eclipse.org'            , testJobFolder:'YBuilds'      , testConfigurations: Y_TEST_CONFIGURATIONS]
 		}
 	}
 	error("Unsupported job: $JOB_BASE_NAME" )

--- a/JenkinsJobs/YBuilds/Y_unit_tests.groovy
+++ b/JenkinsJobs/YBuilds/Y_unit_tests.groovy
@@ -13,7 +13,7 @@ for (STREAM in config.Y.streams.keySet()){
 	def MINOR = STREAM.split('\\.')[1]
 	for (TEST_CONFIG in TEST_CONFIGURATIONS){
 
-		pipelineJob('YPBuilds/ep' + MAJOR + MINOR + 'Y-unit-' + TEST_CONFIG.os + '-' + TEST_CONFIG.arch + '-java' + TEST_CONFIG.javaVersion){
+		pipelineJob('YBuilds/ep' + MAJOR + MINOR + 'Y-unit-' + TEST_CONFIG.os + '-' + TEST_CONFIG.arch + '-java' + TEST_CONFIG.javaVersion){
 			description('Run Eclipse SDK Tests for the platform implied by this job\'s name')
 			parameters { // Define parameters in job configuration to make them available from the very first build onwards
 				stringParam('buildId', null, 'Build Id to test (such as I20240611-1800, N20120716-0800).')

--- a/JenkinsJobs/seedJob.jenkinsfile
+++ b/JenkinsJobs/seedJob.jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
 						def folderDefinitions = [
 							'AutomatedTests': [ displayName: 'Automated Tests', description: 'Folder for Unit Tests'],
 							'Builds': [description: 'Eclipse periodic build jobs.'],
-							'YPBuilds': [displayName: 'Y and P Builds', description: 'Builds and tests for the beta java builds.'],
+							'YBuilds': [displayName: 'Y Builds', description: 'Builds and tests for the beta java builds.'],
 							'Cleanup': [description: 'Cleanup Scripts.'],
 							'Releng': [description: 'Jobs related to routine releng tasks. Some are periodic, some are "manual" jobs ran only when needed.'],
 						]
@@ -48,7 +48,7 @@ pipeline {
 								'''.stripIndent() + config.schedule).trim() : null]
 						}
 						jobConfigurations.Y.streams.each{ STREAM, config ->
-							pipelineJobDefinitions["YPBuilds/Y-build-${STREAM}"] = [scriptPath: buildJob.scriptPath, branch: config.branch,
+							pipelineJobDefinitions["YBuilds/Y-build-${STREAM}"] = [scriptPath: buildJob.scriptPath, branch: config.branch,
 								description: 'Beta Java Eclipse builds.', disabled: config.disabled, cronTrigger: config.schedule ? ('''\
 								TZ=America/Toronto
 								# Format: Minute Hour Day Month Day-of-week (1-7)

--- a/RELENG.md
+++ b/RELENG.md
@@ -44,7 +44,7 @@ The **Y-build** is a full sdk build with the new java version for testing.
 The **P-build** is a patch build that contains modified plugins designed to be installed on top of the current I-build to test the new java version.
 They are now managed by the JDT-project itself in (org.eclipse.jdt.releng)[https://github.com/eclipse-jdt/eclipse.jdt/tree/master/org.eclipse.jdt.releng].
 
-The builds themselves and their unit tests are in the (Y Builds)[JenkinsJobs/YBuilds] folder in git and the (Y and P Builds)[https://ci.eclipse.org/releng/job/YPBuilds/] folder in jenkins.
+The builds themselves and their unit tests are in the (Y Builds)[JenkinsJobs/YBuilds] folder in git and the (Y Builds)[https://ci.eclipse.org/releng/job/YBuilds/] folder in jenkins.
 
 ## Setting Up New Builds
 


### PR DESCRIPTION
since P-builds are now managed in the JDT JIPP.

If applied the build-tools have to be adjusted too:
- https://github.com/eclipse-platform/eclipse.platform.releng.buildtools/blob/c5f7ecf1951d44311e24ce7bd6b505189aabb4da/bundles/org.eclipse.build.tools/src/org/eclipse/releng/generators/TestResultsGenerator.java#L812

@stephan-herrmann, @jarthana and @mpalat is this fine for you?
I don't know if you reference these jobs directly in Jenkins. If yes, you would have to adjust some URLs