### PR TITLE
Update version of org.eclipse.sdk.tests to 4.39

### DIFF
--- a/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
+++ b/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
@@ -306,7 +306,7 @@ pipeline {
 						--include \\*.sh \
 						--fixed-strings "${PREVIOUS_RELEASE_VERSION}")
 					# The eclipse-platform-parent/pom.xml contains the previous version in the baseline repository variable
-					if [[ -z "${matchingFiles}" ]] || [[ "$(echo $matchingFiles)" == 'eclipse-platform-parent/pom.xml eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml' ]]; then
+					if [[ -z "${matchingFiles}" ]] || [[ "${matchingFiles}" == 'eclipse-platform-parent/pom.xml' ]]; then
 						echo "No unexpected references to previous version ${PREVIOUS_RELEASE_VERSION} found."
 						exit 0
 					else

--- a/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.sdk.tests"
       label="%featureName"
-      version="4.38.100.qualifier"
+      version="4.39.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">
@@ -54,7 +54,7 @@
    <plugin
          id="org.eclipse.core.tests.resources"
          version="0.0.0"/>
-         
+
    <plugin
          id="org.eclipse.core.tests.resources.saveparticipant"
          version="0.0.0"/>
@@ -134,7 +134,7 @@
    <plugin
          id="org.eclipse.jdt.core.tests.performance"
          version="0.0.0"/>
-         
+
    <plugin
          id="org.eclipse.jdt.core.tests.builder.mockcompiler"
          version="0.0.0"/>


### PR DESCRIPTION
And revert `[RelEng] Ignore misaligned version of org.eclipse.sdk.tests feature`.

This reverts commit 13d2ebc9ff14ab674810d6587867dc42cae49f1c.

Follow-up on
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3508