### PR TITLE
[I/Y-Build] Unify build configurations into buildConfigurations.json

### DIFF
--- a/JenkinsJobs/AutomatedTests/I_unit_tests.groovy
+++ b/JenkinsJobs/AutomatedTests/I_unit_tests.groovy
@@ -1,17 +1,9 @@
 def config = new groovy.json.JsonSlurper().parseText(readFileFromWorkspace('buildConfigurations.json'))
 
-def TEST_CONFIGURATIONS = [
-	[os: 'linux' , ws:'gtk'  , arch: 'x86_64' , javaVersion: 21, agentLabel: 'ubuntu-2404'        , javaHome: "tool(type:'jdk', name:'temurin-jdk21-latest')" ],
-	[os: 'linux' , ws:'gtk'  , arch: 'x86_64' , javaVersion: 25, agentLabel: 'ubuntu-2404'        , javaHome: "tool(type:'jdk', name:'openjdk-jdk25-latest')" ],
-	[os: 'macosx', ws:'cocoa', arch: 'aarch64', javaVersion: 21, agentLabel: 'nc1ht-macos11-arm64', javaHome: "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11-arm64/Contents/Home'" ],
-	[os: 'macosx', ws:'cocoa', arch: 'x86_64' , javaVersion: 21, agentLabel: 'nc1ht-macos11-arm64', javaHome: "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11/Contents/Home'" ],
-	[os: 'win32' , ws:'win32', arch: 'x86_64' , javaVersion: 21, agentLabel: 'qa6xd-win11'        , javaHome: "'C:\\\\Program Files\\\\Eclipse Adoptium\\\\jdk-21.0.5.11-hotspot'" ],
-]
-
 for (STREAM in config.I.streams.keySet()){
 	def MAJOR = STREAM.split('\\.')[0]
 	def MINOR = STREAM.split('\\.')[1]
-	for (TEST_CONFIG in TEST_CONFIGURATIONS){
+	for (TEST_CONFIG in config.I.tests){
 
 		pipelineJob('AutomatedTests/ep' + MAJOR + MINOR + 'I-unit-' + TEST_CONFIG.os + '-' + TEST_CONFIG.arch + '-java' + TEST_CONFIG.javaVersion){
 			description('Run Eclipse SDK Tests for the platform implied by this job\'s name')

--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -1,36 +1,5 @@
-
-def I_TEST_CONFIGURATIONS = [
-  [ os: 'linux' , ws: 'gtk'  , arch: 'x86_64' , javaVersion: 21],
-  [ os: 'linux' , ws: 'gtk'  , arch: 'x86_64' , javaVersion: 25],
-  [ os: 'macosx', ws: 'cocoa', arch: 'aarch64', javaVersion: 21],
-  [ os: 'macosx', ws: 'cocoa', arch: 'x86_64' , javaVersion: 21],
-  [ os: 'win32' , ws: 'win32', arch: 'x86_64' , javaVersion: 21],
-]
-def Y_TEST_CONFIGURATIONS = [
-  [ os: 'linux' , ws: 'gtk'  , arch: 'x86_64' , javaVersion: 21],
-  [ os: 'linux' , ws: 'gtk'  , arch: 'x86_64' , javaVersion: 25],
-  [ os: 'macosx', ws: 'cocoa', arch: 'aarch64', javaVersion: 21],
-  [ os: 'macosx', ws: 'cocoa', arch: 'x86_64' , javaVersion: 21],
-]
-def BUILD = {
-	def matcher = "$JOB_BASE_NAME" =~ '(?<type>[IY])-build-(?<major>\\d).(?<minor>\\d+)'
-	if (matcher) {
-		def buildConfig = [ type: matcher.group('type'), testPrefix: "ep${matcher.group('major')}${matcher.group('minor')}${matcher.group('type')}-unit"]
-		switch(buildConfig.type) {
-			case 'I': return [*:buildConfig,
-				typeName: 'Integration' , branchLabel: 'master',
-				mailingList: 'platform-releng-dev@eclipse.org', testJobFolder:'AutomatedTests', testConfigurations: I_TEST_CONFIGURATIONS]
-			case 'Y': return [*:buildConfig,
-				typeName: 'Beta Java 25', branchLabel: 'java25',
-				mailingList: 'jdt-dev@eclipse.org'            , testJobFolder:'YBuilds'      , testConfigurations: Y_TEST_CONFIGURATIONS]
-		}
-	}
-	error("Unsupported job: $JOB_BASE_NAME" )
-}()
-
-def testConfigurationsExpected = BUILD.testConfigurations.collect{c ->
-		"${BUILD.testPrefix}-${c.os}-${c.arch}-java${c.javaVersion}_${c.os}.${c.ws}.${c.arch}_${c.javaVersion}"
-	}.join(',')
+@groovy.transform.Field
+def BUILD = null
 
 pipeline {
 	options {
@@ -63,43 +32,42 @@ spec:
 		ant 'apache-ant-latest'
 	}
 	environment {
-		BUILD_TYPE = "${BUILD.type}"
-		BUILD_TYPE_NAME = "${BUILD.typeName}"
-		PATCH_OR_BRANCH_LABEL = "${BUILD.branchLabel}"
-
 		MAVEN_OPTS = '-Xmx4G'
 		CJE_ROOT = "${WORKSPACE}/cje-production"
 		logDir = "$CJE_ROOT/buildlogs"
-		TEST_CONFIGURATIONS_EXPECTED = "${testConfigurationsExpected}"
 	}
 	stages {
-		stage('Setup intial configuration'){
+		stage('Set up environment') {
 			steps {
+				script { // Extend build configuration with data from the configuration file
+					def matcher = "$JOB_BASE_NAME" =~ '(?<type>[IY])-build-(?<major>\\d).(?<minor>\\d+)'
+					if (!matcher) {
+						error("Unsupported job: $JOB_BASE_NAME")
+					}
+					assignEnvVariable('BUILD_TYPE', matcher.group('type'))
+					def configurations = readJSON(file: "${WORKSPACE}/JenkinsJobs/buildConfigurations.json")
+					BUILD = configurations["${BUILD_TYPE}"]
+					assignEnvVariable('BUILD_TYPE_NAME', BUILD.typeName)
+					assignEnvVariable('PATCH_OR_BRANCH_LABEL', BUILD.branchLabel)
+					assignEnvVariable('TEST_NAME_PREFIX', "ep${matcher.group('major')}${matcher.group('minor')}${BUILD_TYPE}-unit")
+					assignEnvVariable('TEST_CONFIGURATIONS_EXPECTED', BUILD.tests.collect{ c ->
+						"${TEST_NAME_PREFIX}-${c.os}-${c.arch}-java${c.javaVersion}_${c.os}.${c.ws}.${c.arch}_${c.javaVersion}"
+					}.join(','))
+				}
 				dir("${CJE_ROOT}") {
-                    sh '''
-                        chmod +x mbscripts/*
-                        mkdir -p $logDir
-                    '''
+					sh '''
+						set -eo pipefail
+						chmod +x mbscripts/*
+						mkdir -p $logDir
+						
+						./mbscripts/mb010_createEnvfiles.sh ${CJE_ROOT}/buildproperties.shsource 2>&1 | tee $logDir/mb010_createEnvfiles.sh.log
+					'''
 				}
-			}
-		}
-	  stage('Generate environment variables'){
-          steps {
-				dir("${CJE_ROOT}/mbscripts") {
-                sh '''
-                    set -eo pipefail
-                    ./mb010_createEnvfiles.sh $CJE_ROOT/buildproperties.shsource 2>&1 | tee $logDir/mb010_createEnvfiles.sh.log
-                '''
-				}
-			}
-		}
-		stage('Export environment variables stage 1'){
-			steps {
 				script {
 					def buildProps = readBuildProperties("${CJE_ROOT}/buildproperties.properties")
-					env.BUILD_IID = buildProps.BUILD_TYPE + buildProps.TIMESTAMP
-					env.STREAM = buildProps.STREAM
-					env.RELEASE_VER = buildProps.RELEASE_VER
+					assignEnvVariable('BUILD_IID', buildProps.BUILD_TYPE + buildProps.TIMESTAMP)
+					assignEnvVariable('STREAM', buildProps.STREAM)
+					assignEnvVariable('RELEASE_VER', buildProps.RELEASE_VER)
 				}
 			}
 		}
@@ -294,11 +262,11 @@ spec:
 				}
 			}
 		}
-		stage('Trigger tests'){
+		stage('Trigger tests') {
 			steps {
 				script {
-					for (c in BUILD.testConfigurations) {
-						build job: "${BUILD.testJobFolder}/${BUILD.testPrefix}-${c.os}-${c.arch}-java${c.javaVersion}", wait: false, parameters: [
+					for (c in BUILD.tests) {
+						build job: "${BUILD.testJobFolder}/${TEST_NAME_PREFIX}-${c.os}-${c.arch}-java${c.javaVersion}", wait: false, parameters: [
 							string(name: 'buildId', value: "${BUILD_IID}")
 						]
 					}
@@ -357,6 +325,12 @@ spec:
 			to: "${BUILD.mailingList}", from:'genie.releng@eclipse.org'
 		}
 	}
+}
+
+@NonCPS
+def assignEnvVariable(String name, String value) {
+	env[name] = value
+	println("${name}=${value}")
 }
 
 def readBuildProperties(String buildPropertiesFile){

--- a/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
+++ b/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
@@ -284,11 +284,9 @@ pipeline {
 							build.branch = env.MAINTENANCE_BRANCH
 							build.schedule = ''
 						}
+						builds.I.branchLabel = env.MAINTENANCE_BRANCH
 					}
 				}
-				replaceInFile('JenkinsJobs/Builds/build.jenkinsfile', [
-					"typeName: 'Integration' , branchLabel: 'master'" : "typeName: 'Integration' , branchLabel: '${MAINTENANCE_BRANCH}'",
-				])
 				replaceInFile('JenkinsJobs/Builds/dockerImages.jenkinsfile', [
 					'-b master' : "-b ${MAINTENANCE_BRANCH}",
 				])

--- a/JenkinsJobs/YBuilds/Y_unit_tests.groovy
+++ b/JenkinsJobs/YBuilds/Y_unit_tests.groovy
@@ -1,17 +1,9 @@
 def config = new groovy.json.JsonSlurper().parseText(readFileFromWorkspace('buildConfigurations.json'))
 
-def TEST_CONFIGURATIONS = [
-	[os: 'linux' , ws:'gtk'  , arch: 'x86_64' , javaVersion: 21, agentLabel: 'ubuntu-2404'        , javaHome: "tool(type:'jdk', name:'temurin-jdk21-latest')" ],
-	[os: 'linux' , ws:'gtk'  , arch: 'x86_64' , javaVersion: 25, agentLabel: 'ubuntu-2404'        , javaHome: "install('jdk', 'https://download.java.net/java/GA/jdk25/bd75d5f9689641da8e1daabeccb5528b/36/GPL/openjdk-25_linux-x64_bin.tar.gz')" ],
-	[os: 'macosx', ws:'cocoa', arch: 'aarch64', javaVersion: 21, agentLabel: 'nc1ht-macos11-arm64', javaHome: "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11-arm64/Contents/Home'" ],
-	[os: 'macosx', ws:'cocoa', arch: 'x86_64' , javaVersion: 21, agentLabel: 'nc1ht-macos11-arm64', javaHome: "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11/Contents/Home'" ],
-	[os: 'win32' , ws:'win32', arch: 'x86_64' , javaVersion: 21, agentLabel: 'qa6xd-win11'        , javaHome: "'C:\\\\Program Files\\\\Eclipse Adoptium\\\\jdk-21.0.5.11-hotspot'" ],
-]
-
 for (STREAM in config.Y.streams.keySet()){
 	def MAJOR = STREAM.split('\\.')[0]
 	def MINOR = STREAM.split('\\.')[1]
-	for (TEST_CONFIG in TEST_CONFIGURATIONS){
+	for (TEST_CONFIG in config.Y.tests){
 
 		pipelineJob('YBuilds/ep' + MAJOR + MINOR + 'Y-unit-' + TEST_CONFIG.os + '-' + TEST_CONFIG.arch + '-java' + TEST_CONFIG.javaVersion){
 			description('Run Eclipse SDK Tests for the platform implied by this job\'s name')

--- a/JenkinsJobs/buildConfigurations.json
+++ b/JenkinsJobs/buildConfigurations.json
@@ -1,19 +1,111 @@
 {
     "I": {
+        "typeName": "Integration",
+        "branchLabel": "master",
         "streams": {
             "4.38": {
                 "branch": "master",
                 "schedule": "0 18 * 8-10 *\n0 18 1-26 11 *"
             }
-        }
+        },
+        "mailingList": "platform-releng-dev@eclipse.org",
+        "testJobFolder": "AutomatedTests",
+        "tests": [
+            {
+                "os": "linux",
+                "ws": "gtk",
+                "arch": "x86_64",
+                "javaVersion": 21,
+                "agentLabel": "ubuntu-2404",
+                "javaHome": "tool(type:'jdk', name:'temurin-jdk21-latest')"
+            },
+            {
+                "os": "linux",
+                "ws": "gtk",
+                "arch": "x86_64",
+                "javaVersion": 25,
+                "agentLabel": "ubuntu-2404",
+                "javaHome": "tool(type:'jdk', name:'openjdk-jdk25-latest')"
+            },
+            {
+                "os": "macosx",
+                "ws": "cocoa",
+                "arch": "aarch64",
+                "javaVersion": 21,
+                "agentLabel": "nc1ht-macos11-arm64",
+                "javaHome": "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11-arm64/Contents/Home'"
+            },
+            {
+                "os": "macosx",
+                "ws": "cocoa",
+                "arch": "x86_64",
+                "javaVersion": 21,
+                "agentLabel": "nc1ht-macos11-arm64",
+                "javaHome": "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11/Contents/Home'"
+            },
+            {
+                "os": "win32",
+                "ws": "win32",
+                "arch": "x86_64",
+                "javaVersion": 21,
+                "agentLabel": "qa6xd-win11",
+                "javaHome": "'C:\\\\Program Files\\\\Eclipse Adoptium\\\\jdk-21.0.5.11-hotspot'"
+            }
+        ]
     },
     "Y": {
+        "typeName": "Beta Java 25",
+        "branchLabel": "java25",
         "streams": {
             "4.38": {
                 "branch": "master",
                 "disabled": "true",
                 "schedule": "0 10 * 8-10 2,4,6\n0 10 1-26 11 2,4,6"
             }
-        }
+        },
+        "mailingList": "jdt-dev@eclipse.org",
+        "testJobFolder": "YBuilds",
+        "tests": [
+            {
+                "os": "linux",
+                "ws": "gtk",
+                "arch": "x86_64",
+                "javaVersion": 21,
+                "agentLabel": "ubuntu-2404",
+                "javaHome": "tool(type:'jdk', name:'temurin-jdk21-latest')"
+            },
+            {
+                "os": "linux",
+                "ws": "gtk",
+                "arch": "x86_64",
+                "javaVersion": 25,
+                "agentLabel": "ubuntu-2404",
+                "javaHome": "install('jdk', 'https://download.java.net/java/GA/jdk25/bd75d5f9689641da8e1daabeccb5528b/36/GPL/openjdk-25_linux-x64_bin.tar.gz')"
+            },
+            {
+                "os": "macosx",
+                "ws": "cocoa",
+                "arch": "aarch64",
+                "javaVersion": 21,
+                "agentLabel": "nc1ht-macos11-arm64",
+                "javaHome": "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11-arm64/Contents/Home'"
+            },
+            {
+                "os": "macosx",
+                "ws": "cocoa",
+                "arch": "x86_64",
+                "javaVersion": 21,
+                "agentLabel": "nc1ht-macos11-arm64",
+                "javaHome": "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11/Contents/Home'"
+            },
+            {
+                "os": "win32",
+                "ws": "win32",
+                "arch": "x86_64",
+                "javaVersion": 21,
+                "agentLabel": "qa6xd-win11",
+                "javaHome": "'C:\\\\Program Files\\\\Eclipse Adoptium\\\\jdk-21.0.5.11-hotspot'"
+            }
+        ]
     }
 }

--- a/RELENG.md
+++ b/RELENG.md
@@ -53,9 +53,9 @@ The builds themselves and their unit tests are in the (Y Builds)[JenkinsJobs/YBu
 When the JDT team is ready they will raise an issue to create new Y builds and supply the name of the new branch, usually `BETA_JAVA##`.
 
 **Things to Do:**
-  * Update the Y-build configuration in the (build.jenkinsfile)[JenkinsJobs/Builds/build.jenkinsfile]
-    - Update `branchLabel` and `typeName` to the name of the new java version
-  * Remove the disablement of the current stream in the Y-build configuration in the (buildConfigurations.json)[JenkinsJobs/buildConfigurations.json] (should be the only Y-build stream).
+  * Update the Y-build configuration in the (buildConfigurations.json)[JenkinsJobs/buildConfigurations.json]
+    - Update `branchLabel` and `typeName` to the name of the new java version.
+    - Remove the disablement of the current stream in the Y-build configuration (should be the only Y-build stream).
+    - Add unit tests for the new java version and remove old ones.
   * Update and rename the java repository files in (cje-production/streams)[cje-production/streams]
     - Repos without a `BETA_JAVA##` branch should be set to master
-  * Add unit tests for the new java version in (JenkinsJobs/YBuilds)[JenkinsJobs/YBuilds] and (build.jenkinsfile)[JenkinsJobs/Builds/build.jenkinsfile]

--- a/cje-production/mbscripts/mb010_createEnvfiles.sh
+++ b/cje-production/mbscripts/mb010_createEnvfiles.sh
@@ -64,7 +64,7 @@ do
     fi
     fn-addToPropFiles $key "$value"
   fi
-done < ../buildproperties.txt
+done < ${CJE_ROOT}/buildproperties.txt
 
 source $BUILD_ENV_FILE
 # add BUILD_ENV_FILE* variables to prop files before using fn-write-property in common-functions.shsource


### PR DESCRIPTION
The buildConfigurations.json becomes the central and only source for configurations of all I/Y-builds and their associated tests. It's read by the seed-job to create the corresponding Jenkins jobs and during I/Y-builds executions.

This avoids a definition of test configurations split over multiple files and avoids continuous changes in the build pipeline file due to regular version, Java or infrastructure updates.