### PR TITLE
[I/Y-Build] Use new names of Windows products in test bootstrap

### DIFF
--- a/production/testScripts/configuration/sdk.tests/testScripts/test.xml
+++ b/production/testScripts/configuration/sdk.tests/testScripts/test.xml
@@ -820,7 +820,7 @@
     <echo message="build id of runtimeArchive ${buildIdToUse}" />
     <condition
       property="osArchiveNameSuffix"
-      value="win32-${arch}.zip">
+      value="win32-win32-${arch}.zip">
       <and>
         <equals
           arg1="${os}"


### PR DESCRIPTION
This was missed in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3767

respectively in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3776