### PR TITLE
Fix check for trailing newline in 'touch on comparator error'-pipeline

### DIFF
--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -602,6 +602,7 @@ pipeline {
 			""" + (env.COMPARATOR_ERRORS_SUBJECT == '' ? '' : """
 			Check unanticipated comparator messages:
 			https://download.eclipse.org/eclipse/downloads/drops4/${BUILD_ID}/buildlogs/comparatorlogs/buildtimeComparatorUnanticipated.log.txt
+			(If appropriate, affected projects can be touched using: ${JENKINS_URL}job/Releng/job/touchCompatorErrorProjects)
 			""") + """
 			Software site repository:
 			https://download.eclipse.org/eclipse/updates/${RELEASE_VER}-${BUILD_TYPE}-builds

--- a/JenkinsJobs/Releng/touchCompatorErrorProjects.jenkinsfile
+++ b/JenkinsJobs/Releng/touchCompatorErrorProjects.jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
 							fi
 							# Ensure file terminates with a newline
 							lastChar=\$(tail -c1 ${forceQualifierUpdateFile} | od -An -tx1)
-							if [ ! "\${lastChar}" = "0a" ] && [ ! "\${lastChar}" = "0d" ]; then
+							if [ ! \${lastChar} = '0a' ] && [ ! \${lastChar} = '0d' ]; then
 								echo '' >> ${forceQualifierUpdateFile}
 							fi
 							echo '${message}' >> ${forceQualifierUpdateFile}


### PR DESCRIPTION
The `lastChar` contains a leading space. Removing the quotes around it allows the shell to ignore it.

And add a reference to that job in the RelEng JIPP in case of comparator errors.