### PR TITLE
[I/Y-Build] Fix extension of test overview file and counting of tests

### DIFF
--- a/JenkinsJobs/AutomatedTests/integrationTests.jenkinsfile
+++ b/JenkinsJobs/AutomatedTests/integrationTests.jenkinsfile
@@ -128,7 +128,7 @@ pipeline {
 										
 										# Download the result summary directly to the storage server
 										ssh genie.releng@projects-storage.eclipse.org \
-											curl --fail --location --output "${remoteResultsDirectory}/${JOB_BASE_NAME}.xml" "${BUILD_URL}/testReport/api/json?tree=failCount,passCount,skipCount,duration"
+											curl --fail --location --output "${remoteResultsDirectory}/${JOB_BASE_NAME}.json" "${BUILD_URL}/testReport/api/json?tree=failCount,passCount,skipCount,duration"
 									fi
 								'''
 							}

--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -677,7 +677,7 @@ pipeline {
 			https://download.eclipse.org/eclipse/downloads/drops4/${BUILD_ID}
 			
 			Build logs and/or test results (eventually):
-			https://download.eclipse.org/eclipse/downloads/drops4/${BUILD_ID}/testResults.php
+			https://download.eclipse.org/eclipse/downloads/drops4/${BUILD_ID}/tests.html
 			""" + (env.COMPARATOR_ERRORS_SUBJECT == '' ? '' : """
 			Check unanticipated comparator messages:
 			https://download.eclipse.org/eclipse/downloads/drops4/${BUILD_ID}/buildlogs/comparatorlogs/buildtimeComparatorUnanticipated.log.txt

--- a/JenkinsJobs/Releng/updateIndex.jenkinsfile
+++ b/JenkinsJobs/Releng/updateIndex.jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
 										# Count elements in list of expected tests
 										grep "^TEST_CONFIGURATIONS_EXPECTED" \${drop}/buildproperties.properties | awk -F= "{print \\\$2}" | grep -o "ep[0-9A-Za-z]*-unit-" | wc -l
 										# Count number of test-result overview files
-										find \${drop}/testresults -maxdepth 1 -type f -name "ep*-unit-*.json" | wc -l
+										find \${drop}/testresults -maxdepth 1 -type f -name "ep*-unit-*.json" ! -name "ep*-unit-*-summary.json" | wc -l
 										# Count number of old-style test-result overview files (still relevant for not yet archived releases)
 										find \${drop}/testresults -maxdepth 1 -type f -name "ep*-unit-*.xml" | wc -l
 										if [  -f \${drop}/index.html ]; then


### PR DESCRIPTION
and fix the link to tests in the build announcement mail.

Follow-up on
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3554