### PR TITLE
[RelEng] Fix final file transfer in indices updates

### DIFF
--- a/JenkinsJobs/Releng/updateIndex.jenkinsfile
+++ b/JenkinsJobs/Releng/updateIndex.jenkinsfile
@@ -87,8 +87,8 @@ pipeline {
 				}
 				sshagent(['projects-storage.eclipse.org-bot-ssh']) {
 					sh '''
-						rsync -avzh site-eclipse/. genie.releng@projects-storage.eclipse.org:${EP_ROOT}/eclipse/downloads/
-						rsync -avzh site-equinox/. genie.releng@projects-storage.eclipse.org:${EP_ROOT}/equinox/
+						rsync -rvzh site-eclipse/. genie.releng@projects-storage.eclipse.org:${EP_ROOT}/eclipse/downloads/
+						rsync -rvzh site-equinox/. genie.releng@projects-storage.eclipse.org:${EP_ROOT}/equinox/
 					'''
 				}
 			}


### PR DESCRIPTION
Fixes the following error
```
rsync: [generator] failed to set permissions on
"/home/data/httpd/download.eclipse.org/eclipse/downloads/.": Operation not permitted (1)
```

Follow-up on
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3554