### PR TITLE
Ignore -jdk suffix for updates.

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/update-rules.xml
+++ b/eclipse.platform.releng.prereqs.sdk/update-rules.xml
@@ -5,23 +5,13 @@
 	<!-- see https://www.mojohaus.org/versions/versions-maven-plugin/version-rules.html -->
 	<!-- see https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#special -->
 	<ignoreVersions>
-		<ignoreVersion type="regex">.+[-.](?i:alpha|beta|M|RC)\d*$</ignoreVersion>
+		<ignoreVersion type="regex">.+[-.](?i:alpha|beta|M|RC|jdk)\d*$</ignoreVersion>
 	</ignoreVersions>
 	
 	<rules>
 		<rule groupId="jakarta.inject" comparisonMethod="maven">
 			<ignoreVersions>
 				<ignoreVersion>2.0.1.MR</ignoreVersion>
-			</ignoreVersions>
-		</rule>
-		<rule groupId="biz.aQute.bnd" artifactId="biz.aQute.tester.junit-platform" comparisonMethod="maven">
-			<ignoreVersions>
-				<ignoreVersion>7.2.0</ignoreVersion>
-			</ignoreVersions>
-		</rule>
-		<rule groupId="org.bndtools" artifactId="org.bndtools.templating" comparisonMethod="maven">
-			<ignoreVersions>
-				<ignoreVersion>7.2.0</ignoreVersion>
 			</ignoreVersions>
 		</rule>
 	</rules>


### PR DESCRIPTION
- Specifically net.bytebuddy 1.18.7-jdk5 where we expect there will be subsequent versions, e.g., 1.18.8-jdk5.
- Remove no-longer-used biz.aQute.bnd rules.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3680/