### PR TITLE
Temporary fix for console logs link

### DIFF
--- a/sites/eclipse/build/tests.html
+++ b/sites/eclipse/build/tests.html
@@ -22,7 +22,7 @@
 		<ul class="data-ref">
 			<li><a href="buildlogs/reporeports/index.html"><b>Repository Reports </b></a></li>
 			<li><a href="buildlogs/logs.html"><b>Build and Release Engineering Logs</b></a></li>
-			<li><a href="testresults/logs.html"><b>Test Console Logs</b></a></li> <!-- TODO: Once testresults/logs.html is implementd change this link to it -->
+			<li><a href="testresults/"><b>Test Console Logs</b></a></li> <!-- TODO: Once testresults/logs.html is implementd change this link to it -->
 			<li><a href="apitools/analysis/html/index.html"><b>API Tools Version Verification Report</b></a>
 				This tool verifies the versions of the plugins against Eclipse ${previousReleaseAPILabel}
 				(Exclusions listed in <a href="https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob//eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt">apiexclude/exclude_list_external.txt</a>).


### PR DESCRIPTION
There was a TODO added in
d69c793#diff-b313c31bda76f031d731c30cd7d1166bf24e73622534768a0e726417d66103edR25

Until the "proper" testresults/logs.html is implemented, let just point to directory with log files.

Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3574