### PR TITLE
[I/Y-Build] Update to renewed composite build-tools repository

### DIFF
--- a/cje-production/buildproperties.txt
+++ b/cje-production/buildproperties.txt
@@ -38,5 +38,5 @@ BASEBUILD_ID="I20251126-2330"
 #release id for downloading eclipse
 PREVIOUS_RELEASE_ID="S-4.38RC2-202511262330"
 
-BUILDTOOLS_REPO="https://download.eclipse.org/eclipse/updates/buildtools/snapshots"
+BUILDTOOLS_REPO="https://download.eclipse.org/eclipse/updates/buildtools"
 ECLIPSE_RUN_REPO="https://download.eclipse.org/eclipse/updates/4.39-I-builds/"


### PR DESCRIPTION
The build-tools composite now contains the latest builds (again),since:
- https://github.com/eclipse-platform/eclipse.platform.releng.buildtools/pull/102