### PR TITLE
[RelEng] Update N&N entry links in doc bundles in release preparation

### DIFF
--- a/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
+++ b/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
@@ -229,20 +229,20 @@ pipeline {
 				gitCommitAllExcludingSubmodules("Move previous version to ${PREVIOUS_RELEASE_CANDIDATE_TAG} in build scripts")
 			}
 		}
-		stage('Clear Qualifier-update files') {
+		stage('Update doc bundles') {
 			steps {
 				dir('eclipse.platform.common/bundles') {
 					sh '''
+						# Update links to N&N entries
+						for whatsNewFile in */whatsNew/*_whatsnew.html; do
+							sed --expression "s|Eclipse ${PREVIOUS_RELEASE_VERSION}|Eclipse ${NEXT_RELEASE_VERSION}|" -i "${whatsNewFile}"
+							sed --expression "s|news/${PREVIOUS_RELEASE_VERSION}/|news/${NEXT_RELEASE_VERSION}/|" -i "${whatsNewFile}"
+						done
 						# Clear content of all forceQualifierUpdate files in this directory
 						for file in */forceQualifierUpdate.txt; do
 							> "$file"
 						done
-						# Commit cleared files, if there was content to remove
-						if [ -n "$(git diff --shortstat .)" ] ; then
-							git commit --message "Clean forceQualifierUpdate files of doc bundles for ${NEXT_RELEASE_VERSION} development" .
-						else
-							echo 'The forceQualifierUpdate files of all doc bundles are already empty. Nothing to do.'
-						fi
+						git commit --message "Update doc bundles for ${NEXT_RELEASE_VERSION} development" .
 					'''
 				}
 			}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -58,13 +58,9 @@ Tasks to be completed after RC2
 Tasks that need to be completed before Friday
 
   * Create an issue to track the current release tasks (see [Release 4.24](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/273)).
-    - Tag @lshanmug (New & Noteworthy), @SarikaSinha (Readme), @ktatavarthi (JDT and Platform Migration Guides), @niraj-modi (SWT Javadoc bash).
+    - Tag @SarikaSinha (Readme), @ktatavarthi (JDT and Platform Migration Guides), @niraj-modi (SWT Javadoc bash).
     - Update the Acknowledgements.
     - A script to create this issue exists [here](scripts/GAReleasePrep.sh) for those who have the hub cli tool installed.
-  * **New & Noteworthy**
-    Currently this is handled by @lshanmug who will
-    - Create a tracking issue in the [eclipse.platform.common](https://github.com/eclipse-platform/eclipse.platform.common) repo (see [N&N for 4.26](https://github.com/eclipse-platform/eclipse.platform.common/pull/93) as an example).
-    - Update the WhatsNew files and folders for the doc bundles.
   * **Readme**
     Currently handled by @SarikaSinha
     - Create a tracking issue in [www.eclipse.org-eclipse](https://github.com/eclipse-platform/www.eclipse.org-eclipse) (see [Readme file for 4.26](https://github.com/eclipse-platform/www.eclipse.org-eclipse/issues/24) as an example).

--- a/scripts/GAReleasePrep.sh
+++ b/scripts/GAReleasePrep.sh
@@ -27,7 +27,6 @@ BODY="Umbrella bug to track release activities for ${STREAM}
 For previous bug please refer to eclipse-platform/eclipse.platform.releng.aggregator#${PREV_ISSUE}.
 
 
-- [ ] New & Noteworthy
 - [ ] Readme file for ${STREAM}
 - [ ] ${STREAM} Acknowledgements
 - [ ] Migration Guide


### PR DESCRIPTION
Automating this avoids the need to do these changes manually and applies them in the beginning of a release cycle.
If applied later, the doc-bundles are pointing to the wrong (i.e. the previous release's) N&N site during the development cycle.

The PDE part is done in
- https://github.com/eclipse-pde/eclipse.pde/pull/2146

This should make issues like https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3504 and the associated separate PRs obsolete.

I also tried to clean-up the corresponding documentation
@elsazac and @MohananRahul is this change complete or did I oversaw/forget anything?