### PR TITLE
[I/Y-Build] Fix build of launcher bundles for Equinox build website

### DIFF
--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -537,14 +537,12 @@ pipeline {
 										-application org.eclipse.ant.core.antRunner \
 										-buildfile ${ECLIPSE_BUILDER_DIR}/equinox/buildConfigs/equinox-launchers/build.xml \
 										-data $CJE_ROOT/$TMP_DIR/workspace-publishEquinox \
-										-DbuildDir=$BUILD_ID \
 										-DbuildId=$BUILD_ID \
 										-DbuildRepo=$PLATFORM_REPO_DIR \
 										-DequinoxPostingDirectory=${EQUINOX_DROP_DIR} \
 										-Dequinox.build.configs=$ECLIPSE_BUILDER_DIR/equinox/buildConfigs \
 										-Djava.io.tmpdir=$CJE_ROOT/$TMP_DIR \
-										-v \
-										publish
+										-v
 									popd
 									
 									pushd ${EQUINOX_DROP_DIR}/${BUILD_ID}

--- a/eclipse.platform.releng.tychoeclipsebuilder/equinox/buildConfigs/equinox-launchers/build.xml
+++ b/eclipse.platform.releng.tychoeclipsebuilder/equinox/buildConfigs/equinox-launchers/build.xml
@@ -59,7 +59,7 @@
   <target name="compress">
     <!-- set the target based on which OS we are running on since there
     is a difference between unzip and untar/gunzip -->
-    <property name="archiveFullPath" value="${equinoxPostingDirectory}/${buildDir}/${archiveName}" />
+    <property name="archiveFullPath" value="${equinoxPostingDirectory}/${buildId}/${archiveName}" />
     <condition property="compress.target" value="compress-zip">
       <contains string="${archiveName}" substring=".zip" />
     </condition>


### PR DESCRIPTION
And reduce number of variables.

The native launcher bundle build was broken in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3554