### PR TITLE
[Build] Skip baseline version comparision for eclipse-test-plugin

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -903,6 +903,35 @@
       </properties>
     </profile>
     <profile>
+      <id>skip-baseline-comparision-of-tests</id>
+      <activation>
+        <property>
+          <name>packaging</name>
+          <value>eclipse-test-plugin</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.tycho.extras</groupId>
+            <artifactId>tycho-p2-extras-plugin</artifactId>
+            <version>${tycho.version}</version>
+            <executions>
+              <execution>
+                <id>compare-attached-artifacts-with-release</id>
+                <goals>
+                  <goal>compare-version-with-baselines</goal>
+                </goals>
+                <configuration>
+                  <skip>true</skip>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>eclipse-sign</id>
       <build>
         <plugins>

--- a/eclipse.platform.releng/bundles/org.eclipse.test/META-INF/MANIFEST.MF
+++ b/eclipse.platform.releng/bundles/org.eclipse.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.test; singleton:=true
-Bundle-Version: 3.6.500.qualifier
+Bundle-Version: 3.6.600.qualifier
 Eclipse-BundleShape: dir
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/eclipse.platform.releng/bundles/org.eclipse.test/build.properties
+++ b/eclipse.platform.releng/bundles/org.eclipse.test/build.properties
@@ -20,5 +20,6 @@ bin.includes = .,\
 src.includes = about.html
 source.. = src/
 
-# Maven/Tycho pom model adjustments
+# Maven/Tycho POM adjustments
+pom.model.packaging = eclipse-plugin
 pom.model.property.defaultSigning-excludeInnerJars = true

--- a/eclipse.platform.releng/features/org.eclipse.test-feature/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.test-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.test"
       label="%featureName"
-      version="3.9.600.qualifier"
+      version="3.9.700.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
Fixes
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3784

Additionally I wonder if API checks should be skipped too.
IIRC I saw some projects explicitly disabling it, I'll check if some test plugins were among them.