### PR TITLE
Update links to outdated Eclipse-Wiki and PHP resources

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/pom.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2012, 2022 Eclipse Foundation and others.
+  Copyright (c) 2012, 2026 Eclipse Foundation and others.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10
 
   Contributors:
      Igor Fedorenko - initial implementation

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/tasks/task-add_new_jre.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/tasks/task-add_new_jre.htm
@@ -69,7 +69,7 @@
   <a id="EEFile"></a>
   <h2>Execution Environment Files:</h2>
   
-	<p>For more information on EE File structure see the <a href="http://wiki.eclipse.org/index.php/Execution_Environment_Descriptions">Wiki Page</a>.</p>
+	<p>For more information on EE File structure see the <a href="https://wiki.eclipse.org/Execution_Environment_Descriptions">Wiki Page</a>.</p>
 
 	<ol>
   <li> In the <strong>Definition home directory</strong> field, click <strong>File... 

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2012, 2018 Eclipse Foundation and others.
+  Copyright (c) 2012, 2026 Eclipse Foundation and others.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10
 
   Contributors:
      Igor Fedorenko - initial implementation

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/removals.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/removals.html
@@ -229,7 +229,7 @@ and explicitly enabled by specifying <code>-Declipse.e4.inject.javax.disabled=fa
 For further details or to provide feedback on this change, see <a href="https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1056">eclipse.platform.releng.aggregator#1056</a>.
 </p>
 For further information and possible long term compatibility strategies see
-<a href="https://eclipse.dev/eclipse/news/4.30/platform.php#support-jakarta-annotations">Eclipse 4.30 - New and Noteworthy: Support for Jakarta Annotations by Eclipse E4</a>.
+<a href="https://eclipse.dev/eclipse/news/news.html?file=4.30/platform.html#support-jakarta-annotations">Eclipse 4.30 - New and Noteworthy: Support for Jakarta Annotations by Eclipse E4</a>.
 
 <!-- ############################################## -->
 

--- a/eclipse.platform.releng/features/org.eclipse.platform-feature/pom.xml
+++ b/eclipse.platform.releng/features/org.eclipse.platform-feature/pom.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2012, 2014 Eclipse Foundation and others.
+  Copyright (c) 2012, 2026 Eclipse Foundation and others.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10
 
   Contributors:
      Igor Fedorenko - initial implementation

--- a/eclipse.platform.releng/features/org.eclipse.rcp/rootfiles/readme/readme_eclipse.html
+++ b/eclipse.platform.releng/features/org.eclipse.rcp/rootfiles/readme/readme_eclipse.html
@@ -34,7 +34,7 @@ have there. But in the "product's readme" it will point people
 to "the latest version" since there _might_ be changes made 
 after the release.
   <p>
-    The latest version of this document can be found on the web at <a href="https://www.eclipse.org/eclipse/development/readme_eclipse_4.33.php">Eclipse Release Notes 4.33</a>. There may or may
+    The latest version of this document can be found on the web at <a href="https://eclipse.dev/eclipse/development/readme_eclipse_4.33.html">Eclipse Release Notes 4.33</a>. There may or may
     not be changes made after the product is released. You can tell by checking the "last revised" date near the top of this page.
   </p>
 -->
@@ -188,7 +188,7 @@ after the release.
   </p>
   <p>
     Eclipse 4.33 is tested and validated on a number of reference platforms. For the complete list, see <a
-      href="https://www.eclipse.org/projects/project-plan.php?planurl=https://www.eclipse.org/eclipse/development/plans/eclipse_project_plan_4_33.xml#target_environments">Target Environments in the
+      href="https://eclipse.dev/eclipse/development/plans.html?file=plans/eclipse_project_plan_4_33.xml#target_environments">Target Environments in the
       4.33 Plan</a>.
   </p>
   <p>
@@ -408,7 +408,7 @@ after the release.
     <a
       class="mozTocH4"
       name="mozTocId828477"> The default Welcome implementation is HTML-based and requires a supported browser in order to work. If no supported browser can be found, Welcome falls back to its
