### PR TITLE
[RelEng] Fix name of p2.inf files for products in preparation pipeline

### DIFF
--- a/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
+++ b/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
@@ -160,10 +160,10 @@ pipeline {
 					"ECLIPSE_RUN_REPO=\".*\"" : "ECLIPSE_RUN_REPO=\"https://download.eclipse.org/eclipse/updates/${NEXT_RELEASE_VERSION}-I-builds/\"",
 					"NEXT_JAVA_RELEASE_DATE=\".*\"" : "NEXT_JAVA_RELEASE_DATE=\"${NEXT_JAVA_RELEASE_DATE}\"",
 				])
-				replaceInFile('products/eclipse-platform/p2.inf', [
+				replaceInFile('products/eclipse-platform/platform.p2.inf', [
 					"${PREVIOUS_RELEASE_VERSION} Release" : "${NEXT_RELEASE_VERSION} Release",
 				])
-				replaceInFile('products/eclipse-sdk/p2.inf', [
+				replaceInFile('products/eclipse-sdk/sdk.p2.inf', [
 					"${PREVIOUS_RELEASE_VERSION} Release" : "${NEXT_RELEASE_VERSION} Release",
 				])
 				replaceInFile('eclipse.platform.releng/features/org.eclipse.platform-feature/rootfiles/.eclipseproduct', [


### PR DESCRIPTION
This was incorrectly changed in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3480