### PR TITLE
Add org.eclipse.terminal.test to daily build tests

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/testManifest.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/publishingFiles/testManifest.xml
@@ -174,6 +174,9 @@
       name="org.eclipse.team.tests.core"
       type="test" />
     <logFile
+      name="org.eclipse.terminal.test"
+      type="test" />
+    <logFile
       name="org.eclipse.tests.urischeme"
       type="test" />
     <logFile

--- a/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.sdk.tests/feature.xml
@@ -391,4 +391,8 @@
          id="com.github.weisj.jsvg"
          version="0.0.0"/>
 
+   <plugin
+         id="org.eclipse.terminal.test"
+         version="0.0.0"/>
+
 </feature>

--- a/production/testScripts/configuration/sdk.tests/testScripts/test.xml
+++ b/production/testScripts/configuration/sdk.tests/testScripts/test.xml
@@ -1331,6 +1331,12 @@
   </target>
 
   <target
+    name="terminal"
+    depends="init">
+    <runTests testPlugin="org.eclipse.terminal.test" />
+  </target>
+
+  <target
     name="ui"
     depends="init">
     <runTests testPlugin="org.eclipse.ui.tests" />
@@ -1716,6 +1722,7 @@
     <antcall target="jfacedatabinding" />
     <antcall target="filebuffers" />
     <antcall target="teamcore" />
+    <antcall target="terminal" />
     <antcall target="uadoc" />
     <antcall target="uieditors" />
     <antcall target="uinavigator" />


### PR DESCRIPTION
The terminal tests are missing in the I-Build tests. This change adds the according configuration.

This requires the addition of an according `test.xml` to the test plugin first via:
- https://github.com/eclipse-platform/eclipse.platform/pull/2406