### PR TITLE
Eliminate includes of 3rd party bundles in features.

### DIFF
--- a/eclipse.platform.releng/features/org.eclipse.platform-feature/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.platform-feature/feature.xml
@@ -32,16 +32,12 @@
          id="org.eclipse.help"
          version="0.0.0"/>
 
-   <plugin
-         id="org.apache.ant"
-         version="0.0.0"/>
+   <requires>
+      <import plugin="org.apache.ant" version="1.10.15" match="compatible"/>
+   </requires>
 
    <plugin
          id="org.eclipse.ant.core"
-         version="0.0.0"/>
-
-   <plugin
-         id="com.jcraft.jsch"
          version="0.0.0"/>
 
    <plugin


### PR DESCRIPTION
- We don't need com.jcraft.jsch it's required by org.eclipse.jsch.core.
- Convert org.apache.ant to an import.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3585