### PR TITLE
[Build] Autenticate access to Jenkins API in build

### DIFF
--- a/JenkinsJobs/AutomatedTests/integrationTests.jenkinsfile
+++ b/JenkinsJobs/AutomatedTests/integrationTests.jenkinsfile
@@ -92,8 +92,10 @@ pipeline {
 						curl --fail --output getEBuilder.xml https://download.eclipse.org/eclipse/relengScripts/testScripts/bootstrap/getEBuilder.xml
 						ant -f getEBuilder.xml -DbuildId=${params.buildId} -Dosgi.os=${test.os} -Dosgi.ws=${test.ws} -Dosgi.arch=${test.arch} -DtestSuite=${params.testSuite}
 					""")
+					def testResults = junit(keepLongStdio: true, testResults: '**/eclipse-testing/results/xml/*.xml')
+					writeFile(file: "workarea/${buildId}/eclipse-testing/results/${JOB_BASE_NAME}.json",
+						text: """{"passCount":${testResults.passCount},"failCount":${testResults.failCount},"skipCount":${testResults.skipCount},"duration":${getTestDuration()}}""")
 				}
-				junit keepLongStdio: true, testResults: '**/eclipse-testing/results/xml/*.xml'
 			}}
 			post {
 				always {
@@ -124,10 +126,6 @@ pipeline {
 										# First delete result files from a previous run of the same configuration (in case that test configuration was run again), then transfer the new results.
 										ssh genie.releng@projects-storage.eclipse.org rm -rfv ${remoteResultsDirectory}/${JOB_BASE_NAME}* ${remoteResultsDirectory}/*/*${JOB_BASE_NAME}*
 										scp -r ${localResultsDirectory}/* genie.releng@projects-storage.eclipse.org:${remoteResultsDirectory}
-										
-										# Download the result summary directly to the storage server
-										ssh genie.releng@projects-storage.eclipse.org \
-											curl --fail --location --output "${remoteResultsDirectory}/${JOB_BASE_NAME}.json" "${BUILD_URL}/testReport/api/json?tree=failCount,passCount,skipCount,duration"
 									fi
 								'''
 							}
@@ -195,4 +193,12 @@ def getJDKInstallationPath(Map<String, Object> test) {
 
 def pathOf(String path) {
 	return path.replace('/', isUnix() ? '/' : '\\')
+}
+
+def getTestDuration() {
+	// Workaround for https://github.com/jenkinsci/junit-plugin/issues/1235
+	withCredentials([usernameColonPassword(credentialsId: 'jenkins-api', variable: 'JENKINS_API_TOKEN')]) {
+		def summary = sh(script: 'curl --fail --user "${JENKINS_API_TOKEN}" "${BUILD_URL}/testReport/api/json?tree=duration"', returnStdout: true)
+		return readJSON(text: summary).duration
+	}
 }

--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -519,17 +519,20 @@ pipeline {
 			tools {
 				jdk 'temurin-jdk25-latest'
 			}
+			environment {
+				JENKINS_API_TOKEN = credentials('jenkins-api') // username:password
+			}
 			steps {
 				script {
 					// See https://github.com/jenkinsci/pipeline-stage-view-plugin/tree/master/rest-api#get-jobjob-namewfapiruns
-					def description = readJSON(text: sh(script: "curl --fail ${BUILD_URL}/wfapi/describe", returnStdout: true))
+					def description = readJSON(text: sh(script: 'curl --fail ${BUILD_URL}/wfapi/describe --user "${JENKINS_API_TOKEN}"', returnStdout: true))
 					int stageIndex = 0
 					for (jobStage in description['stages']) {
 						if (jobStage.status != 'IN_PROGRESS') {
 							def prefix = 's' + String.format('%03d', stageIndex++) // prefix with index to establish stable order
 							def logFileName = "${DROP_DIR}/${BUILD_ID}/buildlogs/" + prefix + '_' + jobStage.name.replace(' ', '_').replace('Declarative:_', '') + '.log'
 							sh """
-								curl --fail --silent --output '${logFileName}' ${BUILD_URL}/stages/log?nodeId=${jobStage.id}
+								curl --fail --silent --output '${logFileName}' --user "\${JENKINS_API_TOKEN}" ${BUILD_URL}/stages/log?nodeId=${jobStage.id}
 								# Test (efficiently) if the file starts with the no-logs message and if yes, ensure it doesn't contain more other lines
 								if [ "\$(head --lines 1 '${logFileName}' | xargs)" == 'No logs found' ] && [ "\$(wc --lines < '${logFileName}')" -le 1 ]; then
 									rm -f "${logFileName}"


### PR DESCRIPTION
Based on the expected solution from
- https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/7456#note_7160463

This should resolve 
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3804

This is currently a draft as it is not yet tested and probably needs adaption to the final credential names.