### PR TITLE
New & Noteworthy 4.38

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/whatsNew/jdt_whatsnew.html
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/whatsNew/jdt_whatsnew.html
@@ -12,8 +12,8 @@ body { max-width: 900px; font-family: sans-serif; }
 <body>
   <h2>Java Development Tools</h2>
   <p>
-    The new and noteworthy updates for Eclipse 4.37 can be found
-    <a href="https://eclipse.dev/eclipse/news/4.37/jdt.html" target="_blank">here</a>.
+    The new and noteworthy updates for Eclipse 4.38 can be found
+    <a href="https://eclipse.dev/eclipse/news/4.38/jdt.html" target="_blank">here</a>.
   </p>
 </body>
 </html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/whatsNew/platform_isv_whatsnew.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/whatsNew/platform_isv_whatsnew.html
@@ -12,8 +12,8 @@
 <body>
   <h2>Platform and Equinox API</h2>
   <p>
-    The new and noteworthy updates for Eclipse 4.37 can be found
-    <a href="https://eclipse.dev/eclipse/news/4.37/platform_isv.html" target="_blank">here</a>.
+    The new and noteworthy updates for Eclipse 4.38 can be found
+    <a href="https://eclipse.dev/eclipse/news/4.38/platform_isv.html" target="_blank">here</a>.
   </p>
 </body>
 </html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/whatsNew/platform_whatsnew.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/whatsNew/platform_whatsnew.html
@@ -13,8 +13,8 @@
 <body>
   <h2>Platform and Equinox</h2>
   <p>
-    The new and noteworthy updates for Eclipse 4.37 can be found
-    <a href="https://eclipse.dev/eclipse/news/4.37/platform.html" target="_blank">here</a>.
+    The new and noteworthy updates for Eclipse 4.38 can be found
+    <a href="https://eclipse.dev/eclipse/news/4.38/platform.html" target="_blank">here</a>.
   </p>
 </body>
 </html>


### PR DESCRIPTION
Fixes: https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3504

New and Noteworthy for Eclipse 4.38 Help page (JDT and Platform changes)