### PR TITLE
Update Orbit, EMF, and CDT

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -35,18 +35,18 @@
       <unit id="org.apache.httpcomponents.core5.httpcore5-h2" version="5.4.0.v20251215-1000"/>
 
       <!-- This is the "normal" Orbit repository is expected to be updated on milestones and releases based on Orbit deliveries. -->
-      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202512211802"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202512260739"/>
     </location>
 
     <location includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <unit id="org.eclipse.emf.common" version="2.44.0.v20251025-0946"/>
-      <unit id="org.eclipse.emf.ecore" version="2.41.0.v20251025-0946"/>
+      <unit id="org.eclipse.emf.common" version="2.45.0.v20251210-1145"/>
+      <unit id="org.eclipse.emf.ecore" version="2.42.0.v20251210-1145"/>
       <unit id="org.eclipse.emf.ecore.change" version="2.17.0.v20250910-1205"/>
-      <unit id="org.eclipse.emf.ecore.xmi" version="2.39.0.v20250910-1205"/>
+      <unit id="org.eclipse.emf.ecore.xmi" version="2.40.0.v20251210-1145"/>
       <unit id="org.eclipse.emf.edit" version="2.23.0.v20250910-1205"/>
       <unit id="org.eclipse.emf.databinding" version="1.9.0.v20250910-1205"/>
       <unit id="org.eclipse.emf.databinding.edit" version="1.10.0.v20250910-1205"/>
-      <repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.44.0"/>
+      <repository location="https://download.eclipse.org/modeling/emf/emf/builds/milestone/S202601091312"/>
     </location>
 
     <location includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
@@ -70,17 +70,17 @@
       If one wants to use the terminal console feature in a product (e.g. EPP) one needs to include the bundle org.eclipse.debug.terminal.
      -->
     <location includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-       <repository location="https://download.eclipse.org/tools/cdt/releases/12.2/cdt-12.2.0"/>
-       <unit id="org.eclipse.cdt.core.native" version="6.5.0.202506201841"/>
+       <repository location="https://download.eclipse.org/tools/cdt/releases/12.3/cdt-12.3.0"/>
+       <unit id="org.eclipse.cdt.core.native" version="6.6.0.202512020204"/>
        <unit id="org.eclipse.cdt.core.linux" version="6.1.100.202402230238"/>
-       <unit id="org.eclipse.cdt.core.linux.x86_64" version="12.2.0.202509030008"/>
-       <unit id="org.eclipse.cdt.core.linux.ppc64le" version="12.2.0.202509030008"/>
-       <unit id="org.eclipse.cdt.core.linux.aarch64" version="12.2.0.202509030008"/>
-       <unit id="org.eclipse.cdt.core.linux.riscv64" version="12.2.0.202509030008"/>
-       <unit id="org.eclipse.cdt.core.macosx" version="12.2.0.202509030008"/>
-       <unit id="org.eclipse.cdt.core.win32" version="6.1.200.202505191828"/>
-       <unit id="org.eclipse.cdt.core.win32.x86_64" version="12.2.0.202509030008"/>
-       <unit id="org.eclipse.cdt.core.win32.aarch64" version="12.2.0.202509030008"/>
+       <unit id="org.eclipse.cdt.core.linux.x86_64" version="12.3.0.202512021919"/>
+       <unit id="org.eclipse.cdt.core.linux.ppc64le" version="12.3.0.202512021919"/>
+       <unit id="org.eclipse.cdt.core.linux.aarch64" version="12.3.0.202512021919"/>
+       <unit id="org.eclipse.cdt.core.linux.riscv64" version="12.3.0.202512021919"/>
+       <unit id="org.eclipse.cdt.core.macosx" version="12.3.0.202512021919"/>
+       <unit id="org.eclipse.cdt.core.win32" version="6.1.300.202512020204"/>
+       <unit id="org.eclipse.cdt.core.win32.x86_64" version="12.3.0.202512021919"/>
+       <unit id="org.eclipse.cdt.core.win32.aarch64" version="12.3.0.202512021919"/>
     </location>
 
     <!-- uncomment 'eclipse_home' location, with text editor, for use in Eclipse IDE


### PR DESCRIPTION
- Orbit is a new milestone with no content changes that affect the Platform.
- EMF is the latest 2.45 milestone.
- CDT is the latest  12.3 release.

Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3601