### PR TITLE
Build with Tycho 5.0.1-SNAPSHOT

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -65,7 +65,7 @@
     <releaseNumberSDK>${releaseVersion}</releaseNumberSDK>
     <releaseNumberPlatform>${releaseVersion}</releaseNumberPlatform>
 
-    <tycho.version>5.0.0</tycho.version>
+    <tycho.version>5.0.1-SNAPSHOT</tycho.version>
 
     <cbi-plugins.version>1.5.2</cbi-plugins.version>
     <surefire.version>3.5.4</surefire.version>


### PR DESCRIPTION
This makes the fix to not mix JUnit-5 and JUnit-6 bundles in a test-runtime, if both are in the target-platform but only JUnit-5 is actually referenced:
- https://github.com/eclipse-tycho/tycho/pull/5526

The back-port is what will be actually used:
- https://github.com/eclipse-tycho/tycho/pull/5529