### PR TITLE
[Build] Update to cbi-plugins 1.5.4

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -67,7 +67,7 @@
 
     <tycho.version>5.0.2</tycho.version>
 
-    <cbi-plugins.version>1.5.4-SNAPSHOT</cbi-plugins.version>
+    <cbi-plugins.version>1.5.4</cbi-plugins.version>
     <surefire.version>3.5.5</surefire.version>
 
     <eclipse-sdk-repo>https://download.eclipse.org/eclipse/updates/${releaseVersion}-I-builds/</eclipse-sdk-repo>


### PR DESCRIPTION
It seems like version 1.5.4 of the Eclipse cbi-plugins was released.
At least the snapshot repository is is empty
https://repo.eclipse.org/content/repositories/cbi/org/eclipse/cbi/maven/plugins/eclipse-jarsigner-plugin/1.5.4-SNAPSHOT/

and the release folder is not:
https://repo.eclipse.org/content/repositories/cbi/org/eclipse/cbi/maven/plugins/eclipse-jarsigner-plugin/1.5.4/

But I find it strange that there was no corresponding preparation of the subsequent development cycle in
- https://github.com/eclipse-cbi/org.eclipse.cbi/commits/main/maven-plugins/eclipse-jarsigner-plugin