### PR TITLE
Add skija 1.7.0 to eclipse-sdk target

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -90,6 +90,30 @@
     <!-- Maven versions of asm; Orbit versions of asm are specified above. -->
 	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="error" type="Maven">
 		  <dependencies>
+		      <dependency>
+				<groupId>io.github.humbleui</groupId>
+		    	<artifactId>skija-shared</artifactId>
+		    	<version>0.143.11</version>
+		    	<type>jar</type>
+		      </dependency>
+		      <dependency>
+		    	 <groupId>io.github.humbleui</groupId>
+		    	 <artifactId>skija-windows-x64</artifactId>
+		    	 <version>0.143.11</version>
+		    	 <type>jar</type>
+		      </dependency>
+		      <dependency>
+		    	 <groupId>io.github.humbleui</groupId>
+		    	 <artifactId>skija-linux-x64</artifactId>
+		    	 <version>0.143.11</version>
+		    	 <type>jar</type>
+		      </dependency>
+		      <dependency>
+		    	 <groupId>io.github.humbleui</groupId>
+		    	 <artifactId>types</artifactId>
+		    	 <version>0.1.1</version>
+		    	 <type>jar</type>
+		      </dependency>
 			  <dependency>
 				  <groupId>com.github.weisj</groupId>
 				  <artifactId>jsvg</artifactId>


### PR DESCRIPTION
For using skija in SWT, the maven jars must be loaded. 

Are they added here in the right way?

Required for:
https://github.com/eclipse-platform/eclipse.platform.swt/pull/3231#issuecomment-4242232863