### PR TITLE
[RelEng] Unify and improve redirection pages on Downloads sites

### DIFF
--- a/JenkinsJobs/Releng/publishPromotedBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/publishPromotedBuild.jenkinsfile
@@ -119,19 +119,7 @@ pipeline {
 				]
 				
 				// Update html redirect to latest release updates repository
-				writeFile(file: 'index.html', text: """\
-					<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
-					<html>
-						<head>
-							<title>Eclipse</title>
-							<meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
-							<meta http-equiv="REFRESH" content="0;url=https://download.eclipse.org/eclipse/updates/${RELEASE_VERSION_MAJOR}.${RELEASE_VERSION_MINOR}/" />
-						</head>
-						<body>
-							This page will redirect to the <a href="https://download.eclipse.org/eclipse/updates/${RELEASE_VERSION_MAJOR}.${RELEASE_VERSION_MINOR}/">Eclipse latest release</a> repository.
-						</body>
-					</html>
-				""".stripIndent())
+				writeFile(file: 'index.html', text: utilities.redirectionPage("${RELEASE_VERSION_MAJOR}.${RELEASE_VERSION_MINOR}", 'Eclipse Updates', 'latest Eclipse release repository'))
 				sshagent(['projects-storage.eclipse.org-bot-ssh']) {
 					sh 'scp index.html genie.releng@projects-storage.eclipse.org:${DOWNLOAD_ROOT}/eclipse/updates/'
 				}

--- a/JenkinsJobs/Releng/updateIndex.jenkinsfile
+++ b/JenkinsJobs/Releng/updateIndex.jenkinsfile
@@ -89,11 +89,18 @@ pipeline {
 					utilities.writeJSON('site-eclipse/data.json', eclipseOverviewData)
 					def equinoxOverviewData = parseEquinoxBuildDrops(dropData[1])
 					utilities.writeJSON('site-equinox/data.json', equinoxOverviewData)
+					
+					// Redirection pages towards the eclipse downloads overview page
+					writeFile(file: 'downloads-index.html', text: utilities.redirectionPage('downloads', 'Eclipse Downloads'))
+					writeFile(file: 'drops4-index.html', text: utilities.redirectionPage('..', 'Eclipse Downloads'))
 				}
 				sshagent(['projects-storage.eclipse.org-bot-ssh']) {
 					sh '''
-						rsync -rvzh site-eclipse/. genie.releng@projects-storage.eclipse.org:${EP_ROOT}/eclipse/downloads/
-						rsync -rvzh site-equinox/. genie.releng@projects-storage.eclipse.org:${EP_ROOT}/equinox/
+						rsync -rvzh --checksum site-eclipse/. genie.releng@projects-storage.eclipse.org:${EP_ROOT}/eclipse/downloads/
+						rsync -rvzh --checksum site-equinox/. genie.releng@projects-storage.eclipse.org:${EP_ROOT}/equinox/
+						
+						rsync -rvzh --checksum downloads-index.html genie.releng@projects-storage.eclipse.org:${EP_ROOT}/eclipse/index.html
+						rsync -rvzh --checksum drops4-index.html genie.releng@projects-storage.eclipse.org:${EP_ROOT}/eclipse/downloads/drops4/index.html
 					'''
 				}
 			}

--- a/JenkinsJobs/shared/utilities.groovy
+++ b/JenkinsJobs/shared/utilities.groovy
@@ -123,6 +123,20 @@ def copyStaticWebsiteFiles(String gitRoot, String website) {
 	"""
 }
 
+def redirectionPage(String redirectionTarget, String title, String targetName = null) {
+	return """
+	<!DOCTYPE html>
+	<head>
+		<title>${title}</title>
+		<meta http-equiv="refresh" content="0;url=${redirectionTarget}">
+	</head>
+	<body>
+		Redirection to <a href="${redirectionTarget}">${targetName ?: title}</a>.
+	</body>
+	</html>
+	""".stripIndent()
+}
+
 // --- git operations ---
 
 def runHereAndForEachGitSubmodule(Closure task) {


### PR DESCRIPTION
This effectively puts the redirections towards
https://download.eclipse.org/eclipse/downloads/ under version control, which are placed at:
- https://download.eclipse.org/eclipse/index.html
- https://download.eclipse.org/eclipse/downloads/drops4/index.html

and improves their content to also provide a readable message and to redirect immediately and to the directory.
Before it was
- at download.eclipse.org/eclipse/index.html 
```
<meta http-equiv="Refresh" content="1; URL=downloads/">
```
- at download.eclipse.org/eclipse/downloads/drops4/index.html
```
<meta http-equiv="Refresh" content="0; URL=../index.html">
```

Furthermore, in the `Update Index` pipeline, enhance the remote rsync invocation to consider file-checksums when determining changes to avoid repeated overwrites of rarely changing files.