### PR TITLE
Version bump(s) for 4.39 stream

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/META-INF/MANIFEST.MF
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.doc.user; singleton:=true
-Bundle-Version: 3.15.2700.qualifier
+Bundle-Version: 3.15.2800.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.2.0,4.0.0)"

--- a/eclipse.platform.releng/features/org.eclipse.help-feature/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.help-feature/feature.xml
@@ -3,7 +3,7 @@
 <feature
       id="org.eclipse.help"
       label="%featureName"
-      version="2.3.2400.qualifier"
+      version="2.3.2500.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.help.base"
       license-feature="org.eclipse.license"


### PR DESCRIPTION
Add missing version increments after:
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3519