### PR TITLE
[RelEng] Migrate repo.eclipse.org links to new Nexus3 schema

### DIFF
--- a/JenkinsJobs/Releng/deployToMaven.jenkinsfile
+++ b/JenkinsJobs/Releng/deployToMaven.jenkinsfile
@@ -7,7 +7,7 @@ then deploys the artifacts for <code>Eclipse-Platform</code>, <code>JDT</code>, 
 </p>
 <ul>
 <li>
-Snapshots are deployed to <a href="https://repo.eclipse.org/content/repositories/eclipse-snapshots/">https://repo.eclipse.org/content/repositories/eclipse-snapshots/</a>.
+Snapshots are deployed to the <a href="https://repo.eclipse.org/content/repositories/eclipse-maven2-snapshots/">eclipse-maven2-snapshots/</a> repository.
 </li>
 <li>
 Releases are published to <a href="https://repo1.maven.org/maven2/org/eclipse/">Maven central</a> through the <a href="https://central.sonatype.org/publish/publish-portal-guide/">Central Portal</a>.
@@ -31,7 +31,7 @@ pipeline {
 			If left blank (not recommended), the latest I-build is deployed.
 			<ul>
 			<li>
-			Snapshots are deployed to <a href="https://repo.eclipse.org/content/repositories/eclipse-snapshots/">https://repo.eclipse.org/content/repositories/eclipse-snapshots/</a>.
+			Snapshots are deployed to the <a href="https://repo.eclipse.org/content/repositories/eclipse-maven2-snapshots/">eclipse-maven2-snapshots/</a> repository.
 			</li>
 			<li>
 			Releases are published to <a href="https://repo1.maven.org/maven2/org/eclipse/">Maven central</a> through the <a href="https://central.sonatype.org/publish/publish-portal-guide/">Central Portal</a>.
@@ -144,7 +144,7 @@ pipeline {
 										set +x
 										pomFolder=$(dirname ${pomFile})
 										if [ "${DEPLOYMENT_TYPE}" != 'release' ]; then
-											URL=https://repo.eclipse.org/content/repositories/eclipse-snapshots/
+											URL=https://repo.eclipse.org/content/repositories/eclipse-maven2-snapshots/
 											REPO_ID=repo.eclipse.org # server-id in the settings.xml, used for authentication
 											MAVEN_CENTRAL_URL=https://repo1.maven.org/maven2/${pomFolder%-SNAPSHOT}
 											echo "Checking ${MAVEN_CENTRAL_URL}"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The job with the highest release number is the one that builds nightly SDK build
 - If the tests fail to start, test jobs for each platform can be found at https://ci.eclipse.org/releng/job/AutomatedTests/
 - If the build is successful but relevant functionality is severely broken and the build shouldn't be used, the build can be marked as unstable via the [Mark Build](https://ci.eclipse.org/releng/job/Builds/job/markBuild/) job.
 - Daily Maven snapshots are provided by the [Deploy To Maven](https://ci.eclipse.org/releng/job/Releng/job/deployToMaven) job
-and are available from https://repo.eclipse.org/content/repositories/eclipse-snapshots/
+and are available from https://repo.eclipse.org/content/repositories/eclipse-maven2-snapshots/
 
 Milestone and release tasks
 -----------------

--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -82,16 +82,16 @@
     <comparator.repo>${eclipse-sdk-repo}</comparator.repo>
 
     <!-- only used when Tycho snapshot repo is enabled in <pluginRepositories> further down -->
-    <tycho-snapshot-repo.url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</tycho-snapshot-repo.url>
+    <tycho-snapshot-repo.url>https://repo.eclipse.org/content/repositories/tycho-maven2-snapshots/</tycho-snapshot-repo.url>
 
-    <eclipse-snapshots-repo.url>https://repo.eclipse.org/content/repositories/eclipse-snapshots/</eclipse-snapshots-repo.url>
+    <eclipse-snapshots-repo.url>https://repo.eclipse.org/content/repositories/eclipse-maven2-snapshots/</eclipse-snapshots-repo.url>
     <cbi-ecj-version>[3.39,)</cbi-ecj-version>
 
     <!--
       repo for released versions of CBI. Note, we intentionally use as specific a repo as possible.
       See bug 471835.
     -->
-    <eclipse-cbi-repo.url>https://repo.eclipse.org/content/repositories/cbi/</eclipse-cbi-repo.url>
+    <eclipse-cbi-repo.url>https://repo.eclipse.org/content/repositories/cbi-maven2/</eclipse-cbi-repo.url>
 
     <!--
       This eclipse-p2-repo.url is specifically for the build-individual-bundles profile.
@@ -161,12 +161,12 @@
     <repository>
       <id>repo.eclipse.org</id>
       <name>Eclipse Repository - Releases</name>
-      <url>https://repo.eclipse.org/content/repositories/eclipse-releases/</url>
+      <url>https://repo.eclipse.org/content/repositories/eclipse-maven2-releases/</url>
     </repository>
     <snapshotRepository>
       <id>repo.eclipse.org</id>
       <name>Eclipse Repository - Snapshots</name>
-      <url>https://repo.eclipse.org/content/repositories/eclipse-snapshots/</url>
+      <url>https://repo.eclipse.org/content/repositories/eclipse-maven2-snapshots/</url>
     </snapshotRepository>
   </distributionManagement>
   <pluginRepositories>

--- a/eclipse.platform.common/pom.xml
+++ b/eclipse.platform.common/pom.xml
@@ -69,7 +69,7 @@
             <enabled>true</enabled>
           </snapshots>
           <id>eclipse-hosted</id>
-          <url>https://repo.eclipse.org/content/repositories/eclipse/</url>
+          <url>https://repo.eclipse.org/content/repositories/eclipse-maven2/</url>
         </repository>
       </repositories>
     </profile>

--- a/eclipse.platform.releng/pom.xml
+++ b/eclipse.platform.releng/pom.xml
@@ -43,7 +43,7 @@
             <enabled>true</enabled>
           </snapshots>
           <id>eclipse-hosted</id>
-          <url>https://repo.eclipse.org/content/repositories/eclipse/</url>
+          <url>https://repo.eclipse.org/content/repositories/eclipse-maven2/</url>
         </repository>
       </repositories>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <pluginRepositories>
 	<pluginRepository>
 		<id>tycho-snapshots</id>
-		<url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</url>
+		<url>https://repo.eclipse.org/content/repositories/tycho-maven2-snapshots/</url>
 	</pluginRepository>
   </pluginRepositories>
   <modules>


### PR DESCRIPTION
Replace the last path segment in repo.eclipse.org URL using the following rules (with the project's short name):
- <short_name>-snapshots -> <short_name>-maven2-snapshots
- <short_name>-releases -> <short_name>-maven2-releases
- <short_name> -> <short_name>-maven2

Following the announcement at
- https://www.eclipse.org/lists/eclipse.org-committers/msg01548.html

This will hopefully fix the failure in deploying the parent-pom and sdk target to the eclipse maven snapshot repository.

In general the links in all submodules could be updated too, but atm. it seems like the redirects from the old schema still work.

