### PR TITLE
Modernize HTML meta tags in org.eclipse.jdt.doc.isv to HTML5 standards

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api.htm
@@ -2,8 +2,7 @@
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2005. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
+<meta charset="ISO-8859-1">
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
 <title>JDT structure and API</title>
 <link rel="stylesheet" type="text/css" href="../book.css">

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_classpath.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_classpath.htm
@@ -4,8 +4,7 @@
 <head>
 <meta name="copyright" content=
 "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
+<meta charset="utf-8" />
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css" />
 <title>Setting the Java build path</title>
 <link rel="stylesheet" type="text/css" href="../book.css" />

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_codeassist.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_codeassist.htm
@@ -4,8 +4,7 @@
 <head>
 <meta name="copyright" content=
 "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
+<meta charset="utf-8" />
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css" />
 <title>Performing code assist on Java code</title>
 <link rel="stylesheet" type="text/css" href="../book.css" />

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_codeformatter.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_codeformatter.htm
@@ -4,9 +4,7 @@
   <head>
     <meta name="copyright" content=
     "Copyright (c) IBM Corporation and others 2000, 2017. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-    <meta http-equiv="Content-Type" content=
-    "text/html; charset=utf-8" />
-    <meta http-equiv="Content-Style-Type" content="text/css" />
+    <meta charset="utf-8" />
     <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1"
     type="text/css" />
     <title>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_compile.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_compile.htm
@@ -4,8 +4,7 @@
 <head>
 <meta name="copyright" content=
 "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
+<meta charset="utf-8" />
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css" />
 <title>Compiling Java code</title>
 <link rel="stylesheet" type="text/css" href="../book.css" />

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_contributing_a_cleanup.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_contributing_a_cleanup.htm
@@ -4,8 +4,7 @@
 <head>
 <meta name="copyright" content=
 "Copyright (c) IBM Corporation and others 2009, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
+<meta charset="utf-8" />
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css" />
 <title>Contributing a simple clean up and a simple save action using the
 org.eclipse.jdt.ui.cleanUps extension point</title>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_contributing_a_quickfix.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_contributing_a_quickfix.htm
@@ -4,8 +4,7 @@
 <head>
 <meta name="copyright" content=
 "Copyright (c) IBM Corporation and others 2012. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
+<meta charset="utf-8" />
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css" />
 <title>Contributing a quick fix and a quick assist for Java code</title>
 

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_editors.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_editors.htm
@@ -2,8 +2,7 @@
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2007. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
+<meta charset="ISO-8859-1">
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
 <title>Customizing Java editors</title>
 <link rel="stylesheet" type="text/css" href="../book.css">

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_junit.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_junit.htm
@@ -4,8 +4,7 @@
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2005. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
 <!-- Benjamin Muskalla <b.muskalla@gmx.net> - Typo in JUnit ISV doc - https://bugs.eclipse.org/bugs/show_bug.cgi?id=248935 -->
 
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
+<meta charset="ISO-8859-1">
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
 <title>Observing JUnit test runs</title>
 <link rel="stylesheet" type="text/css" href="../book.css">

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_manip.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_manip.htm
@@ -5,8 +5,7 @@
 <head>
 <meta name="copyright" content=
 "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
+<meta charset="utf-8" />
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css" />
 <title>Manipulating Java code</title>
 <link rel="stylesheet" type="text/css" href="../book.css" />

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_open_editor.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_open_editor.htm
@@ -4,8 +4,7 @@
 <head>
 <meta name="copyright" content=
 "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
+<meta charset="utf-8" />
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css" />
 <title>Opening a Java editor</title>
 <link rel="stylesheet" type="text/css" href="../book.css" />

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_options.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_options.htm
@@ -4,8 +4,7 @@
 <head>
 <meta name="copyright" content=
 "Copyright (c) IBM Corporation and others 2000, 2020. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
+<meta charset="utf-8" />
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css" />
 <title>JDT Core options</title>
 </head>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_prompter.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_prompter.htm
@@ -4,8 +4,7 @@
 <head>
 <meta name="copyright" content=
 "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
+<meta charset="utf-8" />
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css" />
 <title>Creating Java specific prompter dialogs</title>
 <link rel="stylesheet" type="text/css" href="../book.css" />

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_render.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_render.htm
@@ -4,8 +4,7 @@
 <head>
 <meta name="copyright" content=
 "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
+<meta charset="utf-8" />
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css" />
 <title>Presenting Java elements in a JFace viewer</title>
 

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_run.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_run.htm
@@ -4,8 +4,7 @@
 <head>
 <meta name="copyright" content=
 "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
