### PR TITLE
[Build] Update eclipse-cbi-plugin to version 1.5.3

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -67,7 +67,7 @@
 
     <tycho.version>5.0.1-SNAPSHOT</tycho.version>
 
-    <cbi-plugins.version>1.5.2</cbi-plugins.version>
+    <cbi-plugins.version>1.5.3</cbi-plugins.version>
     <surefire.version>3.5.4</surefire.version>
 
     <eclipse-sdk-repo>https://download.eclipse.org/eclipse/updates/${releaseVersion}-I-builds/</eclipse-sdk-repo>

--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse-junit-tests/src/main/resources/.gitkeep
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse-junit-tests/src/main/resources/.gitkeep
@@ -1,2 +1,0 @@
-The eclipse-cbi-plugin mojo doesn't create parent directories:
-- https://github.com/eclipse-cbi/org.eclipse.cbi/issues/748


### PR DESCRIPTION
To leverage
- https://github.com/eclipse-cbi/org.eclipse.cbi/pull/751

Allows to remove the workaround from
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3466#discussion_r2507109088