### PR TITLE
[I/Y-Build] Implement workaround to fix tools download on Windows agents

### DIFF
--- a/JenkinsJobs/shared/utilities.groovy
+++ b/JenkinsJobs/shared/utilities.groovy
@@ -127,7 +127,7 @@ def downloadTemurinJDK(int version, String os, String arch, String releaseType='
 
 def installDownloadableTool(String toolType, String url) {
 	dir("${WORKSPACE}/tools/${toolType}") {
-		def scriptText = "curl --fail --location ${url} | tar -xzf -"
+		def scriptText = "curl --fail --location ${url} | ${ isUnix() ? 'tar' : 'C:\\Windows\\System32\\tar.exe'} -xzf -"
 		if (isUnix()) {
 			sh scriptText
 		} else { // Windows 10 and later has a tar.exe that can handle zip files (even read from std-in)


### PR DESCRIPTION
Fixes the failure of the Windows tests
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3516

Relates to
- https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6781#note_5338526

On the long run, the SSH handling should be reworked.