### PR TITLE
Remove org.eclipse.test.source from o.e.test feature

### DIFF
--- a/eclipse.platform.releng/features/org.eclipse.test-feature/feature.xml
+++ b/eclipse.platform.releng/features/org.eclipse.test-feature/feature.xml
@@ -32,10 +32,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.test.source"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.test.performance"
          version="0.0.0"/>
 


### PR DESCRIPTION
Or does anybody know a reason why to keep that particular source bundle?
Git blame doesn't indicate anything.