### PR TITLE
Clean-up test dependency content from eclipse-junit-tests repository

### DIFF
--- a/sites/eclipse-junit-tests/category.xml
+++ b/sites/eclipse-junit-tests/category.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
    <feature id="org.eclipse.test"/>
-   <bundle id="junit-jupiter-api"/>
-   <bundle id="org.junit"/>
    <bundle id="assertj-core"/>
+   <bundle id="org.mockito.mockito-core"/>
+   <bundle id="org.objenesis"/>
    <bundle id="net.bytebuddy.byte-buddy"/>
    <bundle id="net.bytebuddy.byte-buddy-agent"/>
    <bundle id="org.eclipse.sdk.tests"/>
@@ -78,7 +78,6 @@
    <bundle id="org.eclipse.equinox.security.tests"/>
    <bundle id="org.eclipse.equinox.preferences.tests"/>
    <bundle id="org.eclipse.equinox.http.servlet.tests"/>
-   <bundle id="org.apache.commons.commons-fileupload"/>
    <bundle id="org.eclipse.equinox.p2.installer"/>
    <bundle id="org.eclipse.equinox.p2.tests"/>
    <bundle id="org.eclipse.equinox.p2.tests.discovery"/>
@@ -87,8 +86,6 @@
    <bundle id="org.eclipse.equinox.frameworkadmin.test"/>
    <bundle id="org.eclipse.jdt.core.tests.binaries"/>
    <bundle id="org.eclipse.equinox.bidi.tests"/>
-   <bundle id="org.mockito.mockito-core"/>
-   <bundle id="org.objenesis"/>
    <bundle id="org.eclipse.ui.tests.pluginchecks"/>
    <bundle id="org.eclipse.tests.urischeme"/>
    <bundle id="org.eclipse.equinox.common.tests"/>
@@ -96,7 +93,5 @@
    <bundle id="org.eclipse.pde.junit.runtime.tests"/>
    <bundle id="org.eclipse.core.contenttype.tests"/>
    <bundle id="org.eclipse.update.configurator.tests"/>
-   <bundle id="org.eclipse.swt.svg"/>
-   <bundle id="com.github.weisj.jsvg"/>
    <bundle id="org.eclipse.terminal.test"/>
 </site>


### PR DESCRIPTION
Remove bundles that are not necessary anymore because they are already contained in the Eclipse-SDK.

Leverages also
- https://github.com/eclipse-equinox/equinox/pull/1274