### PR TITLE
[Build] Set general test timeout of 20min per test-project

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -138,6 +138,7 @@
     <surefire.moduleProperties>--add-modules=ALL-SYSTEM</surefire.moduleProperties>
     <!-- system specific JVM args; if needed provided by system properties to the build command -->
     <surefire.systemProperties></surefire.systemProperties>
+    <surefire.timeout>1200</surefire.timeout>
     <java.version>17</java.version>
     <printApiMessages>false</printApiMessages>
     <failOnJavadocErrors>false</failOnJavadocErrors>


### PR DESCRIPTION
In PDE we recently had issued with tests waiting forever which lead to builds that ran for a long time until they hit the general build timeout of multiple hours.
While this limit can of course be specified only in the PDE root pom, I think it makes sense to have a general limit by default. My proposal is to set it to 20min per-test project. This is more than sufficient for most test projects, which just run a few minutes and still would give relative fast feedback if something is flawed and hangs.

After a quick search I identified the following projects for which the limit might be too strict (in general or on slow computers):
`org.eclipse.jdt.core.tests.compiler` running ~45min
`org.eclipse.jdt.core.tests.model` running ~15min
`org.eclipse.equinox.p2.tests` running ~15min
`org.eclipse.osgi.tests` running ~10min

there we could just overwrite the general timeout and set it to a more suitable value by a similar property definition in the pom.xml or by using a corresponding `pom.model.property.surefire.timeout` entry in the build.properties (for already pomless projects).

What do the platform and Equinox commiters think?
@stephan-herrmann, @jarthana, @mpalat what do you think about this for JDT?
