### PR TITLE
Add back UI test-harness and required tests to Eclipse P2-repository

### DIFF
--- a/eclipse.platform.releng/features/org.eclipse.test-feature/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.test-feature/feature.xml
@@ -47,4 +47,8 @@
          id="org.eclipse.core.tests.harness"
          version="0.0.0"/>
 
+   <plugin
+         id="org.eclipse.ui.tests.harness"
+         version="0.0.0"/>
+
 </feature>

--- a/sites/eclipse-platform-repository/category.xml
+++ b/sites/eclipse-platform-repository/category.xml
@@ -46,6 +46,18 @@
    <iu id = "org.eclipse.platform.ide">
      <category name="org.eclipse.platform.ide.categoryIU"/>
    </iu>
+   <bundle id="org.eclipse.jdt.core.tests.builder">
+      <category name="org.eclipse.releng.testsIU"/>
+   </bundle>
+   <bundle id="org.eclipse.text.tests">
+      <category name="org.eclipse.releng.testsIU"/>
+   </bundle>
+   <bundle id="org.eclipse.jface.text.tests">
+      <category name="org.eclipse.releng.testsIU"/>
+   </bundle>
+   <bundle id="org.eclipse.core.filebuffers.tests">
+      <category name="org.eclipse.releng.testsIU"/>
+   </bundle>
    <category-def name="org.eclipse.equinox.target.categoryIU" label="Equinox Target Components">
       <description>
          Features especially useful to install as PDE runtime targets.


### PR DESCRIPTION
Add back the tests other tests depend on.

Follow-up on
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3772

The missing test Plug-ins where identified by building all submodules locally against a local build of the Eclipse p2-repository.