### PR TITLE
[RelEng] Fix determination of baseline drop for first promotions

### DIFF
--- a/JenkinsJobs/Releng/promoteBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/promoteBuild.jenkinsfile
@@ -151,10 +151,10 @@ pipeline {
 						renameBuildDrop('eclipse/downloads/drops4', "${DROP_ID}", "${BUILD_LABEL}", "${DL_DROP_ID}", "${DL_LABEL}") { buildProperties ->
 							script {
 								def baselineBuilds = utilities.listBuildDropDirectoriesOnRemote("${EP_ROOT}/eclipse/downloads/drops4", "${DL_TYPE}*") // sorted in ascending order
+								baselineBuilds.remove(env.DL_DROP_ID) // ignore the just promoted drop when determining the latest
 								if (baselineBuilds.isEmpty() && "${DL_TYPE}" == 'S') { // For M1 usually no previous stable build exists
 									baselineBuilds = utilities.listBuildDropDirectoriesOnRemote("${EP_ROOT}/eclipse/downloads/drops4", 'R*')
 								}
-								baselineBuilds.remove(env.DL_DROP_ID) // ignore the just promoted drop when determining the latest
 								buildProperties.gitTag = env.GIT_TAG
 								buildProperties.gitBaselineTag = utilities.stableBuildGitTag("${baselineBuilds.last()}")
 								echo "gitTag: ${buildProperties.gitTag}, gitBaselineTag: ${buildProperties.gitBaselineTag}"


### PR DESCRIPTION
The removal of the just promoted drop must happen before check if the list of baseline drops is empty. Otherwise for the first promotion of a release cycle (usually M1) that check is useless.

Follow-up on
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3651