### PR TITLE
[Build] Stop unused deployments of releng scripts to storage server

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
 						return !sh(script:'''
 							latestCommitID=$(curl https://download.eclipse.org/eclipse/relengScripts/state)
 							git diff --name-only ${latestCommitID} HEAD \\
-								production/ cje-production/ eclipse.platform.releng.tychoeclipsebuilder/
+								production/testScripts/bootstrap
 							''', returnStdout: true).trim().isEmpty()
 					}
 				}
@@ -52,10 +52,6 @@ pipeline {
 						
 						ssh genie.platform@projects-storage.eclipse.org mkdir -p ${serverStaging}/testScripts
 						scp -r production/testScripts/bootstrap genie.platform@projects-storage.eclipse.org:${serverStaging}/testScripts
-						
-						scp -r cje-production genie.platform@projects-storage.eclipse.org:${serverStaging}
-						
-						scp -r eclipse.platform.releng.tychoeclipsebuilder/entitlement genie.platform@projects-storage.eclipse.org:${serverStaging}
 						
 						# Create state file that contains the current commitID for later diffs in this stage's conditional
 						commitID=$(git rev-parse HEAD)


### PR DESCRIPTION
Except for the `getEBuilder.xml` ANT scripts nothing from https://download.eclipse.org/eclipse/relengScripts is used anymore. Therefore the deployment can be stopped.

In fact the entitlements are in use at the moment by
https://github.com/eclipse-equinox/equinox/blob/88ad15678b2607670c883ec3ef5309d9ef7f6ccb/Jenkinsfile#L248

but we can use a github-raw link as well there, which should be sufficient in that case.

In the foreseeable future probably even the `getEBuilder.xml` script becomes obsolete and the entire deployment of releng-scripts to the storage server can be stopped.