-      Forms-based implementation, which has a different (simpler) appearance. Consult the </a><a href="https://www.eclipse.org/swt/faq.php#browserplatforms">SWT FAQ</a> for supported browsers and setting
+      Forms-based implementation, which has a different (simpler) appearance. Consult the </a><a href="https://eclipse.dev/eclipse/swt/faq.html#browserplatforms">SWT FAQ</a> for supported browsers and setting
     up your browser to work with eclipse.
   </p>
   <h4>
@@ -585,7 +585,7 @@ after the release.
     <a
       class="mozTocH4"
       name="mozTocId69222"> The SWT Browser widget uses a platform-specific web browser to render HTML. The org.eclipse.swt.SWTError exception ("No more handles") is thrown on platforms that don't
-      meet the requirements for running the Browser widget. Supported platforms and prerequisites are listed on the SWT FAQ item </a><a href="https://www.eclipse.org/swt/faq.php#browserplatforms">
+      meet the requirements for running the Browser widget. Supported platforms and prerequisites are listed on the SWT FAQ item </a><a href="https://eclipse.dev/eclipse/swt/faq.html#browserplatforms">
       "Which platforms support the SWT Browser?"</a>.
   </p>
   <h4>

--- a/oomph/PlatformSDKConfiguration.setup
+++ b/oomph/PlatformSDKConfiguration.setup
@@ -225,7 +225,7 @@
     and the API baseline is based on the most recent release.
     &lt;p>
     &lt;/p>
-    Please &lt;a href=&quot;https://wiki.eclipse.org/Eclipse_Platform_SDK_Provisioning&quot;>read the tutorial instructions&lt;/a> for more details.
+    Please &lt;a href=&quot;https://github.com/eclipse-ide/.github/blob/main/CONTRIBUTING.md&quot;>follow the general walkthrough&lt;/a> or &lt;a href=&quot;https://eclipse.dev/oomph/?file=Eclipse_Platform_SDK_Provisioning.md&quot;>read the tutorial instructions&lt;/a> for more details.
     &lt;/p>
   </description>
 </setup:Configuration>

--- a/products/eclipse-junit-tests/eclipse-junit-tests.product
+++ b/products/eclipse-junit-tests/eclipse-junit-tests.product
@@ -4,7 +4,7 @@
 <product name="eclipse-junit-tests" uid="eclipse-junit-tests" version="4.40.0.qualifier" type="mixed" includeLaunchers="false" autoIncludeRequirements="false">
 
    <license>
-        <url>http://eclipse.org/legal/epl/notice.php</url>
+        <url>https://www.eclipse.org/legal/epl/notice</url>
         <text>
    Eclipse Foundation Software User Agreement
 

--- a/products/eclipse-junit-tests/pom.xml
+++ b/products/eclipse-junit-tests/pom.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2012, 2014 Eclipse Foundation.
+  Copyright (c) 2012, 2026 Eclipse Foundation.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  https://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10
 
   Contributors:
      Igor Fedorenko - initial implementation

--- a/products/eclipse-junit-tests/src/main/scripts/JUNIT.XSL
+++ b/products/eclipse-junit-tests/src/main/scripts/JUNIT.XSL
@@ -427,7 +427,7 @@
         <td align="left">
             <a href="../../../">Downloads</a> / 
             <a href="../../">Build</a> / 
-            <a href="../../testResults.php">Test Results</a> | 
+            <a href="../../reports.html#tests">Test Results</a> | 
             <a href="../xml/{$filename}"><xsl:value-of select="$filename"/></a>
         </td>
         <td align="right">Designed for use with <a href='http://junit.org/'>JUnit</a> and <a href='https://ant.apache.org/'>Ant</a>.</td>

--- a/products/eclipse-junit-tests/src/main/scripts/library.xml
+++ b/products/eclipse-junit-tests/src/main/scripts/library.xml
@@ -19,7 +19,7 @@
     basedir=".">
 
     <target name="usage">
-        <echo message="Please refer to https://wiki.eclipse.org/Platform-releng/Eclipse_Test_Framework for instructions on usage." />
+        <echo message="Please refer to https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/wiki/Eclipse-Test-Framework for instructions on usage." />
     </target>
 
     <target
@@ -60,7 +60,7 @@
                            extraVMargs="-Dcompliance=1.7"
                            in some local version of testing scripts.
                            Can also be used to do "remote debugging"; See
