### PR TITLE
[Build] Materialize products from local repository to add pgp signatures

### DIFF
--- a/products/eclipse-platform/build.properties
+++ b/products/eclipse-platform/build.properties
@@ -3,6 +3,5 @@ pom.model.property.product.id = org.eclipse.platform.ide
 pom.model.property.product.rootFolder = eclipse
 pom.model.property.product.rootFolder.macosx = Eclipse.app
 pom.model.property.repository.includeAllSources = true
-pom.model.property.repository.includeAllDependencies = true
 
 pom.model.property.eclipse.signing.skip = false

--- a/products/pom.xml
+++ b/products/pom.xml
@@ -40,7 +40,6 @@
 	<properties>
 		<product.installSources>false</product.installSources>
 		<repository.includeAllSources>false</repository.includeAllSources>
-		<repository.includeAllDependencies>false</repository.includeAllDependencies>
 	</properties>
 
 	<build>
@@ -50,8 +49,8 @@
 					<groupId>org.eclipse.tycho</groupId>
 					<artifactId>tycho-p2-repository-plugin</artifactId>
 					<configuration>
+						<includeAllDependencies>true</includeAllDependencies>
 						<includeAllSources>${repository.includeAllSources}</includeAllSources>
-						<includeAllDependencies>${repository.includeAllDependencies}</includeAllDependencies>
 					</configuration>
 				</plugin>
 				<plugin>
@@ -76,6 +75,7 @@
 						</products>
 						<profile>SDKProfile</profile>
 						<installSources>${product.installSources}</installSources>
+						<source>repository</source><!-- Required to add pgp signatures to products -->
 					</configuration>
 					<executions>
 						<execution>


### PR DESCRIPTION
By default products are materialized from the target-platform, but the `pgp-sigatures` produced in a previous execution of the `tycho-pgp-plugin` are only added to the local repository of the product (in it's `target/repository` directory).
In order to make sure that the produced `pgp-sigatures` are included into the products (i.e. their embedded repositories) the later repository has to be the source of the materialization.

Follow-up on
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3480

Similar to (errors repeat themself...)
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/133