### PR TITLE
[Build] Replace deprecated overwrite parameter of maven-resources-plugin

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -291,7 +291,7 @@
             <id>saveproperties</id>
             <configuration>
               <outputDirectory>${project.build.directory}</outputDirectory>
-              <overwrite>true</overwrite>
+              <changeDetection>always</changeDetection>
               <resources>
                 <resource>
                   <directory>saveproperties</directory>
@@ -980,7 +980,7 @@
                 <phase>prepare-package</phase>
                 <configuration>
                   <outputDirectory>${project.build.directory}</outputDirectory>
-                  <overwrite>true</overwrite>
+                  <changeDetection>always</changeDetection>
                   <resources>
                     <resource>
                       <directory>${basedir}</directory>


### PR DESCRIPTION
Use `changeDetection=always` instead, which is the exact replacement More fine-grained control doesn't seem to be necessary for our use-cases.

Fixes numerous new Maven warnings:
```
Parameter 'overwrite' is deprecated: Use changeDetection instead.
```

Caused by
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3698