### PR TITLE
Drop Java 8 from GHA builds

### DIFF
--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -61,13 +61,11 @@ jobs:
       uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
       with:
         java-version: |
-          8
           11
           17
           25
           21
         mvn-toolchain-id: |
-          JavaSE-1.8
           JavaSE-11
           JavaSE-17
           JavaSE-25


### PR DESCRIPTION
With https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3458 MacOS builder has been adapted to the oldest supported MacOS version which is macos-14 which doesn't support Java 8 anymore. Builds fail with:
```
 Error: Java setup failed due to network issue or timeout: Could not
find satisfied version for SemVer '8'.
  Available versions: 25.0.1+8.0.LTS, 25.0.0+36.0.LTS, 24.0.2+12,
24.0.1+9, 24.0.0+36, 23.0.2+7, 23.0.1+11, 23.0.0+37, 22.0.2+9, 22.0.1+8,
22.0.0+36, 21.0.9+10.0.LTS, 21.0.8+9.0.LTS, 21.0.7+6.0.LTS,
21.0.6+7.0.LTS, 21.0.5+11.0.LTS, 21.0.4+7.0.LTS, 21.0.3+9.0.LTS,
21.0.2+13.0.LTS, 21.0.1+12.0.LTS, 21.0.0+35.0.LTS, 20.0.2+9, 20.0.1+9,
20.0.0+36, 19.0.2+7, 19.0.1+10, 19.0.0+36, 18.0.2+101, 18.0.2+9,
18.0.1+10, 18.0.0+36, 17.0.17+10, 17.0.16+8, 17.0.15+6, 17.0.14+7,
17.0.13+11, 17.0.12+7, 17.0.11+9, 17.0.10+7, 17.0.9+9, 17.0.8+101,
17.0.8+7, 17.0.7+7, 17.0.6+10, 17.0.5+8, 17.0.4+101, 17.0.4+8, 17.0.3+7,
17.0.2+8, 17.0.1+12, 17.0.0+35, 11.0.29+7, 11.0.28+6, 11.0.27+6,
11.0.26+4, 11.0.25+9, 11.0.24+8, 11.0.23+9, 11.0.22+7.1, 11.0.22+7,
11.0.21+9, 11.0.20+101, 11.0.20+8, 11.0.19+7, 11.0.18+10, 11.0.17+8,
11.0.16+101, 11.0.16+8, 11.0.15+10
  ```

  thus we have to drop Java 1.8 from the setup matrix.