### PR TITLE
Remove commons-lang:commons-lang:2.6

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -121,12 +121,6 @@
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
-				  <groupId>commons-lang</groupId>
-				  <artifactId>commons-lang</artifactId>
-				  <version>2.6</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
 				  <groupId>commons-logging</groupId>
 				  <artifactId>commons-logging</artifactId>
 				  <version>1.3.5</version>


### PR DESCRIPTION
- This bundle is affected by https://nvd.nist.gov/vuln/detail/CVE-2025-48924
- It appears to be unused.