### PR TITLE
Silense deprecation report for jetty.session

### DIFF
--- a/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
+++ b/eclipse.platform.releng.tychoeclipsebuilder/eclipse/apiexclude/exclude_list_external.txt
@@ -32,6 +32,7 @@ org.eclipse.jetty.io
 org.eclipse.jetty.security
 org.eclipse.jetty.server
 org.eclipse.jetty.servlet
+org.eclipse.jetty.session
 org.eclipse.jetty.util.ajax
 org.eclipse.jetty.util
 org.eclipse.jetty.ee8.server


### PR DESCRIPTION
As reported in
https://download.eclipse.org/eclipse/downloads/drops4/I20260416-1800/apitools/deprecation/apideprecation.html