-                           https://wiki.eclipse.org/Platform-releng/Automated_Testing#Running_Tests 
+                           https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/wiki/Automated-Testing#running-tests
 
             timeout       - overrides default test timeout value (in milliseconds). [May not currently override default?]
 

--- a/products/eclipse-platform/platform.product
+++ b/products/eclipse-platform/platform.product
@@ -38,7 +38,7 @@
    </vm>
 
    <license>
-        <url>http://eclipse.org/legal/epl/notice.php</url>
+        <url>https://www.eclipse.org/legal/epl/notice</url>
         <text>
    Eclipse Foundation Software User Agreement
 

--- a/products/eclipse-sdk/sdk.product
+++ b/products/eclipse-sdk/sdk.product
@@ -34,7 +34,7 @@
    </vm>
 
    <license>
-        <url>http://eclipse.org/legal/epl/notice.php</url>
+        <url>https://www.eclipse.org/legal/epl/notice</url>
         <text>
    Eclipse Foundation Software User Agreement
 

--- a/products/equinox-sdk/equinox-sdk.product
+++ b/products/equinox-sdk/equinox-sdk.product
@@ -4,7 +4,7 @@
 <product uid="org.eclipse.equinox.sdk.product" version="4.40.0.qualifier" useFeatures="true" includeLaunchers="false">
 
    <license>
-        <url>http://eclipse.org/legal/epl/notice.php</url>
+        <url>https://www.eclipse.org/legal/epl/notice</url>
         <text>
    Eclipse Foundation Software User Agreement
 

--- a/products/equinox-sdk/pom.xml
+++ b/products/equinox-sdk/pom.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2014, 2025 IBM Corporation, and others.
+  Copyright (c) 2014, 2026 IBM Corporation, and others.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  https://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10
 
   Contributors:
      David Williams - initial implementation

--- a/products/equinox-starterkit/EclipseRTOSGiStarterKit.product
+++ b/products/equinox-starterkit/EclipseRTOSGiStarterKit.product
@@ -30,7 +30,7 @@
    </vm>
 
    <license>
-        <url>http://eclipse.org/legal/epl/notice.php</url>
+        <url>https://www.eclipse.org/legal/epl/notice</url>
         <text>
    Eclipse Foundation Software User Agreement
 

--- a/products/equinox-starterkit/pom.xml
+++ b/products/equinox-starterkit/pom.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2012, 2025 Eclipse Foundation.
+	Copyright (c) 2012, 2026 Eclipse Foundation.
 	All rights reserved. This program and the accompanying materials
 	are made available under the terms of the Eclipse Distribution License v1.0
 	which accompanies this distribution, and is available at
-	https://www.eclipse.org/org/documents/edl-v10.php
+	https://www.eclipse.org/org/documents/edl-v10
 
 	Contributors:
 		Igor Fedorenko - initial implementation

--- a/products/pom.xml
+++ b/products/pom.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2012, 2025 IBM Corporation, and others.
+	Copyright (c) 2012, 2026 IBM Corporation, and others.
 	All rights reserved. This program and the accompanying materials
 	are made available under the terms of the Eclipse Distribution License v1.0
 	which accompanies this distribution, and is available at
-	https://www.eclipse.org/org/documents/edl-v10.php
+	https://www.eclipse.org/org/documents/edl-v10
 
 	Contributors:
 		Igor Fedorenko - initial implementation

--- a/scripts/declareMilestone.sh
+++ b/scripts/declareMilestone.sh
@@ -30,7 +30,7 @@ Eclipse downloads:
 https://download.eclipse.org/eclipse/downloads/drops4/${IBUILD}
 
 Build logs and/or test results (eventually):
-https://download.eclipse.org/eclipse/downloads/drops4/${IBUILD}/testResults.php
+https://download.eclipse.org/eclipse/downloads/drops4/${IBUILD}/reports.html
 
 Software site repository:
 https://download.eclipse.org/eclipse/updates/${STREAM}-I-builds

