### PR TITLE
[Build] Remove unnecessary resources-plugin executions and set encoding

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -277,18 +277,12 @@
         <artifactId>maven-resources-plugin</artifactId>
         <executions>
           <execution>
-            <id>filter-resources</id>
+            <id>saveproperties</id>
             <goals>
-              <goal>resources</goal>
+              <goal>copy-resources</goal>
             </goals>
             <phase>process-resources</phase>
-            <configuration>
-              <outputDirectory>${project.build.directory}/resources</outputDirectory>
-              <escapeString>\</escapeString>
-            </configuration>
-          </execution>
-          <execution>
-            <id>saveproperties</id>
+            <inherited>false</inherited>
             <configuration>
               <outputDirectory>${project.build.directory}</outputDirectory>
               <changeDetection>always</changeDetection>
@@ -298,11 +292,8 @@
                   <filtering>true</filtering>
                 </resource>
               </resources>
+              <propertiesEncoding>ISO-8859-1</propertiesEncoding><!-- Default encoding for Java properties files-->
             </configuration>
-            <phase>validate</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
           </execution>
         </executions>
       </plugin>
@@ -990,6 +981,7 @@
                       <filtering>true</filtering>
                     </resource>
                   </resources>
+                  <propertiesEncoding>ISO-8859-1</propertiesEncoding><!-- Default encoding for Java properties files-->
                 </configuration>
                 <goals>
                   <goal>copy-resources</goal>

--- a/products/eclipse-junit-tests/pom.xml
+++ b/products/eclipse-junit-tests/pom.xml
@@ -32,13 +32,6 @@
   <build>
     <finalName>${project.artifactId}</finalName>
 
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
-
     <pluginManagement>
       <plugins>
         <plugin>


### PR DESCRIPTION
The `filter-resources` execution of the `maven-resources-plugin` seems not any effect at any project and the specified directory is always just skipped.

Additionally specify the the encoding explicitly when filtering resources, to prevent the INFO from below.
Java properties files are encoded using ISO-8859-1 encoding. Therefore, when filtered by the `maven-resources-plugin`, these files should be written with that encoding.
```
The encoding used to copy filtered properties files has not been set.
This means that the same encoding will be used to copy filtered properties files as when copying other filtered resources.
This might not be what you want! Run your build with --debug to see which files might be affected.
Read more at
https://maven.apache.org/plugins/maven-resources-plugin/examples/filtering-properties-files.html
```