### PR TITLE
Add I-build tests for Java-26.

### DIFF
--- a/JenkinsJobs/buildConfigurations.json
+++ b/JenkinsJobs/buildConfigurations.json
@@ -34,6 +34,17 @@
 				}
 			},
 			{
+				"os": "linux",
+				"ws": "gtk",
+				"arch": "x86_64",
+				"javaVersion": 26,
+				"agent": "ubuntu-2404",
+				"jdk": {
+					"type": "tool",
+					"name": "openjdk-jdk26-latest"
+				}
+			},
+			{
 				"os": "macosx",
 				"ws": "cocoa",
 				"arch": "aarch64",


### PR DESCRIPTION
This enables testing with Java 26 in IBuild following the merge of beta_java26 into master.