### PR TITLE
Add org.eclipse.core.tools to org.eclipse.releng.testsIU

### DIFF
--- a/sites/eclipse-platform-repository/category.xml
+++ b/sites/eclipse-platform-repository/category.xml
@@ -36,6 +36,9 @@
       <category name="org.eclipse.releng.pde.categoryIU"/>
    </feature>
    <feature id="org.eclipse.pde.osgitest.dependencies.feature"/>
+   <feature id="org.eclipse.core.tools">
+      <category name="org.eclipse.releng.testsIU"/>
+   </feature>
    <bundle id="jakarta.annotation-api" version="1.3.5"/>
    <bundle id="jakarta.inject.jakarta.inject-api" version="1.0.5"/>
    <bundle id="org.eclipse.equinox.slf4j"/>


### PR DESCRIPTION
- This is the category labeled `Eclipse Tests, Tools, Examples, and Extras`  with description `Collection of Misc. Features, such as unit tests, SWT and e4 tools, examples, and compatibility features not shipped as part of main SDK, but which some people may desire in creating products based on previous versions of Eclipse.`.

https://github.com/eclipse-platform/eclipse.platform/issues/2457