### PR TITLE
Compute 'build type name' in build website's javascript

### DIFF
--- a/JenkinsJobs/Releng/promoteBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/promoteBuild.jenkinsfile
@@ -352,18 +352,10 @@ EOF
 	utilities.modifyJSON('buildproperties.json') { buildProperties ->
 		buildProperties.identifier = newDropID
 		buildProperties.label = newBuildLabel
-	if ("${DL_TYPE}" == 'R') {
-		buildProperties.kind = 'Release'
-	} else if (newBuildLabel.contains('RC')) {
-		buildProperties.kind = 'Release Candidate'
-	} else if ("${DL_TYPE}" == 'S') {
-		buildProperties.kind = 'Stable'
-	} else {
-		error "Unexpected DL_TYPE value, ${DL_TYPE}"
-	}
-		buildProperties.values().each{ value ->
+		// Update filenames in lists
+		for (value in buildProperties.values()) {
 			if (value instanceof List) {
-				value.each{ fileData ->
+				for (fileData in value) {
 					if('name' in fileData) {
 						fileData.name = fileData.name.replace(oldBuildLabel, newBuildLabel)
 					}

--- a/sites/eclipse/build/index.html
+++ b/sites/eclipse/build/index.html
@@ -17,7 +17,7 @@
 
 	<main>
 
-		<h2>Eclipse <span class="data-ref">${release}</span> <span class="data-ref">${kind}</span> Build: <span class="data-ref">${label}</span></h2>
+		<h2>Eclipse <span class="data-ref">${release}</span> <span class="data-ref">${buildTypeName}</span> Build: <span class="data-ref">${label}</span></h2>
 		<p id="build-state-container"></p>
 		<p>
 			This page provides access to the various deliverables of Eclipse Platform build along with its logs and tests.
@@ -109,6 +109,7 @@
 	</main>
 	<script>
 		loadPageData('buildproperties.json', data => {
+			data.buildTypeName = getBuildTypeName(data)
 			data.updatesP2RepositoryComposite = `https://download.eclipse.org/eclipse/updates/${data.releaseShort}`
 			const buildID = data.identifier
 			const buildType = buildID.charAt(0)

--- a/sites/eclipse/page.js
+++ b/sites/eclipse/page.js
@@ -55,6 +55,17 @@ function getBuildType(buildData) {
     return buildData.identifier.startsWith('Y') ? 'Y' : 'I'
 }
 
+function getBuildTypeName(buildData) {
+    const identifier = buildData.identifier
+    if (identifier.startsWith('R-')) {
+        return 'Release'
+    } else if (identifier.startsWith('S-')) {
+        return identifier.includes('RC') ? 'Release Candidate' : 'Stable'
+    } else {
+        return buildData.kind
+    }
+}
+
 function getWS(os) {
     if (os == 'win32') {
         return 'win32'

--- a/sites/equinox/build/index.html
+++ b/sites/equinox/build/index.html
@@ -18,7 +18,7 @@
 	</div>
 
 	<main>
-		<h2>Equinox <span class="data-ref">${kind}</span> Build: <span class="data-ref">${label}</span></h2>
+		<h2>Equinox <span class="data-ref">${buildTypeName}</span> Build: <span class="data-ref">${label}</span></h2>
 		<p id="build-state-container"></p>
 
 		<span id="build-timestamp"></span>
@@ -65,7 +65,10 @@
 
 	</main>
 	<script>
-		loadPageData('buildproperties.json')
+		loadPageData('buildproperties.json', data => {
+			data.buildTypeName = getBuildTypeName(data)
+			return data
+		})
 
 		contentPostProcessor = (mainElement, build) => {
 			document.title = `Equinox - ${build.label}`


### PR DESCRIPTION
This simplifies the RelEng tasks and places the display logic where it's used.