### PR TITLE
Revert "Update target-platform with latest version"

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -6,7 +6,7 @@
 
       <unit id="com.jcraft.jsch" version="0.1.55.v20230916-1400"/>
 
-      <unit id="org.apache.ant" version="1.10.16.v20260402-1000"/>
+      <unit id="org.apache.ant" version="1.10.15.v20240901-1000"/>
 
       <unit id="org.apache.batik.css" version="1.19.0.v20250506-1400"/>
       <unit id="org.apache.batik.util" version="1.19.0.v20250506-1400"/>
@@ -35,7 +35,7 @@
       <unit id="org.apache.httpcomponents.core5.httpcore5-h2" version="5.4.2.v20260306-1000"/>
 
       <!-- This is the "normal" Orbit repository is expected to be updated on milestones and releases based on Orbit deliveries. -->
-      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202604020800"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202604010740"/>
     </location>
 
     <location includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
This reverts commit 3418a0659f76db7368014510b7fcd35e4002d438 as it breaks Ant support on Windows.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/2605