### PR TITLE
Exclude asm commons from deprecations report

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
@@ -6,6 +6,7 @@
 org.apache.ant
 org.apache.commons.codec
 org.objectweb.asm
+org.objectweb.asm.commons
 org.apache.commons.commons-io
 biz.aQute.bndlib
 org.apache.lucene.core


### PR DESCRIPTION
Third party dependencies are beyond project's control so deprecations in them shouldn't be reported.
https://download.eclipse.org/eclipse/downloads/drops4/I20251006-1800/apitools/deprecation/apideprecation.html