### PR TITLE
Rename tests.html page to reports.html in build website

### DIFF
--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -656,7 +656,7 @@ pipeline {
 			https://download.eclipse.org/eclipse/downloads/drops4/${BUILD_ID}
 			
 			Build logs and/or test results (eventually):
-			https://download.eclipse.org/eclipse/downloads/drops4/${BUILD_ID}/tests.html
+			https://download.eclipse.org/eclipse/downloads/drops4/${BUILD_ID}/reports.html#tests
 			""" + (env.COMPARATOR_ERRORS_SUBJECT == '' ? '' : """
 			Check unanticipated comparator messages:
 			https://download.eclipse.org/eclipse/downloads/drops4/${BUILD_ID}/buildlogs/comparatorlogs/buildtimeComparatorUnanticipated.log.txt

--- a/JenkinsJobs/Releng/updateIndex.jenkinsfile
+++ b/JenkinsJobs/Releng/updateIndex.jenkinsfile
@@ -52,10 +52,15 @@ pipeline {
 										find \${drop}/testresults -maxdepth 1 -type f -name "ep*-unit-*.json" ! -name "ep*-unit-*-summary.json" | wc -l
 										# Count number of old-style test-result overview files (still relevant for not yet archived releases)
 										find \${drop}/testresults -maxdepth 1 -type f -name "ep*-unit-*.xml" | wc -l
-										if [  -f \${drop}/index.html ]; then
-											echo "style-new"
+										#TODO: Remove this after the next three release when there are no old old-style tests on the overview page anymore
+										if [ -f \${drop}/reports.html ]; then
+											echo 'reports.html#tests'
+										elif [ -f \${drop}/tests.html ]; then
+											echo 'tests.html'
+										elif [ -f \${drop}/testResults.php ]; then
+											echo 'testResults.php'
 										else
-											echo "style-old"
+											echo 'unknown'
 										fi
 										if [  -f \${drop}/buildUnstable ]; then
 											echo "unstable"
@@ -113,11 +118,10 @@ def parseEclipseBuildDrops(String buildDrops) {
 		def int testsExpected = Integer.parseInt(dropDataElements[1])
 		def int testsFinishedNew = Integer.parseInt(dropDataElements[2])
 		def int testsFinishedOld = Integer.parseInt(dropDataElements[3])
-		def boolean isNewStyleDrop = dropDataElements[4] == 'style-new'
 		def boolean isUnstable = dropDataElements.length > 5 && dropDataElements[5] == 'unstable'
 		def drop = createDropEntry(dropID, 'drops4', isUnstable, overview)
 		drop.testsCompletion = "${ testsFinishedNew + testsFinishedOld } of ${testsExpected}".toString()
-		drop.testsPath = isNewStyleDrop ? 'tests.html' : 'testResults.php'
+		drop.testsPath = dropDataElements[4]
 	}
 	overview.values().each{ list -> list.sort({d1, d2 -> -d1.label.compareTo(d2.label)})}
 	return overview

--- a/sites/eclipse/build/index.html
+++ b/sites/eclipse/build/index.html
@@ -35,8 +35,8 @@
 
 		<h3>Logs and Test Links</h3>
 		<ul>
-			<li>View the <a href="tests.html">logs for the current build</a>.</li>
-			<li>View the <a href="tests.html">integration and unit test results for the current build.</a>.</li>
+			<li>View the <a href="reports.html#logs">logs for the current build</a>.</li>
+			<li>View the <a href="reports.html#tests">integration and unit test results for the current build.</a>.</li>
 		</ul>
 
 		<h3 id="tests">Summary of Unit Test Results</h3>
@@ -145,7 +145,7 @@
 					const result = testResults[r]
 					const testName = build.expectedTests[r]
 					//TODO: compute nicer, non-breaking label (like for file Platforms?) and align elements horizontally
-					const label = `<a href="tests.html">${testName}</a>`
+					const label = `<a href="reports.html#tests">${testName}</a>`
 					if (result.duration) { // Test configuration completed
 						completedTests++
 						row.innerHTML = `

--- a/sites/eclipse/build/reports.html
+++ b/sites/eclipse/build/reports.html
@@ -3,7 +3,7 @@
 
 <head>
 	<!--TODO: set proper metadata/keywords? -->
-	<title>Test Results</title>
+	<title>Reports</title>
 	<meta name="keywords" content="eclipse,project,plug-ins,plugins,java,ide,swt,refactoring,free java ide,tools,platform,open source,development environment,development,ide" />
 	<link rel="preconnect stylesheet" href="../page.css" /><!-- Replaced by a refernece to a contained copy on deployment -->
 	<script src="../page.js"></script><!-- Replaced by a refernece to a contained copy on deployment -->
@@ -13,11 +13,11 @@
 	<div data-generate="generateDefaultBreadcrumb(this, eclipseBreadcrumbBase)">
 		<a href="../..">Downloads</a>
 		<a class="data-ref" href=".">${label}</a>
-		<span>Test Results</span>
+		<span>Reports</span>
 	</div>
 
 	<main>
-		<h2>Test Results for <a class="data-ref" href=".">${label}</a></h2>
+		<h2>Reports for <span class="data-ref">${label}</span></h2>
 		<h3 id="logs">Logs</h3>
 		<ul class="data-ref">
 			<li><a href="buildlogs/reporeports/index.html"><b>Repository Reports </b></a></li>
@@ -30,7 +30,7 @@
 			<li><a href="apitools/deprecation/apideprecation.html"><b>API Tools Deprecation Report</b></a> This tool generates a report for API deprecated since ${previousReleaseAPILabel}.</li>
 			<li><a href="apitools/apifilters-${label}.zip"><b>Zip of <samp>.api_filters</samp> files used in the build</b></a></li>
 		</ul>
-		<h3 id="test-results">Unit Test Results</h3>
+		<h3 id="tests">Unit Test Results</h3>
 		<p>The unit tests are run on the <a id="ci-tests-folder-url" href="https://ci.eclipse.org/releng">RelEng Jenkins instance</a>.</p>
 		<p>
 			The table shows the unit test results for this build on the platforms tested.


### PR DESCRIPTION
The page previously named tests.html reports test results and compiler issues and lists multiple other reports.