### PR TITLE
[Build] Add back sources to Eclipse-SDK product

### DIFF
--- a/products/eclipse-junit-tests/pom.xml
+++ b/products/eclipse-junit-tests/pom.xml
@@ -39,7 +39,17 @@
       </resource>
     </resources>
 
-
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-p2-repository-plugin</artifactId>
+          <configuration>
+            <includeAllDependencies>false</includeAllDependencies>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/products/eclipse-sdk/build.properties
+++ b/products/eclipse-sdk/build.properties
@@ -2,6 +2,7 @@
 pom.model.property.product.id = org.eclipse.sdk.ide
 pom.model.property.product.rootFolder = eclipse
 pom.model.property.product.rootFolder.macosx = Eclipse.app
+pom.model.property.repository.includeAllSources = true
 pom.model.property.product.installSources = true
 
 pom.model.property.eclipse.signing.skip = false

--- a/products/pom.xml
+++ b/products/pom.xml
@@ -38,6 +38,9 @@
 	<!-- TODO: Move site like products (e.g. equinox-sdk and junit-tests) into sites folder, which also avoids inheriting (for them) unwanted configuration?-->
 	
 	<properties>
+		<!-- If product.installSources is set to true,
+		repository.includeAllSources must always be true too.
+		Otherwise the former has no effect (because source=repository). -->
 		<product.installSources>false</product.installSources>
 		<repository.includeAllSources>false</repository.includeAllSources>
 	</properties>


### PR DESCRIPTION
The sources of all contained bundles were accidentally removed from the eclipse-SDK product in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3549

That is because the p2-repository assembled for the eclipse-SDK product didn't contain sources before, as that repository is not used further. But now that the product is materialized from that p2-repository (since that mentioned change), sources went missing in the product itself too.

Consequently the property `repository.includeAllSources` must now be true if `product.installSources` is true. Otherwise the latter has no effect. If no sources are available in the source-repository, of course Tycho cannot install them.

Additionally remove dependencies again from eclipse-junit-tests product. They were added unintentionally in the mentioned change, too.

Fixes
- https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4684