### PR TITLE
Migration guide for  Eclipse 4.38 from 4.37

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/4.38/faq.html
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/4.38/faq.html
@@ -1,0 +1,19 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2025 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../../book.css">
+<title>Eclipse JDT 4.38 Plug-in Migration FAQ</title>
+</head>
+
+<body>
+
+<h1>Eclipse JDT 4.38 Plug-in Migration FAQ</h1>
+
+<ol>
+	<li>None</li>
+</ol>
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/4.38/incompatibilities.html
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/4.38/incompatibilities.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2025 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta charset="UTF-8">
+<link rel="STYLESHEET" href="../../book.css">
+<title>Incompatibilities between Eclipse 4.37 and 4.38</title>
+</head>
+<body>
+<h1>Incompatibilities Between Eclipse 4.37 and 4.38</h1>
+
+<p>
+  So far Eclipse did not change incompatibly between 4.37 and 4.38 in ways that affect
+  plug-ins. Plug-ins that ran on 4.37 should run on 4.38 without any problems.
+</p>
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/4.38/recommended.html
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/4.38/recommended.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2025 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../../book.css">
+<title>Adopting JDT 4.38 mechanisms and APIs</title>
+</head>
+
+<body>
+
+<h1>Adopting JDT 4.38 Mechanisms and APIs</h1>
+<p>
+  This section describes changes that are required if you are trying to change
+  your 4.37 plug-in to adopt the 4.38 mechanisms and APIs.
+</p>
+
+<ol>
+	<li>None</li>
+</ol>
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/eclipse_4_38_porting_guide.html
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting/eclipse_4_38_porting_guide.html
@@ -1,0 +1,38 @@
+<!DOCTYPE HTML>
+<html lang="en">
+
+<head>
+
+<meta name="copyright" content="Copyright (c) IBM 2025 Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css">
+<title>Eclipse JDT 4.38 Plug-in Migration Guide</title>
+</head>
+
+<body>
+
+<h1>Eclipse JDT 4.38 Plug-in Migration Guide</h1>
+<p>This guide covers migrating Eclipse JDT 4.37 plug-ins to Eclipse JDT 4.38.</p>
+<p>One of the goals of Eclipse 4.38 was to move Eclipse forward while remaining compatible
+  with previous versions to the greatest extent possible. That is, plug-ins written
+  against the Eclipse 4.37 APIs should continue to work in 4.38 in spite of the
+  API changes.</p>
+<p>The key kinds of compatibility are API contract compatibility and binary compatibility.
+  API contract compatibility means that valid use of 4.37 APIs remains valid for
+  4.38, so there is no need to revisit working code. Binary compatibility means
+  that the API method signatures, etc. did not change in ways that would cause
+  existing compiled (&quot;binary&quot;) code to no longer link and run with the
+  new 4.38 libraries.</p>
+<p>While every effort was made to avoid breakage, there are a few areas of incompatibility or new
+  APIs that should be adopted by clients.
+  This document describes those areas and provides instructions for migrating 4.37 plug-ins to
+  4.38.</p>
+<ul>
+  <li><a href="4.38/faq.html">Eclipse JDT 4.38 Plug-in Migration FAQ</a></li>
+  <li><a href="4.38/incompatibilities.html">Incompatibilities between Eclipse JDT 4.37 and 4.38</a></li>
+  <li><a href="4.38/recommended.html">Adopting 4.38 mechanisms and API</a></li>
+</ul>
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/topics_Porting.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/topics_Porting.xml
@@ -4,6 +4,12 @@
 <!-- Define topics for the porting guide index                                     -->
 <!-- ============================================================================= -->
 <toc label="Migration">