--- a/scripts/releng/BuildDropDataGenerator.java
+++ b/scripts/releng/BuildDropDataGenerator.java
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- *  Copyright (c) 2025, 2025 Hannes Wellmann and others.
+ *  Copyright (c) 2025, 2026 Hannes Wellmann and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -129,6 +129,7 @@ void mainEquinoxPageData() throws IOException {
 	buildProperties.add("identifier", JSON.String.create(buildId));
 	buildProperties.add("label", JSON.String.create(buildId));
 	buildProperties.add("kind", JSON.String.create(properties.get("BUILD_TYPE_NAME")));
+	buildProperties.add("releaseShort", JSON.String.create(properties.get("RELEASE_VER")));
 	buildProperties.add("timestamp", JSON.String.create(buildDate.toString()));
 
 	// files

--- a/sites/eclipse/build/buildlogs/logs.html
+++ b/sites/eclipse/build/buildlogs/logs.html
@@ -28,7 +28,7 @@
 		</ul>
 
 		<h3 id="comparator">Comparator Logs</h3>
-		<p>For explaination, see <a href="https://wiki.eclipse.org/Platform-releng/Platform_Build_Comparator_Logs">Platform Build Comparator Logs</a> wiki.</p>
+		<p>For explaination, see <a href="https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/wiki/Platform-Build-Comparator-Logs">Platform Build Comparator Logs</a> wiki.</p>
 		<ul id="comparator-logs">
 		</ul>
 		<p>For an archive of all relevant baseline-versus-current build artifact byte codes download and 'diff' matching files of

--- a/sites/eclipse/build/index.html
+++ b/sites/eclipse/build/index.html
@@ -27,8 +27,8 @@
 			<li><a class="data-ref" href="https://eclipse.dev/eclipse/news/${releaseShort}">New and Noteworthy</a></li>
 			<li><a class="data-ref" href="https://eclipse.dev/eclipse/markdown/?f=news/${releaseShort}/acknowledgements.md">Acknowledgments</a></li>
 			<li><a class="data-ref" href="https://eclipse.dev/eclipse/development/readme.html?file=readme_eclipse_${releaseShort}.html">Eclipse Project ${releaseShort} Readme</a></li>
-			<li><a class="data-ref" href="https://eclipse.dev/eclipse/development/plans.html?file=plans/eclipse_project_plan_${releaseShort}.xml">Eclipse Project Plan</a></li>
-			<li><a class="data-ref" href="https://eclipse.dev/eclipse/development/plans/eclipse_project_plan_${releaseShort}.xml#target_environments">Target Platforms and Environments</a></li>
+			<li><a class="data-ref" href="https://eclipse.dev/eclipse/development/plans.html?file=plans/eclipse_project_plan_${releaseShortUnderscore}.xml">Eclipse Project Plan</a></li>
+			<li><a class="data-ref" href="https://eclipse.dev/eclipse/development/plans.html?file=plans/eclipse_project_plan_${releaseShortUnderscore}.xml#target_environments">Target Platforms and Environments</a></li>
 		</ul>
 
 		<h3 id="reports">Reports</h3>
@@ -158,7 +158,7 @@ gpg: Can't check signature: public key not found
 		<dialog class="details-popup">
 			<h3>Tests and Testing Framework</h3>
 			These packages contain the Test Framework and JUnit Test Plug-ins used to run JUnit plug-in tests from the command line.
-			See the Platform's <a href="https://wiki.eclipse.org/Platform-releng/Automated_Testing">Automated Testing</a> wiki page for more information and setup instructions.
+			See the Platform's <a href="https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/wiki/Automated-Testing">Automated Testing</a> wiki page for more information and setup instructions.
 			Includes both source code and binary.
 		</dialog>
 		<table class="files-table" data-path="eclipseTests"></table>
@@ -230,6 +230,7 @@ gpg: Can't check signature: public key not found
 				} else {
 					data.updatesP2Repository = `${data.updatesP2RepositoryComposite}/${buildID}`
 				}
+				data.releaseShortUnderscore = data.releaseShort.replace('.', '_')
 			}
 			return data
 		})

--- a/sites/eclipse/overview/index.html
+++ b/sites/eclipse/overview/index.html
@@ -15,16 +15,20 @@
 
 	<main>
 		<h1>The Eclipse Project Downloads</h1>
-		<!--TODO: check all the links and migrate them if necessary-->
 		<p>
 			On this page you can find the latest builds produced by the <a href="https://www.eclipse.org/eclipse/">Eclipse Project</a>.
 			To get started, run the program and go through the user and developer documentation provided in the help system or see the <a href="https://help.eclipse.org/">web-based help system</a>.
