### PR TITLE
Do not use new Color(display,...) in docs

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/swt_graphics.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/swt_graphics.htm
@@ -190,7 +190,7 @@ In this example, it allocates and frees the color red while painting.</P>
    shell.addPaintListener (new PaintListener () {
       public void paintControl (PaintEvent event) {
          GC gc = event.gc;
-         Color red = new Color (event.widget.getDisplay (), 0xFF, 0, 0);
+         Color red = new Color (0xFF, 0, 0);
          gc.setForeground (red);
          Rectangle rect = event.widget.getClientArea ();
          gc.drawRectangle (rect.x + 10, rect.y + 10, rect.width - 20, rect.height - 20);


### PR DESCRIPTION
Adjust docs to not recommend what is discussed to be deprecated and is totally not needed.
Contributes to eclipse-platform/eclipse.platform.swt#3233 .