### PR TITLE
[I/Y-Tests] Update to new macOS computers in RelEng Jenkins

### DIFF
--- a/JenkinsJobs/buildConfigurations.json
+++ b/JenkinsJobs/buildConfigurations.json
@@ -49,10 +49,9 @@
 				"ws": "cocoa",
 				"arch": "aarch64",
 				"javaVersion": 21,
-				"agent": "nc1ht-macos11-arm64",
+				"agent": "nc1ht-macos26-arm64",
 				"jdk": {
-					"type": "local",
-					"path": "/Library/Java/JavaVirtualMachines/jdk-21.0.5+11-arm64/Contents/Home"
+					"type": "temurin"
 				}
 			},
 			{
@@ -60,10 +59,9 @@
 				"ws": "cocoa",
 				"arch": "x86_64",
 				"javaVersion": 21,
-				"agent": "nc1ht-macos11-arm64",
+				"agent": "b9h15-macos15-x86_64",
 				"jdk": {
-					"type": "local",
-					"path": "/Library/Java/JavaVirtualMachines/jdk-21.0.5+11/Contents/Home"
+					"type": "temurin"
 				}
 			},
 			{
@@ -124,7 +122,7 @@
 				"ws": "cocoa",
 				"arch": "aarch64",
 				"javaVersion": 26,
-				"agent": "nc1ht-macos11-arm64",
+				"agent": "nc1ht-macos26-arm64",
 				"jdk": {
 					"type": "install",
 					"url": "https://download.java.net/java/early_access/jdk26/23/GPL/openjdk-26-ea+23_macos-aarch64_bin.tar.gz"


### PR DESCRIPTION
Update the I/Y-build tests to run on the new macOS agents in the RelEng JIPP:
- https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6621#note_6796846

Part of
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3315

