### PR TITLE
[I/Y-Build] Ensure build drop directory exists before result gathering

### DIFF
--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -294,6 +294,7 @@ pipeline {
 									sh '''#!/bin/bash -xe
 										set -o pipefail
 										source $CJE_ROOT/buildproperties.shsource
+										mkdir -p $CJE_ROOT/$DROP_DIR/$BUILD_ID
 										cp $CJE_ROOT/buildproperties.* $CJE_ROOT/$DROP_DIR/$BUILD_ID
 										./mb300_gatherEclipseParts.sh $CJE_ROOT/buildproperties.shsource 2>&1 | tee $logDir/mb300_gatherEclipseParts.sh.log
 									'''
@@ -348,6 +349,7 @@ pipeline {
 									sh '''#!/bin/bash -xe
 										set -o pipefail
 										source $CJE_ROOT/buildproperties.shsource
+										mkdir -p $CJE_ROOT/$EQUINOX_DROP_DIR/$BUILD_ID
 										cp $CJE_ROOT/buildproperties.* $CJE_ROOT/$EQUINOX_DROP_DIR/$BUILD_ID
 										./mb310_gatherEquinoxParts.sh $CJE_ROOT/buildproperties.shsource 2>&1 | tee $logDir/mb310_gatherEquinoxParts.sh.log
 									'''

--- a/cje-production/mbscripts/mb300_gatherEclipseParts.sh
+++ b/cje-production/mbscripts/mb300_gatherEclipseParts.sh
@@ -22,14 +22,9 @@ fi
 source $CJE_ROOT/scripts/common-functions.shsource
 source $1
 
-mkdir -p $CJE_ROOT/$DROP_DIR/$BUILD_ID
-mkdir -p $CJE_ROOT/$EQUINOX_DROP_DIR/$BUILD_ID
 mkdir -p $CJE_ROOT/$DROP_DIR/$BUILD_ID/testresults/consolelogs
 
 JavaCMD=${JAVA_HOME}/bin/java
-
-# gather maven properties
-cp $CJE_ROOT/$AGG_DIR/eclipse-platform-parent/target/mavenproperties.properties  $CJE_ROOT/$DROP_DIR/$BUILD_ID/mavenproperties.properties
 
 # gather repo
 REPO_ZIP=$PLATFORM_TARGET_DIR/eclipse.platform.repository-${STREAMMajor}.${STREAMMinor}.${STREAMService}-SNAPSHOT.zip
@@ -109,7 +104,6 @@ fi
       -DbuildRepo=$PLATFORM_REPO_DIR \
       -DbuildDirectory=$CJE_ROOT/$DROP_DIR/$BUILD_ID \
       -DpostingDirectory=$CJE_ROOT/$DROP_DIR \
-      -DequinoxPostingDirectory=$CJE_ROOT/$EQUINOX_DROP_DIR \
       -Djava.io.tmpdir=$CJE_ROOT/$TMP_DIR \
       -v
     popd

--- a/cje-production/mbscripts/mb310_gatherEquinoxParts.sh
+++ b/cje-production/mbscripts/mb310_gatherEquinoxParts.sh
@@ -28,7 +28,6 @@ REPO_DIR=$ECLIPSE_BUILDER_DIR/equinox.starterkit.product/target/products
   
 if [ -d $REPO_DIR ]; then
   pushd $REPO_DIR
-  mkdir -p $CJE_ROOT/$EQUINOX_DROP_DIR/$BUILD_ID
   cp org.eclipse.rt.osgistarterkit.product-linux.gtk.x86_64.tar.gz $CJE_ROOT/$EQUINOX_DROP_DIR/$BUILD_ID/EclipseRT-OSGi-StarterKit-$BUILD_ID-linux-gtk-x86_64.tar.gz
   cp org.eclipse.rt.osgistarterkit.product-macosx.cocoa.x86_64.tar.gz $CJE_ROOT/$EQUINOX_DROP_DIR/$BUILD_ID/EclipseRT-OSGi-StarterKit-$BUILD_ID-macosx-cocoa-x86_64.tar.gz
   cp org.eclipse.rt.osgistarterkit.product-macosx.cocoa.x86_64.dmg $CJE_ROOT/$EQUINOX_DROP_DIR/$BUILD_ID/EclipseRT-OSGi-StarterKit-$BUILD_ID-macosx-cocoa-x86_64.dmg


### PR DESCRIPTION
Due to the now parallel result gathering the existence of the build-drop site directory has to be ensured individually for eclipse and equinox.

Follow up on
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3502