### PR TITLE
Save screenshots to Maven build output directory

### DIFF
--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -94,4 +94,4 @@ jobs:
         if-no-files-found: warn
         path: |
           ${{ github.workspace }}/**/target/surefire-reports/*.xml
-          ${{ github.workspace }}/**/results/**/*.png
+          ${{ github.workspace }}/**/target/screenshots/*.png

--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -131,6 +131,7 @@
     <!-- system specific JVM args; if needed provided by system properties to the build command -->
     <surefire.systemProperties></surefire.systemProperties>
     <surefire.timeout>1200</surefire.timeout>
+    <surefire.screenshot_directory>${project.build.directory}/screenshots</surefire.screenshot_directory>
     <java.version>17</java.version>
     <printApiMessages>false</printApiMessages>
     <failOnJavadocErrors>false</failOnJavadocErrors>
@@ -343,6 +344,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${surefire.version}</version>
+          <configuration>
+            <systemPropertyVariables>
+                <eclipse.test.screenshot_directory>${surefire.screenshot_directory}</eclipse.test.screenshot_directory>
+            </systemPropertyVariables>
+          </configuration>
         </plugin>
          <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -434,6 +440,9 @@
             <enableAssertions>true</enableAssertions>
             <argLine>${surefire.testArgLine} ${surefire.platformSystemProperties} ${surefire.systemProperties} ${surefire.moduleProperties}</argLine>
             <quiet>true</quiet>
+            <systemProperties>
+                <eclipse.test.screenshot_directory>${surefire.screenshot_directory}</eclipse.test.screenshot_directory>
+            </systemProperties>
           </configuration>
         </plugin>
         <plugin>

--- a/eclipse.platform.releng/bundles/org.eclipse.test/src/org/eclipse/test/Screenshots.java
+++ b/eclipse.platform.releng/bundles/org.eclipse.test/src/org/eclipse/test/Screenshots.java
@@ -103,27 +103,34 @@ public final class Screenshots {
         return filename;
     }
 
-    /**
-     * @return unspecified
-     * @noreference This method is not intended to be referenced by clients.
-     */
-    public static File getResultsDirectory() {
-        File resultsDir = getJunitReportOutput(); // ends up in testresults/linux.gtk.x86_6.0/<class>.<test>.png
+	/**
+	 * @return unspecified
+	 * @noreference This method is not intended to be referenced by clients.
+	 */
+	public static File getResultsDirectory() {
+		File resultsDir = discoverResultsDirectory();
+		resultsDir.mkdirs();
+		return resultsDir;
+	}
 
-        if (resultsDir == null) {
-            File eclipseDir = new File("").getAbsoluteFile();
-            if (isRunByGerritHudsonJob()) {
-                resultsDir = new File(eclipseDir, "/../").getAbsoluteFile(); // ends up in the workspace root
-            } else {
-                resultsDir = new File(System.getProperty("java.io.tmpdir"));
-            }
-        }
+	private static File discoverResultsDirectory() {
+		File resultsDir = getJunitReportOutput(); // ends up in testresults/linux.gtk.x86_6.0/<class>.<test>.png
+		if (resultsDir != null) {
+			return resultsDir;
+		}
+		// Set from "surefire.screenshot_directory" Maven property by
+		// eclipse-platform-parent/pom.xml
+		String propertyPath = System.getProperty("eclipse.test.screenshot_directory");
+		if (propertyPath != null) {
+			return new File(propertyPath);
+		}
 
-        resultsDir.mkdirs();
-        return resultsDir;
-    }
+		return new File(System.getProperty("java.io.tmpdir"));
+	}
 
-    private static File getJunitReportOutput() {
+	private static File getJunitReportOutput() {
+		// Current implementation only interfaces with Ant test launcher.
+		// Maven tests do not use "-junitReportOutput" argument.
 		boolean platformAvailable = false;
 		try {
 			Class.forName("org.eclipse.core.runtime.Platform", false, Screenshots.class.getClassLoader());
@@ -140,14 +147,6 @@ public final class Screenshots {
 			}
 		}
 		return null;
-    }
-
-    /**
-     * @return unspecified
-     * @noreference This method is not intended to be referenced by clients.
-     */
-    public static boolean isRunByGerritHudsonJob() {
-        return System.getProperty("user.dir").matches(".*/(?:eclipse|rt\\.equinox)\\.[^/]+-Gerrit/.*");
-    }
+	}
 
 }


### PR DESCRIPTION
Partial fix for eclipse-platform/eclipse.platform.swt#3303.

SWT does not use Platform, so existing heuristics do not work in GitHub Actions.

Once this more sensible screenshot location is set, SWT GHA workflows can be updated to archive screenshots to artifacts. Before the change they have been thrown away and could not be inspected.
