### PR TITLE
[Build] Remove Maven prerequisites intended for maven-plugin projects

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -21,9 +21,6 @@
   <artifactId>eclipse-platform-parent</artifactId>
   <version>4.40.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <prerequisites>
-    <maven>3.9.9</maven>
-  </prerequisites>
   <properties>
     <!-- As of Tycho 0.22, skipTests takes priority, if maven.test.skip also specified,
       with different value. See https://bugs.eclipse.org/442976.


### PR DESCRIPTION
Removing the prerequisites removes the warning, which states:
```
The project org.eclipse:eclipse-platform-parent:pom:4.40.0-SNAPSHOT uses prerequisites
which is only intended for maven-plugin projects but not for non maven-plugin projects.
For such purposes you should use the maven-enforcer-plugin.
See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
```

Since the maven requirement is probably mainly/only driven by Tycho, we should just rely on the prerequisites defined within Tycho and keep it simple here.