### PR TITLE
[RelEng] Disable validation when adding child to composite repository

### DIFF
--- a/JenkinsJobs/Releng/modifyP2CompositeRepository.jenkinsfile
+++ b/JenkinsJobs/Releng/modifyP2CompositeRepository.jenkinsfile
@@ -46,6 +46,7 @@ pipeline {
 						-Dp2.composite.children.add=${params.add} \\
 						-Dp2.composite.children.remove=${params.remove} \\
 						-Dp2.composite.children.limit=${params.sizeLimit ?: 0} \\
+						-Dp2.composite.validate=false \\
 						${params.repositoryName ? ("-Dp2.repository.name='" + params.repositoryName + "'") : ''} \\
 				"""
 					sshagent(['projects-storage.eclipse.org-bot-ssh']) {


### PR DESCRIPTION
Not verifying the existing of the child to add can increase the robustness of the operation (it guards against false negative existence check results due to server-side caching issues).
And the added child repositories are expected to always exist anyways, otherwise it's a programming/configuration error.

This will hopefully prevent a similar failure like today when preparing the new development cycle:
- https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6088#note_6430785