### PR TITLE
[RelEng] Set publication time at release day to 10:00 UTC

### DIFF
--- a/JenkinsJobs/Releng/sendAnnouncement.jenkinsfile
+++ b/JenkinsJobs/Releng/sendAnnouncement.jenkinsfile
@@ -93,7 +93,7 @@ pipeline {
 								  - [ ] Submit the pending PRs in this repository to update build scripts to ${releaseVersion} GA on master and the ${releaseVersion}-maintenance branch
 								
 								### Release day
-								at ${eclipseReleaseDates.GA.format(dateFormat)} 15:00 UTC
+								at ${eclipseReleaseDates.GA.format(dateFormat)} 10:00 UTC
 								  - [ ] [Publish the staged ${releaseVersion} release build](${releaseDocURL}#make-the-release-visible)
 								
 								### Clean-up after release

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -107,7 +107,7 @@ The actual steps to release
     - Submit these PRs now.
 
 **Wednesday**
-The release is scheduled for 15:00 UTC.
+The release is scheduled for 10:00 UTC.
 
   - #### Make the Release Visible
     - Run the [Publish Promoted Build](https://ci.eclipse.org/releng/job/Releng/job/publishPromotedBuild/) job in Releng jenkins to make the promoted build visible on the download page.


### PR DESCRIPTION
As proposed in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3679#discussion_r3299369137

this moves the time of the final publication of the release at the release day to 12:00 UTC (which translate to 07AM EST, 14:00 CEST or 17:30 IST).
Doing it earlier relaxes the situation for SimRel which wants to release after the Eclipse project.
Since the only task is starting one job, not much preparation time is needed at that day.

Since all people involved in the RelEng work are actually in Europe or India, we could even move this to 10:00 UTC, which would be 12:00 CEST or 15:30 IST.

@merks is that time fine fine for SimRel.
CC @MohananRahul 