### PR TITLE
Fix notification for unsuccessful smoke tests on platform-releng mailing list

### DIFF
--- a/JenkinsJobs/AutomatedTests/smokeTests.jenkinsfile
+++ b/JenkinsJobs/AutomatedTests/smokeTests.jenkinsfile
@@ -66,16 +66,11 @@ pipeline {
 	post {
         unsuccessful {
             emailext subject: "Smoke test for ${buildId} - ${currentBuild.currentResult}", 
-            body: "Smoke Tests failed. Please go to ${BUILD_URL} and check the build failure",
-            to: "sravankumarl@in.ibm.com sravan.lakkimsetti@gmail.com rahul.mohanan@ibm.com",
+            body: "Smoke tests failed for this build. Please review the logs at ${BUILD_URL} to identify the cause.",
+            to: "platform-releng-dev@eclipse.org",
             from:"genie.releng@eclipse.org"
         }
-        success {
-            emailext subject: "Smoke test for ${buildId} - SUCCESS",
-            body: "Smoke Tests successful: ${BUILD_URL}",
-            to: "sravankumarl@in.ibm.com sravan.lakkimsetti@gmail.com rahul.mohanan@ibm.com",
-            from:"genie.releng@eclipse.org"
-        }
+        
 	}
 }
 


### PR DESCRIPTION
Send notification to platform-releng mailing list for unsuccessful smoke test results to improve build failure visibility.