### PR TITLE
[RelEng] Automate early redirection for Platform Oomph Setup

### DIFF
--- a/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
+++ b/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
@@ -209,6 +209,30 @@ pipeline {
 				}
 			}
 		}
+		stage('Early setup redirection') {
+			steps {
+				dir('oomph') {
+					script {
+						def previousRC = utilities.loadBuildDropProperties("${PREVIOUS_RELEASE_CANDIDATE_ID}")
+						replaceInFile('Platform.setup', [
+							"early.redirection.${PREVIOUS_RELEASE_VERSION}" : "early.redirection.${NEXT_RELEASE_VERSION}",
+							" ${PREVIOUS_RELEASE_VERSION}" : " ${NEXT_RELEASE_VERSION}",
+							" ${previousRC.PREVIOUS_RELEASE_VER}" : " ${PREVIOUS_RELEASE_VERSION}",
+						])
+						replaceAllInFile('Platform.setup', [
+							'id="early.redirection"\\s+disabled="true"' : 'id="early.redirection"',
+							*:redirectionTaskReplacementEntry('early.redirection.ibuild',
+								"https://download.eclipse.org/eclipse/updates/${PREVIOUS_RELEASE_VERSION}-I-builds",
+								"https://download.eclipse.org/eclipse/updates/${NEXT_RELEASE_VERSION}-I-builds"),
+							*:redirectionTaskReplacementEntry('early.redirection.baseline',
+								"https://download.eclipse.org/eclipse/updates/${previousRC.PREVIOUS_RELEASE_REPO_ID}/${previousRC.PREVIOUS_RELEASE_ID}",
+								"https://download.eclipse.org/eclipse/updates/${PREVIOUS_RELEASE_VERSION}-I-builds/${PREVIOUS_RELEASE_CANDIDATE_I_BUILD}"),
+						])
+						sh "git commit --message 'Enable and update early redirection for ${NEXT_RELEASE_VERSION} in platform setup' ."
+					}
+				}
+			}
+		}
 		stage('Apply individual updates') {
 			environment {
 				UPDATE_SCRIPT = 'prepareNextDevCycle.sh'
@@ -444,3 +468,9 @@ def replaceAllInFile(String filePath, Map<String,String> replacements) {
 def gitCommitAllExcludingSubmodules(String commitMessage) {
 	utilities.gitCommitAllExcludingSubmodules(commitMessage)
 }
+
+def redirectionTaskReplacementEntry(String taskId, String newSourceURL, String newTargetURL) {
+	def regex = """(?s)(?<sourcePrefix>id="${java.util.regex.Pattern.quote(taskId)}".+?sourceURL=")[^"]+(?<targetPrefix>"\\s+?targetURL=")[^"]+"""
+	return [ (regex) : "\${sourcePrefix}${newSourceURL}\${targetPrefix}${newTargetURL}"]
+}
+

--- a/JenkinsJobs/Releng/promoteBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/promoteBuild.jenkinsfile
@@ -241,6 +241,12 @@ pipeline {
 						}
 						
 						utilities.gitCommitAllExcludingSubmodules("Update previous release version to ${BUILD_MAJOR}.${BUILD_MINOR} GA across build scripts")
+						
+						// Disable early setup redirection
+						utilities.replaceAllInFile('oomph/Platform.setup', [
+							'(?<=id="early\\.redirection")(?<separator>\\s+)' : '${separator}disabled="true"${separator}',
+						])
+						utilities.gitCommitAllExcludingSubmodules("Disable early redirection for ${BUILD_MAJOR}.${BUILD_MINOR} in platform setup")
 					}
 					script { // Update the maintenance branch
 						sh 'git checkout -b updateMaintenance "origin/${MAINTENANCE_BRANCH}"'

--- a/oomph/Platform.setup
+++ b/oomph/Platform.setup
@@ -179,29 +179,33 @@
         defaultEditorID="org.eclipse.ui.genericeditor.GenericEditor"/>
   </setupTask>
   <setupTask
-      xsi:type="setup:VariableTask"
-      type="BOOLEAN"
-      name="early.redirection.4.41"
-      defaultValue="true"
-      storageURI="scope://Workspace"
-      label="Early redirect to 4.41">
-    <description>Redirect 4.39 p2 repos to 4.40 and redirect 4.40 repos to 4.41 to begin development on the open master streams immediately.</description>
-  </setupTask>
-  <setupTask
       xsi:type="setup:CompoundTask"
-      filter="(early.redirection.4.41=true)"
-      name="EarlyRedirection">
+      id="early.redirection"
+      name="Early Redirection">
     <setupTask
-        xsi:type="setup:RedirectionTask"
-        sourceURL="https://download.eclipse.org/eclipse/updates/4.40-I-builds"
-        targetURL="https://download.eclipse.org/eclipse/updates/4.41-I-builds">
-      <description>Redirect 4.40 I-builds to 4.41 I-builds</description>
+        xsi:type="setup:VariableTask"
+        type="BOOLEAN"
+        name="early.redirection.4.41"
+        defaultValue="true"
+        storageURI="scope://Workspace"
+        label="Early redirect to 4.41">
+      <description>Redirect baseline release p2 repo to 4.40 RC and the current I-builds repo to 4.41-I-builds to begin development on the open master streams immediately.</description>
     </setupTask>
     <setupTask
         xsi:type="setup:RedirectionTask"
+        id="early.redirection.ibuild"
+        filter="(early.redirection.4.41=true)"
+        sourceURL="https://download.eclipse.org/eclipse/updates/4.40-I-builds"
+        targetURL="https://download.eclipse.org/eclipse/updates/4.41-I-builds">
+      <description>Redirect I-builds repository to next release I-builds</description>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:RedirectionTask"
+        id="early.redirection.baseline"
+        filter="(early.redirection.4.41=true)"
         sourceURL="https://download.eclipse.org/eclipse/updates/4.39/R-4.39-202602260420"
         targetURL="https://download.eclipse.org/eclipse/updates/4.40-I-builds/I20260528-0011">
-      <description>Redirect the release 4.39 build to the final 4.40 I-build which should point at the simple repository to avoid redirecting to 4.40 while it's still empty before the actual release</description>
+      <description>Redirect the previous release baseline p2 repo to the final RC I-build repo of the upcoming release which should point at the simple repository to avoid redirecting to the upcoming release repo while it's still empty before the actual release.</description>
     </setupTask>
   </setupTask>
   <project name="platform"


### PR DESCRIPTION
Update and enable the early redirection for the Platform setup when preparing a new development cycle.
When promoting the GA artifacts of the previous RC, disable the redirection again.

In order to simplify this process, the structure of the redirection tasks is slightly adjusted.

Since the required testing is pending , this is currently a draft.