### PR TITLE
[RelEng] Ignore misaligned version of org.eclipse.sdk.tests feature

### DIFF
--- a/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
+++ b/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
@@ -306,7 +306,7 @@ pipeline {
 						--include \\*.sh \
 						--fixed-strings "${PREVIOUS_RELEASE_VERSION}")
 					# The eclipse-platform-parent/pom.xml contains the previous version in the baseline repository variable
-					if [[ -z "${matchingFiles}" ]] || [[ "${matchingFiles}" == 'eclipse-platform-parent/pom.xml' ]]; then
+					if [[ -z "${matchingFiles}" ]] || [[ "$(echo $matchingFiles)" == 'eclipse-platform-parent/pom.xml eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml' ]]; then
 						echo "No unexpected references to previous version ${PREVIOUS_RELEASE_VERSION} found."
 						exit 0
 					else


### PR DESCRIPTION
The version of the org.eclipse.sdk.tests feature was increased twice in this release cycle and therefore isn't properly updated in the release preparation anymore.
To unbreak the release preparation it's misaligned version is temporarily ignored/accepted.

Caused by
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3399

With the preparation of the upcomming release cycle this should be reverted again (and the version of the `org.eclipse.sdk.tests` feature updated to `4.39`.