### PR TITLE
[I/Y-Build] Indent buildConfiguration.json with tabs instead of spaces

### DIFF
--- a/JenkinsJobs/buildConfigurations.json
+++ b/JenkinsJobs/buildConfigurations.json
@@ -1,111 +1,111 @@
 {
-    "I": {
-        "typeName": "Integration",
-        "branchLabel": "master",
-        "streams": {
-            "4.38": {
-                "branch": "master",
-                "schedule": "0 18 * 8-10 *\n0 18 1-26 11 *"
-            }
-        },
-        "mailingList": "platform-releng-dev@eclipse.org",
-        "testJobFolder": "AutomatedTests",
-        "tests": [
-            {
-                "os": "linux",
-                "ws": "gtk",
-                "arch": "x86_64",
-                "javaVersion": 21,
-                "agentLabel": "ubuntu-2404",
-                "javaHome": "tool(type:'jdk', name:'temurin-jdk21-latest')"
-            },
-            {
-                "os": "linux",
-                "ws": "gtk",
-                "arch": "x86_64",
-                "javaVersion": 25,
-                "agentLabel": "ubuntu-2404",
-                "javaHome": "tool(type:'jdk', name:'openjdk-jdk25-latest')"
-            },
-            {
-                "os": "macosx",
-                "ws": "cocoa",
-                "arch": "aarch64",
-                "javaVersion": 21,
-                "agentLabel": "nc1ht-macos11-arm64",
-                "javaHome": "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11-arm64/Contents/Home'"
-            },
-            {
-                "os": "macosx",
-                "ws": "cocoa",
-                "arch": "x86_64",
-                "javaVersion": 21,
-                "agentLabel": "nc1ht-macos11-arm64",
-                "javaHome": "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11/Contents/Home'"
-            },
-            {
-                "os": "win32",
-                "ws": "win32",
-                "arch": "x86_64",
-                "javaVersion": 21,
-                "agentLabel": "qa6xd-win11",
-                "javaHome": "'C:\\\\Program Files\\\\Eclipse Adoptium\\\\jdk-21.0.5.11-hotspot'"
-            }
-        ]
-    },
-    "Y": {
-        "typeName": "Beta Java 25",
-        "branchLabel": "java25",
-        "streams": {
-            "4.38": {
-                "branch": "master",
-                "disabled": "true",
-                "schedule": "0 10 * 8-10 2,4,6\n0 10 1-26 11 2,4,6"
-            }
-        },
-        "mailingList": "jdt-dev@eclipse.org",
-        "testJobFolder": "YBuilds",
-        "tests": [
-            {
-                "os": "linux",
-                "ws": "gtk",
-                "arch": "x86_64",
-                "javaVersion": 21,
-                "agentLabel": "ubuntu-2404",
-                "javaHome": "tool(type:'jdk', name:'temurin-jdk21-latest')"
-            },
-            {
-                "os": "linux",
-                "ws": "gtk",
-                "arch": "x86_64",
-                "javaVersion": 25,
-                "agentLabel": "ubuntu-2404",
-                "javaHome": "install('jdk', 'https://download.java.net/java/GA/jdk25/bd75d5f9689641da8e1daabeccb5528b/36/GPL/openjdk-25_linux-x64_bin.tar.gz')"
-            },
-            {
-                "os": "macosx",
-                "ws": "cocoa",
-                "arch": "aarch64",
-                "javaVersion": 21,
-                "agentLabel": "nc1ht-macos11-arm64",
-                "javaHome": "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11-arm64/Contents/Home'"
-            },
-            {
-                "os": "macosx",
-                "ws": "cocoa",
-                "arch": "x86_64",
-                "javaVersion": 21,
-                "agentLabel": "nc1ht-macos11-arm64",
-                "javaHome": "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11/Contents/Home'"
-            },
-            {
-                "os": "win32",
-                "ws": "win32",
-                "arch": "x86_64",
-                "javaVersion": 21,
-                "agentLabel": "qa6xd-win11",
-                "javaHome": "'C:\\\\Program Files\\\\Eclipse Adoptium\\\\jdk-21.0.5.11-hotspot'"
-            }
-        ]
-    }
+	"I": {
+		"typeName": "Integration",
+		"branchLabel": "master",
+		"streams": {
+			"4.38": {
+				"branch": "master",
+				"schedule": "0 18 * 8-10 *\n0 18 1-26 11 *"
+			}
+		},
+		"mailingList": "platform-releng-dev@eclipse.org",
+		"testJobFolder": "AutomatedTests",
+		"tests": [
+			{
+				"os": "linux",
+				"ws": "gtk",
+				"arch": "x86_64",
+				"javaVersion": 21,
+				"agentLabel": "ubuntu-2404",
+				"javaHome": "tool(type:'jdk', name:'temurin-jdk21-latest')"
+			},
+			{
+				"os": "linux",
+				"ws": "gtk",
+				"arch": "x86_64",
+				"javaVersion": 25,
+				"agentLabel": "ubuntu-2404",
+				"javaHome": "tool(type:'jdk', name:'openjdk-jdk25-latest')"
+			},
+			{
+				"os": "macosx",
+				"ws": "cocoa",
+				"arch": "aarch64",
+				"javaVersion": 21,
+				"agentLabel": "nc1ht-macos11-arm64",
+				"javaHome": "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11-arm64/Contents/Home'"
+			},
+			{
+				"os": "macosx",
+				"ws": "cocoa",
+				"arch": "x86_64",
+				"javaVersion": 21,
+				"agentLabel": "nc1ht-macos11-arm64",
+				"javaHome": "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11/Contents/Home'"
+			},
+			{
+				"os": "win32",
+				"ws": "win32",
+				"arch": "x86_64",
+				"javaVersion": 21,
+				"agentLabel": "qa6xd-win11",
+				"javaHome": "'C:\\\\Program Files\\\\Eclipse Adoptium\\\\jdk-21.0.5.11-hotspot'"
+			}
+		]
+	},
+	"Y": {
+		"typeName": "Beta Java 25",
+		"branchLabel": "java25",
+		"streams": {
+			"4.38": {
+				"branch": "master",
+				"disabled": "true",
+				"schedule": "0 10 * 8-10 2,4,6\n0 10 1-26 11 2,4,6"
+			}
+		},
+		"mailingList": "jdt-dev@eclipse.org",
+		"testJobFolder": "YBuilds",
+		"tests": [
+			{
+				"os": "linux",
+				"ws": "gtk",
+				"arch": "x86_64",
+				"javaVersion": 21,
+				"agentLabel": "ubuntu-2404",
+				"javaHome": "tool(type:'jdk', name:'temurin-jdk21-latest')"
+			},
+			{
+				"os": "linux",
+				"ws": "gtk",
+				"arch": "x86_64",
+				"javaVersion": 25,
+				"agentLabel": "ubuntu-2404",
+				"javaHome": "install('jdk', 'https://download.java.net/java/GA/jdk25/bd75d5f9689641da8e1daabeccb5528b/36/GPL/openjdk-25_linux-x64_bin.tar.gz')"
+			},
+			{
+				"os": "macosx",
+				"ws": "cocoa",
+				"arch": "aarch64",
+				"javaVersion": 21,
+				"agentLabel": "nc1ht-macos11-arm64",
+				"javaHome": "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11-arm64/Contents/Home'"
+			},
+			{
+				"os": "macosx",
+				"ws": "cocoa",
+				"arch": "x86_64",
+				"javaVersion": 21,
+				"agentLabel": "nc1ht-macos11-arm64",
+				"javaHome": "'/Library/Java/JavaVirtualMachines/jdk-21.0.5+11/Contents/Home'"
+			},
+			{
+				"os": "win32",
+				"ws": "win32",
+				"arch": "x86_64",
+				"javaVersion": 21,
+				"agentLabel": "qa6xd-win11",
+				"javaHome": "'C:\\\\Program Files\\\\Eclipse Adoptium\\\\jdk-21.0.5.11-hotspot'"
+			}
+		]
+	}
 }

--- a/JenkinsJobs/shared/utilities.groovy
+++ b/JenkinsJobs/shared/utilities.groovy
@@ -23,7 +23,7 @@ def modifyJSON(String jsonFilePath, Closure transformation) {
 	def json = readJSON(file: jsonFilePath)
 	transformation.call(json)
 	// This leads to prettier results than using the writeJSON() step, even with the pretty parameter set.
-	writeFile(file: jsonFilePath, text: JsonOutput.prettyPrint(JsonOutput.toJson(json)), encoding :'UTF-8')
+	writeFile(file: jsonFilePath, text: JsonOutput.prettyPrint(JsonOutput.toJson(json)).replace('    ','\t'), encoding :'UTF-8')
 }
 
 def runHereAndForEachGitSubmodule(Closure task) {


### PR DESCRIPTION
- Aligns to default formatting settings of the Generic Editor (so tabs with probably sneak in on the long run anyways)
- Matches recent indentation style of source files

Minor advantages
- Simpler indentation and configurable configuration
- Smaller file size