### PR TITLE
[I/Y-Build] Use new names of Windows platform product

### DIFF
--- a/production/testScripts/runTests2.xml
+++ b/production/testScripts/runTests2.xml
@@ -98,7 +98,7 @@
       dest="${executionDir}/eclipse-platform-${buildIdToUse}-win32-win32-${osgi.arch}.zip" />
 		<get
       verbose="${selectiveVerbose}"
-      src="${previousReleaseLocation}/eclipse-platform-${previousReleaseVersion}-win32-${osgi.arch}.zip"
+      src="${previousReleaseLocation}/eclipse-platform-${previousReleaseVersion}-win32-win32-${osgi.arch}.zip"
       dest="${platformLocation}/eclipse-platform-${previousReleaseVersion}-win32-win32-${osgi.arch}.zip" />
 	</target>
 	<target


### PR DESCRIPTION
This is the last part of
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3776

and was only applicable after moving to the next stream.

Without it, the execution of I/Y-build tests on Windows fails in the bootstrap phase.