### PR TITLE
[Y-Build] Permanently enable Beta Java 27 builds

### DIFF
--- a/JenkinsJobs/buildConfigurations.json
+++ b/JenkinsJobs/buildConfigurations.json
@@ -83,7 +83,6 @@
 		"streams": {
 			"4.40": {
 				"branch": "master",
-				"disabled": "true",
 				"schedule": "0 10 * 2-4 2,4,6\n0 10 1-27 5 2,4,6"
 			}
 		},


### PR DESCRIPTION
This was missed in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3763