### PR TITLE
Add early variable resolution in build websites to reduce flickering

### DIFF
--- a/sites/eclipse/build/index.html
+++ b/sites/eclipse/build/index.html
@@ -110,18 +110,20 @@
 	<script>
 		loadPageData('buildproperties.json', data => {
 			data.buildTypeName = getBuildTypeName(data)
-			data.updatesP2RepositoryComposite = `https://download.eclipse.org/eclipse/updates/${data.releaseShort}`
-			const buildID = data.identifier
-			const buildType = buildID.charAt(0)
-			if (buildType == 'I' || buildType == 'Y') {
-				data.updatesP2RepositoryComposite += `-${buildType}-builds`
-			}
-			if (buildType == 'S') {
-				data.updatesP2RepositoryComposite += '-I-builds'
-				const timestamp = buildID.substring(buildID.lastIndexOf('-') + 1, buildID.length)
-				data.updatesP2Repository = `${data.updatesP2RepositoryComposite}/I${timestamp.substring(0, 8)}-${timestamp.substring(8, 12)}`
-			} else {
-				data.updatesP2Repository = `${data.updatesP2RepositoryComposite}/${buildID}`
+			if (data.releaseShort) {
+				data.updatesP2RepositoryComposite = `https://download.eclipse.org/eclipse/updates/${data.releaseShort}`
+				const buildID = data.identifier
+				const buildType = buildID.charAt(0)
+				if (buildType == 'I' || buildType == 'Y') {
+					data.updatesP2RepositoryComposite += `-${buildType}-builds`
+				}
+				if (buildType == 'S') {
+					data.updatesP2RepositoryComposite += '-I-builds'
+					const timestamp = buildID.substring(buildID.lastIndexOf('-') + 1, buildID.length)
+					data.updatesP2Repository = `${data.updatesP2RepositoryComposite}/I${timestamp.substring(0, 8)}-${timestamp.substring(8, 12)}`
+				} else {
+					data.updatesP2Repository = `${data.updatesP2RepositoryComposite}/${buildID}`
+				}
 			}
 			return data
 		})


### PR DESCRIPTION
Especially for Stable and Release builds most interpolated data, that are prominently shown at the top of the main page, can be derived from the drop-folder's name, which is contained in the page's URL/location. Using the identifier implied by the drop-folder allows to render the page with these most prominently visible variables already resolved initially and not only on the second pass, when the buildproperties.json is fetched. Thus this reduces flickering.