### PR TITLE
[RelEng] Escape single quotes in data of queries to the GitHub API

### DIFF
--- a/JenkinsJobs/shared/githubAPI.groovy
+++ b/JenkinsJobs/shared/githubAPI.groovy
@@ -131,6 +131,7 @@ def queryGithubAPI(String method, String endpoint, Map<String, Object> queryPara
 		""".replace('\t','').trim()
 	if (queryParameters != null) {
 		def params = writeJSON(json: queryParameters, returnText: true)
+		params = params.replace("'", "'\\''") // Escape single quotes by '\''
 		query += " -d '" + params + "'"
 	}
 	if (_GH_API_IS_DRY_RUN && !method.isEmpty()) {


### PR DESCRIPTION
Some PR bodies created during the preparation of a new release contain single quotes since:
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3679

Not escaping them breaks the quoting of the data argument of a curl invocation, which is surrounded with single quotes.