### PR TITLE
Stop publishing the obsolete org.eclipse.equinox.executable unit

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/category.xml
@@ -46,11 +46,6 @@
    <iu id = "org.eclipse.platform.ide">
      <category name="org.eclipse.platform.ide.categoryIU"/>
    </iu>
-   <iu>
-     <query> 
-       <expression type="match">id == 'org.eclipse.equinox.executable'</expression>
-     </query>
-   </iu>
    <category-def name="org.eclipse.equinox.target.categoryIU" label="Equinox Target Components">
       <description>
          Features especially useful to install as PDE runtime targets.

--- a/eclipse.platform.releng.tychoeclipsebuilder/equinox/buildConfigs/equinox-launchers/build.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/equinox/buildConfigs/equinox-launchers/build.xml
@@ -39,7 +39,6 @@
         <destination kind="metadata" location="file://${featureTemp}" name="Equinox Launchers Repo" format="file://${buildRepo}" />
         <destination kind="artifact" location="file://${featureTemp}" name="Equinox Launchers Repo" format="file://${buildRepo}" />
         <iu id="org.eclipse.equinox.executable.feature.group" version="" />
-        <iu id="org.eclipse.equinox.executable" version="" />
         <slicingOptions platformFilter="@{os},@{ws},@{arch}" includeOptional="false" includeNonGreedy="false" followStrict="true" />
       </p2.mirror>
       <p2.repo2runnable destination="${featureTemp2}/eclipse">


### PR DESCRIPTION
This unit is now effectivly only an alias for the
'org.eclipse.equinox.executable.feature.group' unit. If any reference to the former still exists, it should be changed to use the latter instead.

Follow-up on
- https://github.com/eclipse-equinox/equinox/pull/1089

If there are no objections I plan to submit this later this evening, in time for tonights I-build, which is scheduled to be M2.