### PR TITLE
[I/Y-Build] Add missing binary folder suffix of JDK installs on macOS

### DIFF
--- a/JenkinsJobs/AutomatedTests/integrationTests.jenkinsfile
+++ b/JenkinsJobs/AutomatedTests/integrationTests.jenkinsfile
@@ -172,7 +172,7 @@ def getJDKInstallationPath(Map<String, Object> test) {
 	switch(test.jdk.type) {
 		case 'tool': return tool(type:'jdk', name: test.jdk.name)
 		case 'local': return test.jdk.path
-		case 'install': return utilities.installDownloadableTool('jdk', test.jdk.url)
+		case 'install': return utilities.installDownloadableTool('jdk', test.jdk.url) + (test.os == 'macosx' ? '/Contents/Home' : '')
 		case 'temurin': return utilities.downloadTemurinJDK(test.javaVersion, test.os, test.arch, test.jdk.ea ? 'ea' : 'ga')
 	}
 }


### PR DESCRIPTION
This is similar to downloadTemurinJDK() method in utilities.groovy.

Fixes the failure of the Mac Y-build tests
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3516