-			If you have problems installing or getting the workbench to run, <a href="https://wiki.eclipse.org/The_Official_Eclipse_FAQs">check out the Eclipse Project FAQ</a>, or try posting a question to the <a href="https://www.eclipse.org/forums/">forum</a>.
+			If you have problems installing or getting the workbench to run, <a href="https://github.com/eclipse-platform/eclipse.platform/blob/master/docs/FAQ/The_Official_Eclipse_FAQs.md">check out the Eclipse Project FAQ</a>,
+			or try posting a question at the <em>Discussions</em> area of the affected
+			<a href="https://github.com/eclipse-platform/">Eclipse Platform</a>,
+			<a href="https://github.com/eclipse-equinox/">Equinox</a>,
+			<a href="https://github.com/eclipse-jdt/">JDT</a> or <a href="https://github.com/eclipse-pde/">PDE</a> repository
+			or just at <a href="https://github.com/eclipse-platform/.github/discussions">Eclipse Platform Discussions</a>.
 		</p>
 		<p>
 			See the <a href="https://www.eclipse.org/downloads/">main Eclipse Foundation download site</a> for convenient all-in-one packages.
 			The <a href="https://archive.eclipse.org/eclipse/downloads/">archive site</a> contains older releases (including the last 3.x version, <a href="https://archive.eclipse.org/eclipse/downloads/drops/R-3.8.2-201301310800/">3.8.2</a>).
-			For reference, see also the <a href="https://wiki.eclipse.org/Eclipse_Project_Update_Sites">p2 repositories provided</a>, and the <a href="https://www.eclipse.org/eclipse/platform-releng/buildSchedule.html">build schedule</a>.
+			For reference, see also the <a href="https://calendar.google.com/calendar/embed?src=prfk26fdmpru1mptlb06p0jh4s%40group.calendar.google.com">Eclipse Build and RelEng calendar</a>.
 		</p>
 		<h3 id="latest-downloads">Latest Downloads</h3>
 		<table class="builds-table" data-path="latest"></table>
@@ -32,9 +36,13 @@
 		<h3 id="latest-release">Latest Releases</h3>
 		<dialog class="details-popup">
 			<h3>Latest Releases</h3>
-			<em>Releases</em> are builds that have been declared as release for the general public - for example <code>R4.38</code>.
+			<em>Releases</em> are builds that have been declared as release for the general public.
 			Releases are the right builds for people who want to be on a stable, tested release, and don't need the latest greatest features and improvements.
-			Release builds always have an "R" at the beginning of the name i.e. <code>R4.0</code>, <code>R4.37</code> etc.
+			Release builds always have an "R" at the beginning of the name i.e. <code>R4.0</code>, <code>R4.39</code> etc.
+			<p>
+				The p2-repositories of specific releases are located within <a href="https://download.eclipse.org/eclipse/updates">download.eclipse.org/eclipse/updates</a>.<br>
+				For the latest release the p2-repositories is always referenced from <a href="https://download.eclipse.org/eclipse/updates/latest">download.eclipse.org/eclipse/updates/latest</a>.
+			</p>
 			<h4>Retention policy</h4>
 			Releases are retained indefinitely.<br>
 			However, only the build websites of the last three releases are provided at this main download area.
@@ -64,6 +72,10 @@
 			Even though changes are developed with great diligence, I-Builds are more likely to contain bugs and functionality degradations may occur temporarily.
 			In case of a severe problem the corresponding I-Build is marked as <em>unstable</em>.
 			I-Builds are recommended for developers of Eclipse itself and for those interested in testing the very latest features, bug-fixes and state.
+			<p>
+				The p2-repostory of a specific I-build is linked at the build's page.<br>
+				The p2-repositories of the latest I-builds are is always referenced from <a href="https://download.eclipse.org/eclipse/updates/I-builds/">download.eclipse.org/eclipse/updates/I-builds</a>.
+			</p>
 			<h4>Retention policy</h4>
 			The build website of an I-Build is retained for at least five days.
 			From older I-Builds only the first (not unstable) build of a week is retained until the targeted release is published.

