### PR TITLE
Switch mavenBuild GHA to MacOS 14

### DIFF
--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -45,7 +45,7 @@ jobs:
         config: 
           - { name: Linux,   os: ubuntu-latest  }
           - { name: Windows, os: windows-latest }
-          - { name: MacOS,   os: macos-13   }
+          - { name: MacOS,   os: macos-14   }
     defaults:
       run: # Run on bash/cmd, because powershell (the Windows default) interprets dots in arguments differently
         shell: ${{ matrix.config.name == 'Windows' && 'cmd' || 'bash' }}


### PR DESCRIPTION
MacOS 13 is being phased out as per
https://github.com/actions/runner-images/issues/13046