### PR TITLE
Fix dependabot for SHA-pinned actions

### DIFF
--- a/.github/workflows/checkDependencies.yml
+++ b/.github/workflows/checkDependencies.yml
@@ -78,7 +78,7 @@ jobs:
           fetch-depth: 0
           ref: master
       - name: Set up Maven
-        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
+        uses: stCarolas/setup-maven@12eb41b233df95d49b0c11fc1b5bc8312e5d4ce0 # v5.1
         with:
           maven-version: ${{ inputs.mavenVersion }}
       - name: Set up JDK

--- a/.github/workflows/checkMergeCommits.yml
+++ b/.github/workflows/checkMergeCommits.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Block Merge Commits
-        uses: Morishiri/block-merge-commits-action@a4554c78def8d874966a8d1e20e2971121443755
+        uses: Morishiri/block-merge-commits-action@a4554c78def8d874966a8d1e20e2971121443755 # v1.0.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Update Message

--- a/.github/workflows/checkVersions.yml
+++ b/.github/workflows/checkVersions.yml
@@ -64,7 +64,7 @@ jobs:
           version-check-${{ runner.os }}-maven-
 
     - name: Set up Maven
-      uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
+      uses: stCarolas/setup-maven@12eb41b233df95d49b0c11fc1b5bc8312e5d4ce0 # v5.1
       with:
         maven-version: 3.9.14
 

--- a/.github/workflows/cleanCode.yml
+++ b/.github/workflows/cleanCode.yml
@@ -115,7 +115,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.branch }}
       - name: Set up Maven
-        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
+        uses: stCarolas/setup-maven@12eb41b233df95d49b0c11fc1b5bc8312e5d4ce0 # v5.1
         if: ${{ fromJson(steps.list-prs.outputs.prs)[9] == null }}
         with:
           maven-version: ${{ inputs.mavenVersion }}

--- a/.github/workflows/codeQLworkflow.yml
+++ b/.github/workflows/codeQLworkflow.yml
@@ -78,7 +78,7 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Set up Maven
-      uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
+      uses: stCarolas/setup-maven@12eb41b233df95d49b0c11fc1b5bc8312e5d4ce0 # v5.1
       with:
         maven-version: ${{ inputs.mavenVersion }}
 

--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -73,7 +73,7 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Set up Maven
-      uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
+      uses: stCarolas/setup-maven@12eb41b233df95d49b0c11fc1b5bc8312e5d4ce0 # v5.1
       with:
         maven-version: ${{ inputs.mavenVersion }}
 

--- a/.github/workflows/publishTestResults.yml
+++ b/.github/workflows/publishTestResults.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Create badge
         if: github.ref == 'refs/heads/master' && inputs.gist-url != ''
-        uses: emibcn/badge-action@f9150fde070fcca0c4e832437611b44838fcd325
+        uses: emibcn/badge-action@f9150fde070fcca0c4e832437611b44838fcd325 # v2.0.4
         with:
           label: Tests
           status: '${{ fromJSON( steps.test-results.outputs.json ).formatted.stats.tests_succ }} passed, ${{ fromJSON( steps.test-results.outputs.json ).formatted.stats.tests_fail }} failed'
@@ -81,7 +81,7 @@ jobs:
 
       - name: Upload badge to Gist
         if: github.ref == 'refs/heads/master' && inputs.gist-url != ''
-        uses: andymckay/append-gist-action@ab30bf28df67017c7ad696500b218558c7c04db3
+        uses: andymckay/append-gist-action@ab30bf28df67017c7ad696500b218558c7c04db3 # 0.3
         with:
           token: ${{ secrets.gist-token }}
           gistURL: ${{ inputs.gist-url }}

--- a/.github/workflows/updateTarget.yml
+++ b/.github/workflows/updateTarget.yml
@@ -30,7 +30,7 @@ jobs:
         fetch-depth: 0
         ref: ${{ inputs.branch }}
     - name: Set up Maven
-      uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
+      uses: stCarolas/setup-maven@12eb41b233df95d49b0c11fc1b5bc8312e5d4ce0 # v5.1
       with:
         maven-version: 3.9.14
     - name: Set up JDK


### PR DESCRIPTION
Dependabot doesn't do updates if:
* SHA doesn't have vMAJOR.MINOR comment
* SHA has only vMAJOR

Updated setup-maven to v5.1 to prevent warnings about deprecated Nodejs 20.
For others without version comment - such is added.