+	<topic label="Migrating to Eclipse JDT 4.38 from 4.37">
+		<topic label="Introduction" href="porting/eclipse_4_38_porting_guide.html"/>
+		<topic label="FAQ"                             href="porting/4.38/faq.html" />
+		<topic label="Incompatibilities"               href="porting/4.38/incompatibilities.html" />
+		<topic label="Adopting 4.38 Mechanisms and API" href="porting/4.38/recommended.html" />
+	</topic>
 	<topic label="Migrating to Eclipse JDT 4.37 from 4.36">
 		<topic label="Introduction" href="porting/eclipse_4_37_porting_guide.html"/>
 		<topic label="FAQ"                             href="porting/4.37/faq.html" />

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.38/faq.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.38/faq.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2025 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../../book.css" type="text/css">
+<title>Eclipse 4.38 Plug-in Migration FAQ</title>
+</head>
+<body>
+<h1>Eclipse 4.38 Plug-in Migration FAQ</h1>
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.38/incompatibilities.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.38/incompatibilities.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2025 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../../book.css" type="text/css">
+<title>Incompatibilities between Eclipse 4.37 and 4.38</title>
+</head>
+<body>
+<h1>Incompatibilities Between Eclipse 4.37 and 4.38</h1>
+
+<p>
+  Eclipse changed in incompatible ways between 4.37 and 4.38 in ways that affect
+  plug-ins. The following entries describe the areas that changed and provide
+  instructions for migrating 4.37 plug-ins to 4.38. Note that you only need to look
+  here if you are experiencing problems running your 4.37 plug-in on 4.38.
+</p>
+<p>
+See also the list of <a href="../removals.html">deprecated API removals</a> for this release.
+</p>
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.38/recommended.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/4.38/recommended.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML>
+<html lang="en">
+
+<head>
+	<meta name="copyright"
+		content="Copyright (c) 2025 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+	<meta charset="utf-8">
+	<link rel="STYLESHEET" href="../../book.css" type="text/css">
+	<title>Adopting 4.38 mechanisms and APIs</title>
+</head>
+
+<body>
+	<h1>Adopting 4.38 Mechanisms and APIs</h1>
+
+	<p>This section describes changes that are required if you are
+		trying to change your 4.37 plug-in to adopt the 4.38 mechanisms and
+		APIs.</p>
+
+	<!-- ##############################################
+	 ############################################## -->
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/eclipse_4_38_porting_guide.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/eclipse_4_38_porting_guide.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2025 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<title>Eclipse 4.38 Plug-in Migration Guide</title>
+</head>
+
+<body>
+
+<h1>Eclipse 4.38 Plug-in Migration Guide</h1>
+<p>This guide covers migrating Eclipse 4.37 plug-ins to Eclipse 4.38.</p>
+<p>One of the goals of Eclipse 4.38 was to move Eclipse forward while remaining compatible
+  with previous versions to the greatest extent possible. That is, plug-ins written
+  against the Eclipse 4.37 APIs should continue to work in 4.38 in spite of any API changes.</p>
+<p>The key kinds of compatibility are API contract compatibility and binary compatibility.
+  API contract compatibility means that valid use of 4.37 APIs remains valid for
+  4.38, so there is no need to revisit working code. Binary compatibility means
+  that the API method signatures, etc. did not change in ways that would cause
+  existing compiled (&quot;binary&quot;) code to no longer link and run with the
+  new 4.38 libraries.</p>
+<p>While every effort was made to avoid breakage, there are a few areas of incompatibility or new
+  APIs that should be adopted by clients.
+  This document describes those areas and provides instructions for migrating 4.37 plug-ins to
+  4.38.</p>
+<ul>
+  <li><a href="4.38/faq.html">Eclipse 4.38 Plug-in Migration FAQ</a></li>
+  <li><a href="4.38/incompatibilities.html">Incompatibilities between Eclipse 4.37 and 4.38</a></li>
+  <li><a href="4.38/recommended.html">Adopting 4.38 mechanisms and API</a></li>
+</ul>
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/topics_Porting.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/topics_Porting.xml
@@ -5,6 +5,12 @@
 <!-- ============================================================================= -->
 <toc label="Migration">
 	<topic label="Deprecated API removals" href="porting/removals.html"/>
+	<topic label="Migrating to Eclipse 4.38 from 4.37">
+		<topic label="Introduction" href="porting/eclipse_4_38_porting_guide.html"/>
+		<topic label="FAQ" href="porting/4.38/faq.html" />
+		<topic label="Incompatibilities" href="porting/4.38/incompatibilities.html" />
+		<topic label="Adopting 4.38 mechanisms and API" href="porting/4.38/recommended.html" />
+	</topic>
 	<topic label="Migrating to Eclipse 4.37 from 4.36">
 		<topic label="Introduction" href="porting/eclipse_4_37_porting_guide.html"/>
 		<topic label="FAQ" href="porting/4.37/faq.html" />


### PR DESCRIPTION
Migration guide for Eclipse 4,38 from 4.37