### PR TITLE
[RelEng] Streamline Y-builds p2 repositories

### DIFF
--- a/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
+++ b/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
@@ -306,7 +306,8 @@ pipeline {
 				]
 				build job: 'Releng/modifyP2CompositeRepository', wait: true, propagate: true, parameters: [
 					string(name: 'repositoryPath', value: "eclipse/updates/${NEXT_RELEASE_VERSION}-Y-builds"),
-					string(name: 'repositoryName', value: "Eclipse ${NEXT_RELEASE_VERSION} Beta Java builds")
+					string(name: 'repositoryName', value: "Eclipse ${NEXT_RELEASE_VERSION} Beta Java builds"),
+					string(name: 'add', value: "https://download.eclipse.org/eclipse/updates/${PREVIOUS_RELEASE_VERSION}-Y-builds/"),
 				]
 				build job: 'Releng/modifyP2CompositeRepository', wait: true, propagate: true, parameters: [
 					string(name: 'repositoryPath', value: "eclipse/updates/${NEXT_RELEASE_VERSION}"),
@@ -319,12 +320,6 @@ pipeline {
 					string(name: 'repositoryName', value: "Eclipse latest integration builds"),
 					string(name: 'sizeLimit', value: '1'), // Clear all previous children
 					string(name: 'add', value: "https://download.eclipse.org/eclipse/updates/${NEXT_RELEASE_VERSION}-I-builds/"),
-				]
-				build job: 'Releng/modifyP2CompositeRepository', wait: true, propagate: true, parameters: [
-					string(name: 'repositoryPath', value: "eclipse/updates/Y-builds"),
-					string(name: 'repositoryName', value: "Eclipse latest Beta Java builds"),
-					string(name: 'sizeLimit', value: '1'), // Clear all previous children
-					string(name: 'add', value: "https://download.eclipse.org/eclipse/updates/${NEXT_RELEASE_VERSION}-Y-builds/"),
 				]
 			}
 		}


### PR DESCRIPTION
Populate a new Y-builds composite repo upon creation during the preparation with a redirect to the previous release's composite p2-repository.
This was requested some time ago in an issue I don't recall exactly anymore to make the transition to a new development stream smoother.

This also removes the generic latest Y-build composite currently at:
https://download.eclipse.org/eclipse/updates/Y-builds/

In the past the different schedules of I-builds and Y-builds with respect to the end of each stream lead to repeated confusion and we decided it's simpler to just drop the generic Y-build repository:
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3273
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2927#issuecomment-2729202646
  > Ergo: I don't see much use in the generic Y-build repo.

As far as I can tell, the generic Y-builds repository is not used in builds anymore already:
- https://github.com/eclipse-jdt/eclipse.jdt.core/pull/3821

@stephan-herrmann, @mpalat and @jarthana, are both changes fine for you?