### PR TITLE
Exclude com.ibm.icu from deprecation report

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
@@ -22,6 +22,7 @@ junit-platform-commons
 junit-platform-engine
 junit-platform-launcher
 org.commonmark
+com.ibm.icu
 
 ## SPECIAL CASE FOR SWT: THE FRAGMENT IS ANALYZED AS PART OF THE HOST
 org.eclipse.swt.win32.win32.x86_64


### PR DESCRIPTION
As it's third party lib it doesn't play by the project rules thus just polutes https://download.eclipse.org/eclipse/downloads/drops4/I20251103-1800/apitools/deprecation/apideprecation.html