### PR TITLE
[RelEng] Create release issue earlier and enhance its content

### DIFF
--- a/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
+++ b/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
@@ -366,6 +366,7 @@ pipeline {
 						- [ ] Run the [`Create Jobs`](https://ci.eclipse.org/releng/job/CreateJobs/) seed job to create the Jenkins jobs of the new stream
 						- [ ] Start the new [`I-build-${NEXT_RELEASE_VERSION}`](https://ci.eclipse.org/releng/job/Builds/job/I-build-${NEXT_RELEASE_VERSION}/) job for the first I-build of the new stream
 						  - In case the new I-build job is not sufficiently stable, disable it temporarily until it's ready for the usual schedule
+						- [ ] As soon as the new I-build is stable, [`Send the Announcement`](https://ci.eclipse.org/releng/job/Releng/job/sendAnnouncement/) that the master is open again.
 						""".stripIndent(), prBranch)
 					
 					utilities.forEachGitSubmodule{ submodulePath ->

--- a/JenkinsJobs/Releng/sendAnnouncement.jenkinsfile
+++ b/JenkinsJobs/Releng/sendAnnouncement.jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
 		maven 'apache-maven-latest'
 	}
 	stages {
-		stage('Send Mail') {
+		stage('Make Announcement') {
 			steps {
 				script {
 					def utilities = load 'JenkinsJobs/shared/utilities.groovy'
@@ -48,6 +48,7 @@ pipeline {
 					def mavenProperties = readProperties(file: 'eclipse-platform-parent/target/mavenproperties.properties')
 					def simRel = "${mavenProperties.RELEASE_YEAR}-${mavenProperties.RELEASE_MONTH}"
 					def eclipseReleaseDates = utilities.readReleaseDates("${simRel}")
+					def dateFormat = java.time.format.DateTimeFormatter.ofPattern('EEEE, dd MMMM yyyy').localizedBy(Locale.ENGLISH)
 					
 					switch (params.type) {
 					case 'MASTER_OPEN':
@@ -62,7 +63,43 @@ pipeline {
 						if (rcDate == null) {
 							error "RC Reminder can only be sent for default candidates, but not for RC${rcNumber}"
 						}
-						def dateFormat = dateFormat('EEEE, dd MMMM yyyy')
+						def releaseIssue = null
+						if (rcNumber == '2') {
+							def headCommit = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
+							def releaseDocURL = "https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/${headCommit}/RELEASE.md"
+							releaseIssue = githubAPI.createIssue('eclipse-platform/eclipse.platform.releng.aggregator', "Release ${releaseVersion}", """\
+								Umbrella issue to track the final activities for the `${releaseVersion}` release.
+								
+								### RC2 week
+								before the RC2 build at end of ${eclipseReleaseDates.RC2.minusDays(2).format(dateFormat)}:
+								  - [ ] [Create Readme files](${releaseDocURL}#Readme)
+								  - [ ] [Create Migration Guide](${releaseDocURL}#migration-guide)
+								  - [ ] Ensure the build is cleared of comparator errors in doc bundles
+								    - Check this before the final RC2 build and again before promoting the final GA release
+								
+								After RC2 promotion:
+								  - [ ] [Prepare subsequent development cycle](${releaseDocURL}#preparation-for-the-next-release)
+								    - [ ] Perform a _Dry-Run_ with the final parameters (ideally shortly) before and verify correctness
+								
+								### Five days before release
+								at ${eclipseReleaseDates.GA.minusDays(5).format(dateFormat)}
+								  - [ ] [Promote latest RC2(a,b,...) to GA release](${releaseDocURL}#promote-to-ga)
+								  (it is only staged and will be hidden until it's published at release)
+								
+								### One day before release
+								at ${eclipseReleaseDates.GA.minusDays(1).format(dateFormat)}
+								  - [ ] [Publish ${releaseVersion} to Maven central](${releaseDocURL}#complete-publication-to-maven-central)
+								  - [ ] [Contribute ${releaseVersion} to SimRel](${releaseDocURL}#contribute-to-simrel)
+								  - [ ] Submit the pending PRs in this repository to update build scripts to ${releaseVersion} GA on master and the ${releaseVersion}-maintenance branch
+								
+								### Release day
+								at ${eclipseReleaseDates.GA.format(dateFormat)} 15:00 UTC
+								  - [ ] [Publish the staged ${releaseVersion} release build](${releaseDocURL}#make-the-release-visible)
+								
+								### Clean-up after release
+								  - [ ] Delete the old [`I-build-${releaseVersion}`](https://ci.eclipse.org/releng/job/Builds/) job and its associated [Test jobs](https://ci.eclipse.org/releng/job/AutomatedTests/).
+								""".stripIndent())
+						}
 						utilities.sendEmail("Eclipse and Equinox ${releaseVersion} (${simRel}) RC${rcNumber} Reminder", """\
 							We are scheduled to promote and contribute ${releaseVersion} RC${rcNumber} to SimRel on ${rcDate.format(dateFormat)}.
 							
@@ -78,14 +115,21 @@ pipeline {
 							All fixes submitted must have a project lead vote on the bug report, and the fix must be reviewed by an additional committer (any committer other than the one who made the fix).
 							A positive review from a project lead means implicit approval and no vote is needed on the bug report.
 							Ongoing changes to documentation, tests or examples do not require approval.
-							""")
+							""" + (releaseIssue != null ? """
+							
+							Also note:
+							The master branch of each repository will stay closed after RC2 until the preparation of the subsequent development cycle is completed and the reopening was annocuned.
+							
+							The final steps towards the ${releaseVersion} release are tracked in
+							${releaseIssue}
+							""":''))
 						break
 					case 'SIGNOFF_RC':
 						def signOffDeadline = params.deadline ? utilities.parseDate(params.deadline) : eclipseReleaseDates["RC${rcNumber}"]
 						if (signOffDeadline == null) {
 							error "No default deadline for RC${rcNumber}"
 						}
-						def date = dateFormat('EEEE, dd MMMM yyyy').format(signOffDeadline)
+						def date = dateFormat.format(signOffDeadline)
 						def signOffIssueTitle = "Declare ${releaseVersion} RC${rcNumber}"
 						def signOffCandidateDetails = """
 							Current candidate
@@ -113,16 +157,14 @@ pipeline {
 							- ${date}, around 09:00 (UTC)
 							Deadline for sign-off (or, by then, comment in this issue when you expect to sign-off).
 							- ${date}, around 12:00 (UTC)
-							Promote approved build to S-${releaseVersion}${releaseVersion}-* and contribute to simultaneous release repository.
+							Promote approved build to S-${releaseVersion}-* and contribute to simultaneous release repository.
 							
 							Remember to investigate and document here any failing JUnit tests.
 							
 							---
 							- [ ] Platform:
-							  - [ ] Resources
+							  - [ ] Platform
 							  - [ ] UI
-							  - [ ] Debug
-							  - [ ] Ant
 							  - [ ] SWT
 							  - [ ] Releng
 							- [ ] JDT:
@@ -132,38 +174,12 @@ pipeline {
 							- [ ] PDE
 							- [ ] Equinox
 							""".stripIndent())
-						def releaseIssue = null
-						if (rcNumber == '2') {
-							releaseIssue = githubAPI.createIssue('eclipse-platform/eclipse.platform.releng.aggregator', "Release ${releaseVersion}", """\
-								Umbrella issue to track release activities for ${releaseVersion}
-								
-								- [ ] Readme file for ${releaseVersion}
-								- [ ] Migration Guide
-								- [ ] Ensure the build is cleared of comparator errors in doc bundles before RC2 build
-								- [ ] Preparation of the subsequent development cycle
-								  - After RC2 was promoted, run the [`Prepare Next Development Cycle`](https://ci.eclipse.org/releng/job/Releng/job/prepareNextDevCycle/) Jenkins job and complete the tasks listed in the PR created by it in this repository.
-								  - [ ] Run it with final parameters as `dry-run` (ideally shortly) before and verify correctnes.
-								
-								- [ ] Publish ${releaseVersion} to Maven central
-								  - The final publication should be done one or two days before the release to ensure everything is mirrored at the time of release.
-								- [ ] Contribute ${releaseVersion} to SimRel
-								  - Should be done one day before the release to ensure the SimRel aggregation does not contain the RC I-build repo, which is deleted on release day.
-								- [ ] Submit the pending PRs to update build scripts to ${releaseVersion} GA on master and the ${releaseVersion}-maintenance
-								  - Should be done one day before the release
-								
-								- [ ] Delete the old [`I-build-${releaseVersion}`](https://ci.eclipse.org/releng/job/Builds/) job and its associated [Test jobs](https://ci.eclipse.org/releng/job/AutomatedTests/).
-								""".stripIndent())
-						}
 						utilities.sendEmail(signOffIssueTitle, """\
 							Please sign off and declare ${releaseVersion} RC${rcNumber} on
 							${signOffIssue}
 							
 							${signOffCandidateDetails}
-							""" + (releaseIssue != null ? """
-							
-							The final steps towards the ${releaseVersion} release are tracked in
-							${releaseIssue}
-							""":''))	
+							""")	
 						break
 					default:
 						error "Unsupported mail type: ${params.type}"
@@ -172,8 +188,4 @@ pipeline {
 			}
 		}
 	}
-}
-
-def dateFormat(String pattern) {
-	return java.time.format.DateTimeFormatter.ofPattern(pattern).localizedBy(Locale.ENGLISH)
 }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -58,11 +58,10 @@ Tasks that need to be completed before Friday
 
 The job sending the request to sign-off of RC2, also creates the issue to track the final release steps in this repository.
 
-  * **Readme**
-    Currently handled by @SarikaSinha
+  * #### Readme
     - Create a tracking issue in [www.eclipse.org-eclipse](https://github.com/eclipse-platform/www.eclipse.org-eclipse) (see [Readme file for 4.26](https://github.com/eclipse-platform/www.eclipse.org-eclipse/issues/24) as an example).
     - Add Readme files and update generatation scripts.
-  * **Migration Guide**
+  * #### Migration Guide
     - Create a tracking issue in [eclipse.platform.releng.aggregator](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues) and link it to the main release issue.
     - Every release a new porting guide and folder need to be added to [eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/tree/master/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting), named with the version being migrated *to*.
       - i.e `eclipse_4_27_porting_guide.html` is for migrating from 4.26 tp 4.27.
@@ -82,7 +81,7 @@ Sometimes there is a critical issue that requires a fix, if it's decided that on
 The actual steps to release
 
 **Friday**
-  * #### **Promote to GA**
+  * #### Promote to GA
     - After **SimRel** declares RC2 (usually on Friday before the final release) run the [Promote Build](https://ci.eclipse.org/releng/job/Releng/job/promoteBuild/) job to promote RC2 (or RC2a, ...) to be the final release.
       - `DROP_ID`: Final release candidate's ID, e.g.: `S-4.36RC2-202505281830`
       - `CHECKPOINT`: blank for final releases
@@ -92,29 +91,30 @@ The actual steps to release
     - It will again update the Acknowledgements and creates a PR if there are any last changes.
       Review and submit it at https://github.com/eclipse-platform/www.eclipse.org-eclipse/pulls
     - You can subscribe to [cross-project-issues](https://accounts.eclipse.org/mailing-list/cross-project-issues-dev) to get the notifications on Simrel releases.
-  - #### **Contribute to SimRel**
-    - If SimRel is not updated before the I-builds are cleaned up (specifically the build for RC2/GA) it will break. 
 
 **Tuesday/Monday**
-  - #### **Complete Publication to Maven Central**
+  - #### Complete Publication to Maven Central
     - The final release to Maven-Central should happen latest by Tuesday before the release since there is up to a 24 hour delay for the Maven mirrors.
     - The artifacts have been deployed into a Maven-Central _staging_ repository by the `Promote Build` job when the RC was promoted to GA release.
     - Login to https://central.sonatype.com/ and `Publish` the three staging repositories for `Platform`, `JDT` and `PDE` by closing them.
       - Make sure the name of the deployment you are about to release matches the tag and timestamp of the final release repository.
         E.g for a P2 repo with id `R-4.36-202505281830` the deployments should be named `PLATFORM_R-4.36-202505281830`, `PDE_R-4.36-202505281830` or `JDT_R-4.36-202505281830` respectivly.
       - If you do not have an account on `central.sonatype.com` for performing the rest of the release request one by creating an [EF Help Desk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues) issue to get permissions for platform, JDT and PDE projects and tag an existing release engineer to give approval.
-  - #### **Contribute to SimRel**
+  - #### Contribute to SimRel
     - The final release repo has to be contributed to SimRel before the currently active I-build repo is deleted (is done automatically after the release is published)
+  - #### Update build versions to GA
+    - Upon promotion of the final GA build, PRs for the the master and corresponding maintenance branch were created to update the build to the GA versions.
+    - Submit these PRs now.
 
 **Wednesday**
 The release is scheduled for 15:00 UTC.
 
-  - #### **Make the Release Visible**
+  - #### Make the Release Visible
     - Run the [Publish Promoted Build](https://ci.eclipse.org/releng/job/Releng/job/publishPromotedBuild/) job in Releng jenkins to make the promoted build visible on the download page.
       - `releaseBuildID`: the full id of the release build to publish, e.g. `R-4.36-202505281830`
   - The (still existing) I-Build jobs of that release can now be deleted (together with the associdated test jobs), because we are now sure a RC respins won't happen anymore.
 
-### **Preparation for the next Release**
+### Preparation for the next Release
   - After RC2 is promoted/published run the [`Prepare Next Development Cycle`](https://ci.eclipse.org/releng/job/Releng/job/prepareNextDevCycle/) job
     - Review the Pull-Requests created by it in this `eclipse.platform.releng.aggregator` repository and all its submodules and complete the listed tasks.
 


### PR DESCRIPTION
In the created release issue, link the corresponding section of the Release documentation to make the details easily available.

Additionally
- Update list of components in sign-off issue
- Add note and task about reopning the master branch