### PR TITLE
Show code tasks in compile logs of build website

### DIFF
--- a/sites/eclipse/build/reports.html
+++ b/sites/eclipse/build/reports.html
@@ -54,18 +54,18 @@
 			<tbody id="test-results-summary"></tbody>
 		</table>
 
-		<h3 id="compiler-issues">Plugins containing compile warnings or infos</h3>
+		<h3 id="compiler-issues">Compile issues</h3>
 		<p>
-			The table below shows the plugins in which warnings were encountered.
+			The table below shows the plugins in which warnings, infos or open tasks were encountered.
 			Click on the jar file's row to view its detailed report.
 		</p>
 		<table class="styled-table">
 			<thead>
 				<tr>
 					<th>Compile Logs (Jar Files)</th>
-					<th style="text-align: center">General Warnings</th>
-					<th style="text-align: center">Access Warnings</th>
-					<th style="text-align: center">Infos</th>
+					<th style="text-align: center;width: 20%;">Warnings</th>
+					<th style="text-align: center;width: 20%;">Infos</th>
+					<th style="text-align: center;width: 20%;">Tasks</th>
 				</tr>
 			</thead>
 			<tbody id="compiler-issues-body"></tbody>
@@ -139,16 +139,16 @@
 				row.classList.add('collapsible-table-main-row')
 				insertLeanCell(row, false).innerHTML = shortName
 				addLinkCell(row, `${shortName}--warnings`, issues.warnings)
-				addLinkCell(row, `${shortName}--access_warnings`, issues.access)
 				addLinkCell(row, `${shortName}--infos`, issues.infos)
+				addLinkCell(row, `${shortName}--tasks`, issues.tasks)
 				// Details row (collapsed by default)
 				const detailsRow = compilerIssues.insertRow()
 				detailsRow.classList.add('collapsible-table-details-row')
 
 				const content = ''
-					+ (issues.warnings > 0 ? getDetailsContent(logFile, shortName, 'warnings') : '')
-					+ (issues.access > 0 ? getDetailsContent(logFile, shortName, 'access_warnings') : '')
-					+ (issues.infos > 0 ? getDetailsContent(logFile, shortName, 'infos') : '')
+					+ (issues.warnings > 0 ? getDetailsContent(logFile, shortName, 'warning') : '')
+					+ (issues.infos > 0 ? getDetailsContent(logFile, shortName, 'info') : '')
+					+ (issues.tasks > 0 ? getDetailsContent(logFile, shortName, 'task') : '')
 
 				detailsRow.innerHTML = `<td colspan="${row.cells.length}">${content}</td>
 					`
