### PR TITLE
Limit PR creation in checkDependencies.yml to 10 open PRs

### DIFF
--- a/.github/workflows/checkDependencies.yml
+++ b/.github/workflows/checkDependencies.yml
@@ -73,32 +73,46 @@ jobs:
       max-parallel: 1
       fail-fast: false
     steps:
+      - name: List number of open PRs
+        id: list-prs
+        run: |
+            json_output=$(gh pr list -l 'dependency-check' -R $OWNER/$REPO -L 20 --json id)
+            echo "prs=$json_output" | tee -a "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: ${{ fromJson(steps.list-prs.outputs.prs)[9] == null }}
         with:
           fetch-depth: 0
           ref: master
       - name: Set up Maven
         uses: stCarolas/setup-maven@12eb41b233df95d49b0c11fc1b5bc8312e5d4ce0 # v5.1
+        if: ${{ fromJson(steps.list-prs.outputs.prs)[9] == null }}
         with:
           maven-version: ${{ inputs.mavenVersion }}
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        if: ${{ fromJson(steps.list-prs.outputs.prs)[9] == null }}
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: maven
       - name: Check ${{ matrix.bundles }} 
-        working-directory: ${{ matrix.bundles }} 
+        working-directory: ${{ matrix.bundles }}
+        if: ${{ fromJson(steps.list-prs.outputs.prs)[9] == null }}
         run: >-
           mvn -B -ntp ${{ inputs.maven-goals }} -DskipTests -Pdependency-check -Dtycho.dependency.check.apply=true
       - name: Create PR description file if missing
-        if: ${{ hashFiles(format('{0}/target/versionProblems.md', matrix.bundles)) == '' }}
+        if: ${{ hashFiles(format('{0}/target/versionProblems.md', matrix.bundles)) == '' && fromJson(steps.list-prs.outputs.prs)[9] == null }}
         working-directory: ${{ matrix.bundles }}
         run: |
           mkdir -p target
           echo '## No version problems detected' > target/versionProblems.md
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        if: ${{ fromJson(steps.list-prs.outputs.prs)[9] == null }}
         with:
           commit-message: Update version ranges of dependencies for ${{ matrix.bundles }}
           branch: dependency-check/${{ matrix.bundles }}
@@ -106,6 +120,7 @@ jobs:
           body-path: ${{ matrix.bundles }}/target/versionProblems.md
           delete-branch: true
           draft: false
+          labels: dependency-check
           token: ${{ secrets.token }}
           committer: ${{ inputs.author }}
           author: ${{ inputs.author }}


### PR DESCRIPTION
Add PR limiting mechanism matching the pattern in cleanCode.yml:
- Add list-prs step to count open PRs with 'dependency-check' label
- Add if conditions to skip steps when 10+ PRs already exist
- Label created PRs with 'dependency-check' for tracking

Marking this as a draft for now as we need to first cleanup the queue on P2 before we can apply the limits!