### PR TITLE
[RelEng] Clear doc-bundle comparator errors for 4.40 release

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/forceQualifierUpdate.txt
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/forceQualifierUpdate.txt
@@ -1,0 +1,1 @@
+Enforce qualifier update for 4.40 release

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/forceQualifierUpdate.txt
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/forceQualifierUpdate.txt
@@ -1,0 +1,1 @@
+Enforce qualifier update for 4.40 release


### PR DESCRIPTION
For the release the doc-bundles should be cleared of all comparator errors:
https://download.eclipse.org/eclipse/downloads/drops4/I20260525-1800/buildlogs/comparatorlogs/buildtimeComparatorDocBundle.log.txt