### PR TITLE
Update jsvg to 2.1.0

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -93,7 +93,13 @@
 			  <dependency>
 				  <groupId>com.github.weisj</groupId>
 				  <artifactId>jsvg</artifactId>
-				  <version>2.0.0</version>
+				  <version>2.1.0</version>
+				  <type>jar</type>
+			  </dependency>
+			  <dependency>
+				  <groupId>com.github.weisj</groupId>
+				  <artifactId>jsvg-systemlogger</artifactId>
+				  <version>2.1.0</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>


### PR DESCRIPTION
- Temporally add jsvg-systemlogger until we add our own log manger service to SWT's SVG fragment.