### PR TITLE
[I/Y-Build] Use new names of Windows products in test resource download

### DIFF
--- a/production/testScripts/runTests2.xml
+++ b/production/testScripts/runTests2.xml
@@ -90,12 +90,12 @@
     unless="skipInstall">
 		<get
       verbose="${selectiveVerbose}"
-      src="${archiveLocation}/eclipse-SDK-${buildIdToUse}-win32-${osgi.arch}.zip"
-      dest="${executionDir}/eclipse-SDK-${buildIdToUse}-win32-${osgi.arch}.zip" />
+      src="${archiveLocation}/eclipse-SDK-${buildIdToUse}-win32-win32-${osgi.arch}.zip"
+      dest="${executionDir}/eclipse-SDK-${buildIdToUse}-win32-win32-${osgi.arch}.zip" />
 		<get
       verbose="${selectiveVerbose}"
-      src="${archiveLocation}/eclipse-platform-${buildIdToUse}-win32-${osgi.arch}.zip"
-      dest="${executionDir}/eclipse-platform-${buildIdToUse}-win32-${osgi.arch}.zip" />
+      src="${archiveLocation}/eclipse-platform-${buildIdToUse}-win32-win32-${osgi.arch}.zip"
+      dest="${executionDir}/eclipse-platform-${buildIdToUse}-win32-win32-${osgi.arch}.zip" />
 		<get
       verbose="${selectiveVerbose}"
       src="${previousReleaseLocation}/eclipse-platform-${previousReleaseVersion}-win32-${osgi.arch}.zip"


### PR DESCRIPTION
This was missed in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3767

and lead to failures of the Windows tests tonight.