### PR TITLE
Align version of org.eclipse.jdt.doc.user with release version

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/META-INF/MANIFEST.MF
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.doc.user; singleton:=true
-Bundle-Version: 3.15.2900.qualifier
+Bundle-Version: 4.40.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.2.0,4.0.0)"


### PR DESCRIPTION
This simplifies the RelEng process because the bundle's version is automatically increment as part of the usual release preparation. This is already the case for the other doc-bundles that are also very likely to change during a development cycle.

This is similar to
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3527

With this, all doc bundles, except the tips bundles have their version aligned and will be bumped upon release preparation.
This makes sense because all of them very likely change within each release.