### PR TITLE
[Build] Specify timeout for test execution after agent was accessed

### DIFF
--- a/JenkinsJobs/AutomatedTests/integrationTests.jenkinsfile
+++ b/JenkinsJobs/AutomatedTests/integrationTests.jenkinsfile
@@ -2,7 +2,7 @@ def TEST_AGENT = null
 
 pipeline {
 	options {
-		timeout(time: 600, unit: 'MINUTES')
+		timeout(time: 16, unit: 'HOURS') // global timeout (starts at the beginning of this job)
 		timestamps()
 		buildDiscarder(logRotator(numToKeepStr:'15', artifactNumToKeepStr:'5'))
 		skipDefaultCheckout()
@@ -48,7 +48,7 @@ pipeline {
 				ANT_HOME = tool(type:'ant', name:'apache-ant-latest')
 				ANT_OPTS = "-Djava.io.tmpdir=${pathOf(env.WORKSPACE + '/tmp')}"
 			}
-			steps {
+			steps { timeout(time: 8, unit: 'HOURS') { // timeout of test execution (starts after the agent was accessed)
 				// workspace is not always cleaned (a previous clean-up may have failed). Clean before git cloning or custom tools are installed into workspace.
 				cleanWs()
 				checkout scmGit(userRemoteConfigs: [[url: "${scm.userRemoteConfigs[0].url}"]], branches: [[name: "${scm.branches[0].name}"]],
@@ -92,7 +92,7 @@ pipeline {
 					""")
 				}
 				junit keepLongStdio: true, testResults: '**/eclipse-testing/results/xml/*.xml'
-			}
+			}}
 			post {
 				always {
 					script {


### PR DESCRIPTION
The top-level timeout specified in the global options of a Jenkins job is effective from the time the job starts its execution (waiting for the 'main' agents is excluded here). On the contrary timeouts defined on stage level include the time waiting for the stage's agent to become available.
In some cases (currently only for Mac) the same physical machine is used to execute multiple test-configurations. Consequently some configurations have to wait a significant amount of time for the executing agent to become available.

Therefore now timeouts are defined:
An inner one effective only for the actual test execution, sufficient to execute one configuration.
And an outer, global one, effective almost from when the job is triggered and with a larger value to cover the execution of multiple configurations.
The global one mainly exists in order to prevent pending tests to pile up in case the infrastructure is flawed.

Follow-up on
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3416

This should also fix the recent occasional timeout of Mac tests.

FYI @MohananRahul as you also asked for increased runtimes of mac tests (which are displayed similar to how the timeout is applied)