### PR TITLE
[RelEng] Clear doc-bundle comparator errors for 4.40 release

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/forceQualifierUpdate.txt
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/forceQualifierUpdate.txt
@@ -1,1 +1,1 @@
-Regen for I20260111-0430
+Enforce qualifier update for 4.40 release

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/forceQualifierUpdate.txt
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/forceQualifierUpdate.txt
@@ -1,1 +1,1 @@
-Regen for I20260111-0430
+Enforce qualifier update for 4.40 release


### PR DESCRIPTION
Looking at the latest I-build we have comparator errors for two documentation bundles
- https://download.eclipse.org/eclipse/downloads/drops4/I20260224-0350/buildlogs/comparatorlogs/buildtimeComparatorDocBundle.log.txt

These should be cleared for the release, as otherwise the documentation might be out of sync with the documented code.
This should be submitted for the I-build that will probably be RC2 (tomorrow evening) and it should be verified that the I-build eventually promoted to RC2 doesn't have new comparator errors in any doc bundle. In case  the latter occurs the affected bundle has to be touched and another I-build has to be started, becoming the new RC2.
Before promoting the final RC to release it should be checked again that there are no comparator-errors in doc-bundles.

That being said, I think this should be documented in the release preparation documentation (it could be that I have removed it recently and replaced it with a touch in the beginning of a dev-cycle, when I've not fully understand that it's important to do this at the very end).
Furthermore I think the promotion job should ensure that every promted build have doc-bundles that are in-sync and should fail clearly otherwise (of course documenting it for previous verification will also simplify it).
I'll update the documentation and promotion pipeline in this regard.