### PR TITLE
[I/Y-Build] Run ComparatorSummaryExtractor with Java-25

### DIFF
--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -252,6 +252,9 @@ pipeline {
 			}
 		}
 		stage('Check for comparator errors') {
+			tools {
+				jdk 'temurin-jdk25-latest'
+			}
 			steps {
 				sh '''#!/bin/bash -xe
 					source $CJE_ROOT/scripts/common-functions.shsource


### PR DESCRIPTION
The Java source program ComparatorSummaryExtractor now uses multiple files and therefore requires Java-25.

Follow-up on
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3554