### PR TITLE
[I-Build] Promote Equinox drops only for I-builds

### DIFF
--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -407,6 +407,9 @@ pipeline {
 					}
 				}
 				stage('Equinox') {
+					when {
+						environment name: 'BUILD_TYPE', value: 'I'
+					}
 					stages {
 						stage('Gather Equinox parts') {
 							tools {

--- a/JenkinsJobs/Cleanup/cleanupBuilds.jenkinsfile
+++ b/JenkinsJobs/Cleanup/cleanupBuilds.jenkinsfile
@@ -55,7 +55,6 @@ pipeline {
 					steps {
 						sshagent (['projects-storage.eclipse.org-bot-ssh']) {
 							removeSurplusBuildDrops("${EP_EQUINOX_DROPS}", 'I', EQUINOX_RETENTION_COUNT)
-							removeSurplusBuildDrops("${EP_EQUINOX_DROPS}", 'Y', EQUINOX_RETENTION_COUNT)
 						}
 					}
 				}


### PR DESCRIPTION
For Y-builds and others, Equinox drops are not of interest.

@tjwatson and @laeubi respectivly @jarthana and @mpalat, I assume everyone is fine with dropping the promotion of Y-build (and later V-build) drops for Equinox.
In the past there was generally only little interest in the Equinox sites at all.