### PR TITLE
[I/Y-Build] Use new name for previous release Windows product in test

### DIFF
--- a/production/testScripts/runTests2.xml
+++ b/production/testScripts/runTests2.xml
@@ -99,7 +99,7 @@
 		<get
       verbose="${selectiveVerbose}"
       src="${previousReleaseLocation}/eclipse-platform-${previousReleaseVersion}-win32-${osgi.arch}.zip"
-      dest="${platformLocation}/eclipse-platform-${previousReleaseVersion}-win32-${osgi.arch}.zip" />
+      dest="${platformLocation}/eclipse-platform-${previousReleaseVersion}-win32-win32-${osgi.arch}.zip" />
 	</target>
 	<target
     name="getlinzips"


### PR DESCRIPTION
The new naming schema is expected for all products. Therefore the previous release platform product has to use the new schema locally too, even if it's not named like that at the download page.

This was missed in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3767

respectively in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3778