### PR TITLE
Revert "Temporarily use tycho-packaging-plugin with plexus-archiver 4.10.0"

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -412,11 +412,6 @@
               <artifactId>tycho-sourceref-jgit</artifactId>
               <version>${tycho.version}</version>
             </dependency>
-            <dependency>
-              <groupId>org.codehaus.plexus</groupId>
-              <artifactId>plexus-archiver</artifactId>
-              <version>4.10.0</version>
-            </dependency>
           </dependencies>
           <configuration>
             <timestampProvider>jgit</timestampProvider>


### PR DESCRIPTION
Tycho itself has downgraded to plexus-archiver 4.10.0 via
- https://github.com/eclipse-tycho/tycho/pull/5539
- https://github.com/eclipse-tycho/tycho/pull/5542

so the downgrade doesn't have to be repeated in this project.

This reverts commit d4ab283ebaaaf5b40da921442c166fe2fe7218fe.

Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3436