--- a/sites/eclipse/page.css
+++ b/sites/eclipse/page.css
@@ -1,4 +1,4 @@
-@import "https://eclipse.dev/eclipse.org-common/themes/solstice/public/stylesheets/astro.min.css?v0.0.272";
+@import "https://eclipse.dev/eclipse.org-common/themes/solstice/public/stylesheets/astro.min.css";
 @import "https://fonts.googleapis.com/css2?family=Libre+Franklin:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap";
 
 :root {

--- a/sites/eclipse/page.js
+++ b/sites/eclipse/page.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2025, 2025 Ed Merks and others.
+ *  Copyright (c) 2025, 2026 Ed Merks and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -10,7 +10,7 @@
  *
  *  Contributors:
  *     Ed Merks - initial API and implementation
- *     Hannes Wellmann - Apply Eclipse News scripts to reworked Build drop websites
+ *     Hannes Wellmann - Adapt Eclipse News scripts to reworked Build drop websites
  *******************************************************************************/
 
 const meta = toElements(`
@@ -453,10 +453,10 @@ function generateBody() {
 					<div class="menu-heading">Legal</div>
 					<ul class="nav">
 						<ul class="nav">
-							<li><a href="https://www.eclipse.org/legal/privacy.php">Privacy Policy</a></li>
-							<li><a href="https://www.eclipse.org/legal/termsofuse.php">Terms of Use</a></li>
+							<li><a href="https://www.eclipse.org/legal/privacy/">Privacy Policy</a></li>
+							<li><a href="https://www.eclipse.org/legal/terms-of-use/">Terms of Use</a></li>
 							<li><a href="https://www.eclipse.org/legal/compliance/">Compliance</a></li>
-							<li><a href="https://www.eclipse.org/org/documents/Community_Code_of_Conduct.php">Code of
+							<li><a href="https://www.eclipse.org/org/documents/community-code-of-conduct/">Code of
 									Conduct</a></li>
 							<li><a href="https://www.eclipse.org/legal/">Legal Resources</a></li>
 						</ul>
@@ -468,7 +468,7 @@ function generateBody() {
 						<ul class="nav">
 							<li><a href="https://www.eclipse.org/security/">Report a Vulnerability</a></li>
 							<li><a href="https://www.eclipsestatus.io/">Service Status</a></li>
-							<li><a href="https://www.eclipse.org/org/foundation/contact.php">Contact</a></li>
+							<li><a href="https://www.eclipse.org/org/foundation/contact/">Contact</a></li>
 							<li><a href="https://www.eclipse.org//projects/support/">Support</a></li>
 						</ul>
 					</ul>

--- a/sites/equinox/build/index.html
+++ b/sites/equinox/build/index.html
@@ -46,7 +46,7 @@
 		<h3 id="launchers">Native Launchers</h3>
 		<p>
 			Platform-specific native launchers (e.g., eclipse.exe) for the Equinox framework.
-			See the list of <a href="https://www.eclipse.org/projects/project-plan.php?projectid=eclipse#target_environments">supported OS configurations</a>.
+			See the list of <a class="data-ref" href="https://eclipse.dev/eclipse/development/plans.html?file=plans/eclipse_project_plan_${releaseShortUnderscore}.xml#target_environments">supported OS configurations</a>.
 		</p>
 		<table class="files-table" data-path="launchers"></table>
 
@@ -68,6 +68,7 @@
 	<script>
 		loadPageData('buildproperties.json', data => {
 			data.buildTypeName = getBuildTypeName(data)
+			data.releaseShortUnderscore = data.releaseShort.replace('.', '_')
 			return data
 		})
 

--- a/sites/pom.xml
+++ b/sites/pom.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2012, 2025 IBM Corporation, and others.
+	Copyright (c) 2012, 2026 IBM Corporation, and others.
 	All rights reserved. This program and the accompanying materials
 	are made available under the terms of the Eclipse Distribution License v1.0
 	which accompanies this distribution, and is available at
-	https://www.eclipse.org/org/documents/edl-v10.php
+	https://www.eclipse.org/org/documents/edl-v10
 
 	Contributors:
 		Igor Fedorenko - initial implementation


### PR DESCRIPTION
Additionally fix links to project plan.
And replace the link of the removed build-schedule page with a link to the 'Eclipse RelEng Builds' calendar.

Relates to
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2656

Part of
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3614