### PR TITLE
[Build] Add V-Build for testing JDT's development for Java Value Objects

### DIFF
--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -59,9 +59,12 @@ pipeline {
 				script {
 					utilities = load 'JenkinsJobs/shared/utilities.groovy'
 					
-					def job = utilities.matchPattern('Job name', "${JOB_BASE_NAME}", [ /(?<type>[IY])-build-(?<major>\d).(?<minor>\d+)/ ])
+					def job = utilities.matchPattern('Job name', "${JOB_BASE_NAME}", [ /(?<type>[A-Z])-build-(?<major>\d).(?<minor>\d+)/ ])
 					// Load build properties and configuration from the properties and configuration file
 					BUILD = readJSON(file: 'JenkinsJobs/buildConfigurations.json')[job.type]
+					if (BUILD == null) {
+						error "Unsupported build type: ${job.type}"
+					}
 					
 					def int jobStart = currentBuild.startTimeInMillis.intdiv(1000)
 					BUILD_PROPERTIES.TIMESTAMP = sh(script: "TZ='America/New_York' date +%Y%m%d-%H%M --date='@${jobStart}'", returnStdout: true).trim()

--- a/JenkinsJobs/buildConfigurations.json
+++ b/JenkinsJobs/buildConfigurations.json
@@ -139,5 +139,66 @@
 				}
 			}
 		]
+	},
+	"V": {
+		"typeName": "Java Value Objects development",
+		"folder": "VBuilds",
+		"streams": {
+			"4.40": {
+				"branch": "master",
+				"schedule": ""
+			}
+		},
+		"branches": {
+			"eclipse.jdt.core": "VALCO_PDOT_1"
+		},
+		"mailingList": "jdt-dev@eclipse.org",
+		"testsFolder": "VBuilds",
+		"tests": [
+			{
+				"os": "linux",
+				"ws": "gtk",
+				"arch": "x86_64",
+				"javaVersion": 21,
+				"agent": "ubuntu-2404",
+				"jdk": {
+					"type": "tool",
+					"name": "temurin-jdk21-latest"
+				}
+			},
+			{
+				"os": "linux",
+				"ws": "gtk",
+				"arch": "x86_64",
+				"javaVersion": 27,
+				"agent": "ubuntu-2404",
+				"jdk": {
+					"type": "install",
+					"url": "https://download.java.net/java/early_access/valhalla/27/1/openjdk-27-jep401ea3+1-1_linux-x64_bin.tar.gz"
+				}
+			},
+			{
+				"os": "macosx",
+				"ws": "cocoa",
+				"arch": "aarch64",
+				"javaVersion": 27,
+				"agent": "nc1ht-macos26-arm64",
+				"jdk": {
+					"type": "install",
+					"url": "https://download.java.net/java/early_access/valhalla/27/1/openjdk-27-jep401ea3+1-1_macos-aarch64_bin.tar.gz"
+				}
+			},
+			{
+				"os": "win32",
+				"ws": "win32",
+				"arch": "x86_64",
+				"javaVersion": 27,
+				"agent": "qa6xd-win11",
+				"jdk": {
+					"type": "install",
+					"url": "https://download.java.net/java/early_access/valhalla/27/1/openjdk-27-jep401ea3+1-1_windows-x64_bin.zip"
+				}
+			}
+		]
 	}
 }

--- a/JenkinsJobs/seedJob.jenkinsfile
+++ b/JenkinsJobs/seedJob.jenkinsfile
@@ -20,6 +20,7 @@ pipeline {
 							'AutomatedTests': [ displayName: 'Automated Tests', description: 'Folder for Unit Tests'],
 							'Builds': [description: 'Eclipse periodic build jobs.'],
 							'YBuilds': [displayName: 'Y Builds', description: 'Builds and tests for the beta java builds.'],
+							'VBuilds': [displayName: 'V Builds', description: 'Builds and tests for the Java Value Objects development builds.'],
 							'Cleanup': [description: 'Cleanup Scripts.'],
 							'Releng': [description: 'Jobs related to routine releng tasks. Some are periodic, some are "manual" jobs ran only when needed.'],
 						]

--- a/scripts/releng/BuildDropDataGenerator.java
+++ b/scripts/releng/BuildDropDataGenerator.java
@@ -255,7 +255,7 @@ JSON.Object createFileDescription(Path file, FileInfo fileInfo) {
 	return fileEntry;
 }
 
-final Pattern INTEGRATION_BUILD_ID = Pattern.compile("(I|Y)(?<date>\\d{8})-(?<time>\\d{4})");
+final Pattern INTEGRATION_BUILD_ID = Pattern.compile("[A-Z](?<date>\\d{8})-(?<time>\\d{4})");
 final ZoneId BUILD_TIMEZONE = ZoneId.of("America/New_York");
 final DateTimeFormatter BASIC_LOCAL_TIME = DateTimeFormatter.ofPattern("HHmm");
 


### PR DESCRIPTION
This adds a V Builds folder in the [`RelEng Jenkins`](https://ci.eclipse.org/releng) that contains a new `V-build-4.40` and the corresponding test jobs.
The `V-build-4.40` job doesn't run on a schedule and always has to be triggered manually.


Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3818

CC @mpalat and @MohananRahul 

~~This is currently a draft since I'm testing the changes, but I expect it to be ready soon.~~