### PR TITLE
[Build] Define large kubernetes agents directly in pipeline

### DIFF
--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -7,25 +7,25 @@ pipeline {
 		timestamps()
 		buildDiscarder(logRotator(numToKeepStr:'25', artifactNumToKeepStr: '3'))
 	}
-  agent {
-    kubernetes {
-      inheritFrom 'ubuntu-2404'
-      yaml """
-apiVersion: v1
-kind: Pod
-spec:
-  containers:
-  - name: "jnlp"
-    resources:
-      limits:
-        memory: "8Gi"
-        cpu: "4000m"
-      requests:
-        memory: "6Gi"
-        cpu: "2000m"
-"""
-    }
-  }
+	agent {
+		kubernetes {
+			inheritFrom 'ubuntu-2404'
+			yaml '''
+			apiVersion: v1
+			kind: Pod
+			spec:
+			  containers:
+			  - name: "jnlp"
+			    resources:
+			      limits:
+			        memory: "8Gi"
+			        cpu: "4000m"
+			      requests:
+			        memory: "6Gi"
+			        cpu: "2000m"
+			'''.stripIndent()
+		}
+	}
 	tools {
 		jdk 'temurin-jdk21-latest'
 		maven 'apache-maven-latest'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,23 @@ pipeline {
 		timestamps()
 	}
 	agent {
-		label "centos-latest-8gb"
+		kubernetes {
+			inheritFrom 'ubuntu-2404'
+			yaml '''
+			apiVersion: v1
+			kind: Pod
+			spec:
+			  containers:
+			  - name: "jnlp"
+			    resources:
+			      limits:
+			        memory: "8Gi"
+			        cpu: "4000m"
+			      requests:
+			        memory: "4Gi"
+			        cpu: "2000m"
+			'''.stripIndent()
+		}
 	}
 	tools {
 		maven 'apache-maven-latest'


### PR DESCRIPTION
This allows us to adjust the limits by our-self, if they have to be adjusted and allows to remove pre-defined extra templates from JIRO:
- https://github.com/eclipse-cbi/jiro/pull/492