### PR TITLE
Silence deprecation warnings from bcutil

### DIFF
--- a/scripts/releng/apiReport/exclusions.txt
+++ b/scripts/releng/apiReport/exclusions.txt
@@ -10,6 +10,7 @@ org.apache.lucene.core
 org.apache.commons.commons-beanutils
 bcpg
 bcprov
+bcutil
 org.apache.httpcomponents.client5.httpclient5
 org.apache.httpcomponents.core5.httpcore5
 org.apache.httpcomponents.core5.httpcore5-h2


### PR DESCRIPTION
This is beyond project control so doesn't make sense to report it. Can be seen at
https://download.eclipse.org/eclipse/downloads/drops4/I20260421-1800/apitools/deprecation/apideprecation.html