### PR TITLE
[Build] Remove test Plug-ins from Eclipse P2-repository

### DIFF
--- a/sites/eclipse-platform-repository/category.xml
+++ b/sites/eclipse-platform-repository/category.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature id="org.eclipse.sdk.tests">
-      <category name="org.eclipse.releng.testsIU"/>
-   </feature>
    <feature id="org.eclipse.equinox.p2.sdk" version="0.0.0"/>
    <feature id="org.eclipse.equinox.p2.discovery.feature" version="0.0.0"/>
    <feature id="org.eclipse.core.runtime.feature" version="0.0.0"/>
@@ -49,9 +46,6 @@
    <iu id = "org.eclipse.platform.ide">
      <category name="org.eclipse.platform.ide.categoryIU"/>
    </iu>
-   <iu id = "eclipse-junit-tests">
-     <category name="org.eclipse.releng.testsIU"/>
-   </iu>
    <category-def name="org.eclipse.equinox.target.categoryIU" label="Equinox Target Components">
       <description>
          Features especially useful to install as PDE runtime targets.
@@ -74,7 +68,7 @@
    </category-def>
    <category-def name="org.eclipse.releng.testsIU" label="Eclipse Tests, Tools, Examples, and Extras">
       <description>
-         Collection of Misc. Features, such as unit tests, SWT and e4 tools, examples, and compatibility features not shipped as part of main SDK, but which some people may desire in creating products based on previous versions of Eclipse.
+         Collection of miscellaneous Features, such as testing support, SWT and e4 tools, examples, and compatibility features not shipped as part of main SDK, but which some people may desire in creating products based on previous versions of Eclipse.
       </description>
    </category-def>
    <category-def name="org.eclipse.releng.java.languages.categoryIU" label="Eclipse Java Development Tools">


### PR DESCRIPTION
Tests are not intended for downstream consumers at all and therefore just increases the repositories size without any value. A smaller repository can also accelerates the Maven build itself due to an increased parallelism and is of course faster to transfer between build- and storage-server.

Besides all 'test'-Plug-ins, this also removes the `org.eclipse.sdk.tests` feature from the Eclipse p2 repository.

If one really needs the built test Plug-in jars, one can download them with the `eclipse-Automated-Tests` zip from each build drop website.

The only production bundle that is currently removed is `org.apache.commons.commons-fileupload` since it's seems to be only required by tests and only optionally required by `org.eclipse.equinox.http.servlet`. I aim to avoid that via
- https://github.com/eclipse-equinox/equinox/pull/1274

Since this is change affects the entire Eclipse top level project repository I'd like to make all project leads aware and hope everyone is fine with it:
- for Platform: @akurtakov, @iloveeclipse, @HeikoKlare
- for Equinox: @tjwatson and @laeubi
- for JDT: @jarthana and @mpalat
- for PDE: myself (I'm fine with it).