@@ -160,7 +160,7 @@
 			}
 
 			function getDetailsContent(logFile, shortName, issueType) {
-				return appendCopyLinkButton(`<h4 id="${shortName}--${issueType}"><b>${issueType.toUpperCase().replace('_', ' ')} in org.eclipse.${shortName}</b></h4>`) + `
+				return appendCopyLinkButton(`<h4 id="${shortName}--${issueType}s"><b>${issueType.toUpperCase()}S in org.eclipse.${shortName}</b></h4>`) + `
 				<div class="data-loader" data-supplier="parseCompileLogXML('${logFile}')" data-processor="generateCompileLog(arg,'${logFile}','${issueType}')"></div>
 				`
 			}
@@ -174,43 +174,42 @@
 
 		function generateCompileLog(compileLogXML, logFile, issueType) {
 			let content = ''
-			for (const fileProblems of compileLogXML.getElementsByTagName('problems')) {
-				const source = fileProblems.parentNode
+			const elementType = issueType == 'task' ? 'task' : 'problem'
+			const expectedSeverity = issueType.toUpperCase()
+			for (const fileIssues of compileLogXML.getElementsByTagName(`${elementType}s`)) {
+				const source = fileIssues.parentNode
 				const sourceFileName = computeRelativeFilePath(source, logFile)
-				const warnings = parseInt(fileProblems.getAttribute('warnings'))
-				const infos = parseInt(fileProblems.getAttribute('infos'))
-				let counter = 0
-				let elements = ''
-				let severity;
-				for (problem of fileProblems.getElementsByTagName('problem')) {
-					severity = problem.getAttribute('severity')
-					const problemID = problem.getAttribute('id')
-					const line = parseInt(problem.getAttribute('line'))
-					const message = escapeHTML(problem.querySelector('message').getAttribute('value'))
-					const contextValue = problem.querySelector('source_context').getAttribute('value')
-					const sourceStart = parseInt(problem.querySelector('source_context').getAttribute('sourceStart'))
-					const sourceEnd = parseInt(problem.querySelector('source_context').getAttribute('sourceEnd')) + 1
-					const sourceCodeBefore = escapeHTML(contextValue.substring(0, sourceStart))
-					const sourceCode = escapeHTML(contextValue.substring(sourceStart, sourceEnd))
-					const sourceCodeAfter = escapeHTML(contextValue.substring(sourceEnd, contextValue.length))
-					if (isMatchingIssue(issueType, severity, problemID)) {
-						elements += `
-						<tr class="no-zebra-striping">
-							<td style="padding-top:6px; padding-bottom:8px; padding-left:4px; padding-right:4px;">
-								<b>${++counter}.</b> <i>${message}</i>
-								${createCodeEditorBlock(line, `${sourceCodeBefore}${applyCodeMarker(severity.toLowerCase(), sourceCode)}${sourceCodeAfter}`)}
-							</td>
-						</tr>
-						`
-					}
-				}
-				if (counter > 0) {
+				const itemCount = parseInt(fileIssues.getAttribute(`${issueType}s`))
+				if (itemCount > 0) {
 					content += `
-						<h5><b><code>${sourceFileName}</code>: ${counter}&nbsp;${severity.toLowerCase()}${counter > 1 ? 's' : ''}</b></h5>
+						<h5><b><code>${sourceFileName}</code>: ${itemCount}&nbsp;${issueType}${itemCount > 1 ? 's' : ''}</b></h5>
 						<table><tbody>
-							${elements}
-						</tbody></table>
 					`
+					let counter = 0
+					for (issue of fileIssues.getElementsByTagName(elementType)) {
+						if (elementType != 'problem' || expectedSeverity == issue.getAttribute('severity')) {
+							const message = escapeHTML(issue.querySelector('message').getAttribute('value'))
+							content += `
+								<tr class="no-zebra-striping">
+									<td style="padding-top:6px; padding-bottom:8px; padding-left:4px; padding-right:4px;">
+										<b>${++counter}.</b> <i>${message}</i>
+							`
+							const sourceContext = issue.querySelector('source_context')
+							if (sourceContext) {
+								const contextValue = sourceContext.getAttribute('value')
+								const sourceStart = parseInt(sourceContext.getAttribute('sourceStart'))
+								const sourceEnd = parseInt(sourceContext.getAttribute('sourceEnd')) + 1
+
+								const sourceCodeBefore = escapeHTML(contextValue.substring(0, sourceStart))
+								const sourceCode = escapeHTML(contextValue.substring(sourceStart, sourceEnd))
+								const sourceCodeAfter = escapeHTML(contextValue.substring(sourceEnd, contextValue.length))
+								const line = parseInt(issue.getAttribute('line'))
+								content += `${createCodeEditorBlock(line, `${sourceCodeBefore}${applyCodeMarker(issueType, sourceCode)}${sourceCodeAfter}`)}`
+							}
+							content += '</td> </tr>'
+						}
+					}
+					content += '</tbody></table>'
 				}
 			}
 			return content
@@ -240,17 +239,6 @@
 				throw new Error(`Plugin name <${pluginName}>not found in path: ${filePath}`)
 			}
 			return filePath.substring(pluginNameIndex + pluginName.length + 1, filePath.length)
-		}
-
-		const apiWarningIDs = new Set(['ForbiddenReference', 'DiscouragedReference'])
-
-		function isMatchingIssue(expectedType, severity, problemId) {
-			switch (expectedType) {
-				case "warnings": return severity == 'WARNING' && !apiWarningIDs.has(problemId)
-				case "access_warnings": return severity == 'WARNING' && apiWarningIDs.has(problemId)
-				case "infos": return severity == 'INFO'
-				default: throw new Error(`Unexpected type: ${expectedType}`)
-			}
 		}
 
 		function insertLeanCell(row, center) {

--- a/sites/eclipse/page.css
+++ b/sites/eclipse/page.css
@@ -5,6 +5,7 @@
 	--marker-error: red;
 	--marker-warning: orange;
 	--marker-info: dodgerblue;
+	--marker-task: dodgerblue;
 }
 
 .breadcrumbs-default-margin {


### PR DESCRIPTION
and merge general and access warnings into a single warnings column. Also handle warnings without code-context (issued only directly on the file).

The Eclipse-SDK doesn't have access warnings anymore since the remaining once where suppressed (they cannot be resolved):
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/3698