### PR TITLE
[I-Build] Test with Temurin Java-25

### DIFF
--- a/JenkinsJobs/buildConfigurations.json
+++ b/JenkinsJobs/buildConfigurations.json
@@ -24,7 +24,7 @@
 				"arch": "x86_64",
 				"javaVersion": 25,
 				"agentLabel": "ubuntu-2404",
-				"javaHome": "tool(type:'jdk', name:'openjdk-jdk25-latest')"
+				"javaHome": "tool(type:'jdk', name:'temurin-jdk25-latest')"
 			},
 			{
 				"os": "macosx",


### PR DESCRIPTION
Temurin has released its Java-25 binaries in the meantime and they are available in the RelEng JIPP.