### PR TITLE
Escape message/code of compile logs and adapt filename in build website

### DIFF
--- a/scripts/releng/CompilerSummaryGenerator.java
+++ b/scripts/releng/CompilerSummaryGenerator.java
@@ -33,7 +33,7 @@ import utilities.XmlProcessorFactoryRelEng;
 /** @author Dean Roberts (circa 2000!) and David Williams (circa 2016) */
 
 final String XML_EXTENSION = ".xml";
-final String COMPILER_SUMMARY_FILENAME = "compilerSummary.json";
+final String COMPILER_SUMMARY_FILENAME = "logs.json";
 
 Path compileLogsDirectory; // Location of compile logs base directory
 

--- a/sites/eclipse/build/tests.html
+++ b/sites/eclipse/build/tests.html
@@ -186,13 +186,13 @@
 					severity = problem.getAttribute('severity')
 					const problemID = problem.getAttribute('id')
 					const line = parseInt(problem.getAttribute('line'))
-					const message = problem.querySelector('message').getAttribute('value')
+					const message = escapeHTML(problem.querySelector('message').getAttribute('value'))
 					const contextValue = problem.querySelector('source_context').getAttribute('value')
 					const sourceStart = parseInt(problem.querySelector('source_context').getAttribute('sourceStart'))
 					const sourceEnd = parseInt(problem.querySelector('source_context').getAttribute('sourceEnd')) + 1
-					const sourceCodeBefore = contextValue.substring(0, sourceStart)
-					const sourceCode = contextValue.substring(sourceStart, sourceEnd);
-					const sourceCodeAfter = contextValue.substring(sourceEnd, contextValue.length);
+					const sourceCodeBefore = escapeHTML(contextValue.substring(0, sourceStart))
+					const sourceCode = escapeHTML(contextValue.substring(sourceStart, sourceEnd))
+					const sourceCodeAfter = escapeHTML(contextValue.substring(sourceEnd, contextValue.length))
 					if (isMatchingIssue(issueType, severity, problemID)) {
 						elements += `
 						<tr class="no-zebra-striping">

--- a/sites/eclipse/page.js
+++ b/sites/eclipse/page.js
@@ -558,6 +558,13 @@ function prependChildren(element, id, ...children) {
     return element;
 }
 
+function escapeHTML(rawString) {
+    return rawString
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+}
+
 // Collapsibles/accordion tables
 
 let _eventListenersAdded = false


### PR DESCRIPTION
Both was missing in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3610