### PR TITLE
[I/Y-Build] Generalize API report generation and fix website links to it

### DIFF
--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -346,26 +346,21 @@ pipeline {
 									for filter in $(find ${AGG_DIR} -type f -path '*/.settings/.api_filters'); do
 										IFS='/' read -ra PATH_SEGMENTS <<< "${filter}"
 										pluginName="${PATH_SEGMENTS[-3]}"
-										target=${DROP_DIR}/${BUILD_ID}/apifilters/${pluginName}
+										target=${TEMP_DIR}/apifilters/${pluginName}
 										mkdir -p ${target}
 										cp ${filter} ${target}
 									done
-									pushd ${DROP_DIR}/${BUILD_ID}
-										zip -r apitools/apifilters-${BUILD_ID}.zip apifilters/*
-									popd
 									
-									baseline=${DROP_DIR}/${BUILD_ID}/apitoolingreference/Eclipse-SDK-${PREVIOUS_RELEASE_VER}/eclipse-SDK-${PREVIOUS_RELEASE_VER}-win32-x86_64.zip
+									baseline=${TEMP_DIR}/apitoolingreference/repository-${PREVIOUS_RELEASE_VER}.zip
 									mkdir -p $(dirname ${baseline})
-									curl -o ${baseline} https://download.eclipse.org/eclipse/downloads/drops4/${PREVIOUS_RELEASE_ID}/eclipse-SDK-${PREVIOUS_RELEASE_VER}-win32-x86_64.zip
+									curl -o ${baseline} https://download.eclipse.org/eclipse/downloads/drops4/${PREVIOUS_RELEASE_ID}/repository-${PREVIOUS_RELEASE_VER}.zip
 									mvn tycho-eclipse:eclipse-run@generate-api-report -f eclipse-platform-parent \
 										-Declipserun.workArea=${TEMP_DIR}/apitoolings-logs \
 										-DgitRepoRoot=${AGG_DIR} \
 										-Dbaseline=${baseline} \
-										-Dcurrent_location=${DROP_DIR}/${BUILD_ID}/eclipse-SDK-${BUILD_ID}-win32-win32-x86_64.zip \
+										-Dcurrent_location=${PLATFORM_REPO_DIR} \
 										-Dreport=${DROP_DIR}/${BUILD_ID}/apitools \
-										-Dfilter_store=${DROP_DIR}/${BUILD_ID}/apifilters \
-									
-									rm -rf ${DROP_DIR}/${BUILD_ID}/apitoolingreference
+										-Dfilter_store=${TEMP_DIR}/apifilters \
 									
 									# Wait for notarization to complete before checksums are generated.
 									wait

--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -546,7 +546,7 @@
                   <arg>-application</arg>
                   <arg>org.eclipse.ant.core.antRunner</arg>
                   <arg>-buildfile</arg>
-                  <arg>${gitRepoRoot}/eclipse.platform.releng.tychoeclipsebuilder/eclipse/buildScripts/api-tools-builder.xml</arg>
+                  <arg>${gitRepoRoot}/scripts/releng/apiReport/builder.xml</arg>
                 </applicationArgs>
                 <jvmArgs>
                   <arg>-Dbaseline=${baseline}</arg>

--- a/scripts/releng/apiReport/builder.xml
+++ b/scripts/releng/apiReport/builder.xml
@@ -34,7 +34,7 @@
 
     <property
       name="exclude_list_external_location"
-      value="${basedir}/../apiexclude/exclude_list_external.txt" />
+      value="${basedir}/exclusions.txt" />
 
     <!-- create HTML output directory -->
     <property

--- a/scripts/releng/apiReport/exclusions.txt
+++ b/scripts/releng/apiReport/exclusions.txt
@@ -23,6 +23,13 @@ com.ibm.icu
 org.mortbay.jasper.mortbay-apache-jsp
 
 ## SPECIAL CASE FOR SWT: THE FRAGMENT IS ANALYZED AS PART OF THE HOST
+org.eclipse.swt.cocoa.macosx.aarch64
+org.eclipse.swt.cocoa.macosx.x86_64
+org.eclipse.swt.gtk.linux.aarch64
+org.eclipse.swt.gtk.linux.ppc64le
+org.eclipse.swt.gtk.linux.riscv64
+org.eclipse.swt.gtk.linux.x86_64
+org.eclipse.swt.win32.win32.aarch64
 org.eclipse.swt.win32.win32.x86_64
 
 ## Can't guarantee other Eclipse Projects bundles API stabiltiy

--- a/sites/eclipse/build/reports.html
+++ b/sites/eclipse/build/reports.html
@@ -22,12 +22,11 @@
 			<li><a href="buildlogs/reporeports/index.html"><b>Repository Reports </b></a></li>
 			<li><a href="buildlogs/logs.html"><b>Build and Release Engineering Logs</b></a></li>
 			<li><a href="testresults/logs.html"><b>Test Console Logs</b></a></li>
-			<li><a href="apitools/analysis/html/index.html"><b>API Tools Version Verification Report</b></a>
-				This tool verifies the versions of the plugins against Eclipse ${previousReleaseAPILabel}
-				(Exclusions listed in <a href="https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob//eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt">apiexclude/exclude_list_external.txt</a>).
+			<li><a href="apitools/analysis/html/index.html"><b>API Verification Report</b></a><br>
+				API analysis of all Plug-ins against Eclipse ${previousReleaseAPILabel}<br>
+				(Exclusions listed in <a href="https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/master/scripts/releng/apiReport/exclusions.txt">apiReport/exclusions.txt</a>).
 			</li>
-			<li><a href="apitools/deprecation/apideprecation.html"><b>API Tools Deprecation Report</b></a> This tool generates a report for API deprecated since ${previousReleaseAPILabel}.</li>
-			<li><a href="apitools/apifilters-${label}.zip"><b>Zip of <samp>.api_filters</samp> files used in the build</b></a></li>
+			<li><a href="apitools/deprecation/apideprecation.html"><b>API Tools Deprecation Report</b></a> Listing of all API deprecations since ${previousReleaseAPILabel}.</li>
 		</ul>
 		<h3 id="tests">Unit Test Results</h3>
 		<p>The unit tests are run on the <a id="ci-tests-folder-url" href="https://ci.eclipse.org/releng">RelEng Jenkins instance</a>.</p>


### PR DESCRIPTION
Enhances the API analysis report with the following aspects:
- Compare the entire Eclipse repository not just the SDK product for Windows-x86_64
  - This requires the removal of test plugins from the repository as otherwise the `apitooling.apideprecation` task fails:
  https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3772
- Move scripts to a more fitting location
- Remove filters from build websites as they can be looked up in the SCM
- Fix the previously broken links at the Eclipse build websites to the exclusions file
