### PR TITLE
[I/Y-Build] Derive git branch and URL from job definition when cloning

### DIFF
--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -73,8 +73,12 @@ spec:
 			}
 		}
 		stage('Clone and tag Build Inputs') {
+			environment {
+				AGGREGATOR_LOCAL_BRANCH = "${scm.branches[0].name}"
+				AGGREGATOR_REPOSITORY_URL = "${scm.userRemoteConfigs[0].url}" // http(s) URL expected
+			}
 			steps {
-				sshagent (['github-bot-ssh']) {
+				dir("${CJE_ROOT}/${AGG_DIR}") {
 					sh '''#!/bin/bash -xe
 						source $CJE_ROOT/buildproperties.shsource
 						
@@ -82,10 +86,8 @@ spec:
 						git config --global user.name 'Eclipse Releng Bot'
 						
 						# Clone this repo and all submodules into the 'AGG_DIR' directory
-						git clone --branch=$BRANCH --recurse-submodules --remote-submodules \
-							git@github.com:eclipse-platform/eclipse.platform.releng.aggregator.git "$CJE_ROOT/$AGG_DIR"
-						
-						cd "$CJE_ROOT/$AGG_DIR"
+						git clone --branch=${AGGREGATOR_LOCAL_BRANCH} --recurse-submodules --remote-submodules \
+							${AGGREGATOR_REPOSITORY_URL} .
 						
 						if [ -n "${GIT_SUBMODULE_BRANCHES}" ]; then
 							for submodule in ${GIT_SUBMODULE_BRANCHES//,/ }; do
@@ -99,16 +101,10 @@ spec:
 						fi
 						
 						# Create 'Build input' commit (considering commits potentially submitted to the aggregator BRANCH in the meantime)
-						git checkout $BRANCH
+						git checkout ${AGGREGATOR_LOCAL_BRANCH}
 						git pull
 						git commit --all --message="Build input for build $BUILD_ID" || echo 'No submodule changes'
-						
-						if [ "${BUILD_TYPE}" == "I" ]; then
-							git push --verbose origin $BRANCH
-						fi
 					'''
-				}
-				dir("${CJE_ROOT}/${AGG_DIR}") {
 					sshagent (['projects-storage.eclipse.org-bot-ssh']) {
 						// Try to find the last tag of the current build type that is available as a promoted build
 						// by checking the most recent 5 tags and seeing if an update site for it exists
@@ -138,14 +134,21 @@ spec:
 							error('Abort scheduled build due to no changes')
 						}
 					}
-					// Git tagging
+					// Create git tags and push changes
 					sshagent (['github-bot-ssh']) {
 						sh '''#!/bin/bash -xe
 							source $CJE_ROOT/buildproperties.shsource
+							
+							function remoteURL {
+								git config remote.origin.url | sed --expression 's,https://github.com/,git@github.com:,'
+							}
+							export -f remoteURL
+							if [ "${BUILD_TYPE}" == "I" ]; then
+								git push --verbose $(remoteURL) ${AGGREGATOR_LOCAL_BRANCH}
+							fi
 							function tagAndPush {
 								git tag ${BUILD_ID} HEAD
-								pushURL=$(git config remote.origin.url | sed --expression 's,https://github.com/,git@github.com:,')
-								git push "${pushURL}" tag ${BUILD_ID}
+								git push --verbose $(remoteURL) tag ${BUILD_ID}
 							}
 							export -f tagAndPush
 							git submodule foreach 'tagAndPush'

--- a/JenkinsJobs/Builds/dockerImages.jenkinsfile
+++ b/JenkinsJobs/Builds/dockerImages.jenkinsfile
@@ -17,11 +17,15 @@ pipeline {
 	}
 	stages {
 		stage('Get Docker Files') {
+			environment {
+				GIT_BRANCH = "${scm.branches[0].name}"
+				GIT_REPOSITORY = "${scm.userRemoteConfigs[0].url}"
+			}
 			steps {
 				cleanWs()
 				sh '''
-					git clone --depth=1 -b master https://github.com/eclipse-platform/eclipse.platform.releng.aggregator.git
-					git clone --depth=1 -b master https://github.com/eclipse-jdt/eclipse.jdt.core
+					git clone --depth=1 --branch ${GIT_BRANCH} ${GIT_REPOSITORY} eclipse.platform.releng.aggregator
+					git clone --depth=1 --branch ${GIT_BRANCH} https://github.com/eclipse-jdt/eclipse.jdt.core eclipse.jdt.core
 				'''
 			}
 		}

--- a/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
+++ b/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
@@ -286,12 +286,6 @@ pipeline {
 						}
 					}
 				}
-				replaceInFile('JenkinsJobs/Builds/dockerImages.jenkinsfile', [
-					'-b master' : "-b ${MAINTENANCE_BRANCH}",
-				])
-				replaceInFile('cje-production/buildproperties.txt', [
-					'BRANCH="master"' : "BRANCH=\"${MAINTENANCE_BRANCH}\"",
-				])
 				replaceAllInFile('.gitmodules', [
 					'branch\\s*=\\s*master' : "branch = ${MAINTENANCE_BRANCH}",
 				])

--- a/cje-production/buildproperties.txt
+++ b/cje-production/buildproperties.txt
@@ -17,7 +17,6 @@
 # with # are considered comments and no spaces allowed in keys
 
 # CJE build variables
-BRANCH="master"
 RELEASE_VER="4.38"
 STREAM="4.38.0"
 STREAMMajor="4"


### PR DESCRIPTION
This reduces hard-coded branch names in the pipeline file. It also avoids the need to update them, e.g. on maintenance branches respectively simplifies testing changes. As one can either modify the git URL and branch-name in one place or they are derived if a modified copy of the build jobs is used, pointing to a fork of this repository and/or another branch.

This also reduces the changes necessary during the preparation of a new development cycle.

Furthermore this change minimizes the time the SSH-agent is running and unifies git-pushing.