### PR TITLE
[RelEng] Add job to touch projects with unanticipated comparator errors

### DIFF
--- a/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
+++ b/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
@@ -399,14 +399,7 @@ pipeline {
 							echo "Skipping submodule without changes: ${submodulePath}"
 							return
 						}
-						def submoduleURL = sh(script: "git config remote.origin.url", returnStdout: true).trim()
-						// Extract repository path from e.g.: https://github.com/eclipse-platform/eclipse.platform.git
-						def expectedPrefix = 'https://github.com/'
-						def expectedSuffix = '.git'
-						if (!submoduleURL.startsWith(expectedPrefix) || !submoduleURL.endsWith(expectedSuffix)) {
-							error "Unexpected of submodule URL: ${submoduleURL}"
-						}
-						def repoName = submoduleURL.substring(expectedPrefix.length(), submoduleURL.length() - expectedSuffix.length())
+						def repoName = githubAPI.getCurrentRepositoriesGithubName()
 						githubAPI.createPullRequest(repoName, prHeadline, """\
 							Prepare development of Eclipse ${NEXT_RELEASE_VERSION}.
 							This complements:

--- a/JenkinsJobs/Releng/touchCompatorErrorProjects.jenkinsfile
+++ b/JenkinsJobs/Releng/touchCompatorErrorProjects.jenkinsfile
@@ -1,0 +1,101 @@
+// Constants read by job creation
+private static final _JOB_DESCRIPTION = '''
+For a a build with <em>comparator-errors</em>, touches all affected projects to enforce an update of their qualifier and creates PRs with thes corresponding changes.
+'''
+
+pipeline {
+	options {
+		timestamps()
+		timeout(time: 30, unit: 'MINUTES')
+		buildDiscarder(logRotator(numToKeepStr:'10', artifactNumToKeepStr:'2'))
+	}
+	parameters {
+		string(name: 'buildId', trim: true, description: '''
+			The identifier of the build with comparator-errors whoose affected Plugins should be touched.<br>
+			For example: <code>I20260111-0430</code>
+		''')
+		string(name: 'message', defaultValue: 'Enforce qualifier update', description: '''
+			The message appended to all touched qualifier-update files
+		''')
+	}
+	agent {
+		label 'basic'
+	}
+	stages {
+		stage('Checkout Submodules') {
+			steps {
+				sh '''#!/bin/bash -xe
+					git submodule update --init --recursive --remote --depth 1
+					git config --global user.email 'releng-bot@eclipse.org'
+					git config --global user.name 'Eclipse Releng Bot'
+				'''
+			}
+		}
+		stage('Touch projects with errors') {
+			steps {
+				script {
+					
+					def comparatorLog = sh(script: "curl --fail https://download.eclipse.org/eclipse/downloads/drops4/${buildId}/buildlogs/comparatorlogs/buildtimeComparatorUnanticipated.log.txt", returnStdout: true)
+					def errorEntries = comparatorLog.split(/(?m)^\d+\. +/).toList()
+					errorEntries = errorEntries.subList(1, errorEntries.size()) // Drop header
+					for(entry in errorEntries) {
+						def path = entry.readLines()[0].trim()
+						if(path.endsWith('/pom.xml') || path.endsWith('/.tycho-consumer-pom.xml')) {
+							path = path.substring(0, path.lastIndexOf('/'))
+						} else {
+							error("Unexpected path end: ${path}")
+						}
+						if (!fileExists("${path}/META-INF/MANIFEST.MF")) {
+							error("Computed path is not a Plugin root: ${path}")
+						}
+						def forceQualifierUpdateFile = "${path}/forceQualifierUpdate.txt"
+						sh """
+							echo 'Touching: ${path}'
+							if [ ! -f ${forceQualifierUpdateFile} ]; then
+								echo '# To force a version qualifier update add the bug here' >> ${forceQualifierUpdateFile}
+							fi
+							# Ensure file terminates with a newline
+							lastChar=\$(tail -c1 ${forceQualifierUpdateFile} | od -An -tx1)
+							if [ ! "\${lastChar}" = "0a" ] && [ ! "\${lastChar}" = "0d" ]; then
+								echo '' >> ${forceQualifierUpdateFile}
+							fi
+							echo '${message}' >> ${forceQualifierUpdateFile}
+						"""
+					}
+				}
+			}
+		}
+		stage('Create PRs') {
+			steps {
+				script {
+					def utilities = load "JenkinsJobs/shared/utilities.groovy"
+					utilities.setDryRun(false)
+					def githubAPI = load "JenkinsJobs/shared/githubAPI.groovy"
+					githubAPI.setDryRun(true)
+
+					utilities.runHereAndForEachGitSubmodule{ submodulePath ->
+						def boolean isUnchanged = sh(script: 'git status --short --ignore-submodules', returnStdout: true).trim().isEmpty()
+						if (isUnchanged) {
+							echo "Skipping repository without changes: ${submodulePath}"
+							return
+						}
+						def branch = 'enforce-qualifier-update'
+						def msg = 'Enforce qualifier update for project(s) with comparator errors'
+						sh """
+							echo 'Committing changes in ${submodulePath}'
+							git checkout -B '${branch}' HEAD
+							git commit --all --message '${msg}'
+						"""
+						
+						utilities.gitPushBranch(branch, branch)
+						def repoName = githubAPI.getCurrentRepositoriesGithubName()
+						def prURL = githubAPI.createPullRequest(repoName, msg, """\
+							Enforce qualifier update for project(s) with comparator error in build ${buildId}.
+							""".stripIndent(), branch)
+						echo "Created ${prURL}"
+					}
+				}
+			}
+		}
+	}
+}

--- a/JenkinsJobs/shared/githubAPI.groovy
+++ b/JenkinsJobs/shared/githubAPI.groovy
@@ -1,9 +1,9 @@
 
 @groovy.transform.Field
-def boolean IS_DRY_RUN = true
+def boolean _GH_API_IS_DRY_RUN = true
 
 def setDryRun(boolean isDryRun) {
-	IS_DRY_RUN = isDryRun
+	_GH_API_IS_DRY_RUN = isDryRun
 }
 
 /** Returns a list of all repositories in the specified organization.*/
@@ -72,7 +72,7 @@ def queryGithubAPI(String method, String endpoint, Map<String, Object> queryPara
 		def params = writeJSON(json: queryParameters, returnText: true)
 		query += "-d '" + params + "'"
 	}
-	if (IS_DRY_RUN && !method.isEmpty()) {
+	if (_GH_API_IS_DRY_RUN && !method.isEmpty()) {
 		echo "Query (not send): ${query}"
 		return null
 	}
@@ -90,6 +90,17 @@ def queryGithubAPI(String method, String endpoint, Map<String, Object> queryPara
 
 private boolean isFailed(Map response, int successCode) {
 	return response?.errors || (response?.status && response.status?.toInteger() != successCode)
+}
+
+def getCurrentRepositoriesGithubName() {
+	def submoduleURL = sh(script: "git config remote.origin.url", returnStdout: true).trim()
+	// Extract repository path from e.g.: https://github.com/eclipse-platform/eclipse.platform.git
+	def expectedPrefix = 'https://github.com/'
+	def expectedSuffix = '.git'
+	if (!submoduleURL.startsWith(expectedPrefix) || !submoduleURL.endsWith(expectedSuffix)) {
+		error "Unexpected of submodule URL: ${submoduleURL}"
+	}
+	return submoduleURL.substring(expectedPrefix.length(), submoduleURL.length() - expectedSuffix.length())
 }
 
 return this


### PR DESCRIPTION
This simplifies and speeds up the handling of e.g. comparator errors due to byte-code changes caused by compiler adjustments.
This also makes the last knowingly used code of the ['eclipse.platform.releng.buildtools'](https://github.com/eclipse-platform/eclipse.platform.releng.buildtools) repository obsolete:
- https://github.com/eclipse-platform/eclipse.platform.releng.buildtools/issues/106#issuecomment-3725340836