### PR TITLE
[Build] Remove explicit configuration of (now) default archive formats

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/pom.xml
@@ -247,13 +247,6 @@
             <goals>
               <goal>archive-products</goal>
             </goals>
-            <configuration>
-              <formats>
-                <win32>zip</win32>
-                <linux>tar.gz</linux>
-                <macosx>tar.gz</macosx>
-              </formats>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/eclipse.platform.releng.tychoeclipsebuilder/equinox.starterkit.product/pom.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/equinox.starterkit.product/pom.xml
@@ -92,13 +92,6 @@
             <goals>
               <goal>archive-products</goal>
             </goals>
-            <configuration>
-              <formats>
-                <win32>zip</win32>
-                <linux>tar.gz</linux>
-                <macosx>tar.gz</macosx>
-              </formats>
-            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Creating `zip` files on Windows and `tar.gz` on Unix is the default in Tycho for quite some time now.