+<meta charset="utf-8" />
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css" />
 <title>Running a Java program</title>
 <link rel="stylesheet" type="text/css" href="../book.css" />

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_search.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_search.htm
@@ -4,8 +4,7 @@
 <head>
 <meta name="copyright" content=
 "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
+<meta charset="utf-8" />
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css" />
 <title>Using the Java search engine</title>
 <link rel="stylesheet" type="text/css" href="../book.css" />

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_searchindex.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_searchindex.htm
@@ -4,8 +4,7 @@
 <head>
 <meta name="copyright" content=
 "Copyright (c) IBM Corporation and others 2012. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
+<meta charset="utf-8" />
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css" />
 <title>Setting the Java build path</title>
 <link rel="stylesheet" type="text/css" href="../book.css" />

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_utility.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_utility.htm
@@ -2,8 +2,7 @@
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2005. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
+<meta charset="ISO-8859-1">
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
 <title>JavaUI utilities</title>
 <link rel="stylesheet" type="text/css" href="../book.css">

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_wizards.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_wizards.htm
@@ -4,8 +4,7 @@
 <head>
 <meta name="copyright" content=
 "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
+<meta charset="utf-8" />
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css" />
 <title>Java wizard pages</title>
 <link rel="stylesheet" type="text/css" href="../book.css" />

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_write_jar_file.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_write_jar_file.htm
@@ -4,8 +4,7 @@
 <head>
 <meta name="copyright" content=
 "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
+<meta charset="utf-8" />
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css" />
 <title>Programmatically Writing a Jar file</title>
 <link rel="stylesheet" type="text/css" href="../book.css" />

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_apt_building_with_apt.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_apt_building_with_apt.htm
@@ -3,7 +3,7 @@
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
    <meta name="copyright" content="Copyright (c) IBM Corporation and others 2006, 2012. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
+   <meta charset="iso-8859-1"/>
    <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css"/>
    <title>Headless Building with APT in Eclipse</title>
 </head>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_apt_getting_started.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_apt_getting_started.htm
@@ -3,7 +3,7 @@
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
    <meta name="copyright" content="Copyright (c) IBM Corporation and others 2006, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
+   <meta charset="iso-8859-1"/>
    <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css"/>
    <title>Getting started with APT in Eclipse</title>
 </head>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_int.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_int.htm
@@ -2,8 +2,7 @@
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2005. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
+<meta charset="ISO-8859-1">
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
 <title>JDT Programmer's Guide</title>
 <link rel="stylesheet" type="text/css" href="../book.css">

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_int_apt.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_int_apt.htm
@@ -2,8 +2,7 @@
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) BEA Systems 2006, 2012. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
+<meta charset="ISO-8859-1">
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
 <title>JDT Core</title>
 <link rel="stylesheet" type="text/css" href="../book.css">

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_int_core.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_int_core.htm
@@ -2,8 +2,7 @@
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2007. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
+<meta charset="ISO-8859-1">
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
 <title>JDT Core</title>
 <link rel="stylesheet" type="text/css" href="../book.css">

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_int_debug.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_int_debug.htm
@@ -2,8 +2,7 @@
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2018. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
+<meta charset="ISO-8859-1">
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
 <title>JDT Debug</title>
 <link rel="stylesheet" type="text/css" href="../book.css">

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_int_junit.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_int_junit.htm
@@ -2,8 +2,7 @@
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2005. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
+<meta charset="ISO-8859-1">
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
 <title>JDT JUnit integration</title>
 <link rel="stylesheet" type="text/css" href="../book.css">

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_int_model.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_int_model.htm
@@ -4,8 +4,7 @@
 <head>
 <meta name="copyright" content=
 "Copyright (c) IBM Corporation and others 2000, 2011. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." />
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
+<meta charset="utf-8" />
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css" />
 <title>Java model</title>
 <link rel="stylesheet" type="text/css" href="../book.css" />

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_int_ui.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/guide/jdt_int_ui.htm
@@ -2,8 +2,7 @@
 <html lang="en">
 <head>
 <meta name="copyright" content="Copyright (c) IBM Corporation and others 2000, 2005. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<meta http-equiv="Content-Style-Type" content="text/css">
+<meta charset="ISO-8859-1">
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
 <title>JDT UI</title>
 <link rel="stylesheet" type="text/css" href="../book.css">


### PR DESCRIPTION
* Remove obsolete Content-Style-Type meta tags from 20 HTML files in org.eclipse.jdt.doc.isv
* simplify all charset declarations to HTML5 standard