### PR TITLE
[I/Y-Build] Trim whitespace around computed build TIMESTAMP

### DIFF
--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -64,7 +64,7 @@ pipeline {
 					BUILD = readJSON(file: 'JenkinsJobs/buildConfigurations.json')[job.type]
 					
 					def int jobStart = currentBuild.startTimeInMillis.intdiv(1000)
-					BUILD_PROPERTIES.TIMESTAMP = sh(script: "TZ='America/New_York' date +%Y%m%d-%H%M --date='@${jobStart}'", returnStdout: true)
+					BUILD_PROPERTIES.TIMESTAMP = sh(script: "TZ='America/New_York' date +%Y%m%d-%H%M --date='@${jobStart}'", returnStdout: true).trim()
 					BUILD_PROPERTIES.BUILD_TYPE = job.type
 					BUILD_PROPERTIES.BUILD_TYPE_NAME = BUILD.typeName
 					BUILD_PROPERTIES.BUILD_ID = "${BUILD_PROPERTIES.BUILD_TYPE}${BUILD_PROPERTIES.TIMESTAMP}"


### PR DESCRIPTION
This was missing in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3757

The trailing newline didn't lead to severe failures but is still something that should be removed.