### PR TITLE
Align version of org.eclipse.jdt.doc.isv with release version

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/META-INF/MANIFEST.MF
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.doc.isv; singleton:=true
-Bundle-Version: 3.14.3000.qualifier
+Bundle-Version: 4.39.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.2.0,4.0.0)"

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/pom.xml
@@ -19,7 +19,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.doc.isv</artifactId>
-  <version>3.14.3000-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <profiles>


### PR DESCRIPTION
this simplifies the RelEng process because now bundle's version is automatically increment as part of the usual release preparation. This is already the case for the other doc-bundles that contain New&Noteworthy links (and are updated too during the preparation of a new development cycle).

At the moment the bundles version has to be incremented manually:
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3525

And there are valid objections against running the version increment check for the containing folders too:
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3293

@akurtakov, @iloveeclipse or @jarthana and @mpalat, any objections?