### PR TITLE
Remove ISV doc references to deleted org.eclipse.core.runtime.contentTypes extension point

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/runtime_content_contributing.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/runtime_content_contributing.htm
@@ -17,16 +17,16 @@
   other plug-ins. We will look at how the platform defines some of its content 
   types in order to better understand the content type framework.</p>
 <p>Plug-ins define content types by contributing an extension for the extension 
-  point <b><a href="../reference/extension-points/org_eclipse_core_runtime_contentTypes.html">org.eclipse.core.runtime.contentTypes</a></b>. 
+  point <b><a href="../reference/extension-points/org_eclipse_core_contenttype_contentTypes.html">org.eclipse.core.contenttype.contentTypes</a></b>.
   In this extension, a plug-in specifies a simple id and name for the content 
   type (the full id is always the simple id prefixed by the current namespace). 
   The following snippet shows a trimmed down version of the <code>org.eclipse.core.runtime.text</code> 
   content type contribution:</p>
 <pre>
-	&lt;extension point="org.eclipse.core.runtime.contentTypes"&gt;
-		&lt;content-type 
+	&lt;extension point="org.eclipse.core.contenttype.contentTypes"&gt;
+		&lt;content-type
 			id="text"
-			name="%textContentTypeName"&gt;
+			name="%textContentTypeName"
 			file-extensions="txt"&gt;
 			&lt;describer class=&quot;org.eclipse.core.internal.content.TextContentDescriber&quot;/&gt;
 		&lt;/content-type&gt;
@@ -102,7 +102,7 @@
 <p>New file associations can be added to existing content types. For instance, 
   the Resources plug-in associates the <code>org.eclipse.core.runtime.xml</code> 
   to &quot;.project&quot; files:</p>
-<pre>&lt;extension point="org.eclipse.core.runtime.contentTypes"&gt;
+<pre>&lt;extension point="org.eclipse.core.contenttype.contentTypes"&gt;
 	&lt;file-association content-type=&quot;org.eclipse.core.runtime.xml&quot; file-names=&quot;.project&quot;/&gt;
 	...
 </pre>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/extension-points/index.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/reference/extension-points/index.html
@@ -40,11 +40,6 @@
         "org_eclipse_core_runtime_applications.html">org.eclipse.core.runtime.applications</a>
       </li>
       <li>
-
-        <a href=
-        "org_eclipse_core_runtime_contentTypes.html">org.eclipse.core.runtime.contentTypes</a>
-      </li>
-      <li>
         <a href=
         "org_eclipse_core_runtime_preferences.html">org.eclipse.core.runtime.preferences</a>
       </li>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/topics_Reference.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/topics_Reference.xml
@@ -328,7 +328,6 @@
        <topic label="org.eclipse.core.resources.variableResolvers" href="reference/extension-points/org_eclipse_core_resources_variableResolvers.html"/>
        <topic label="org.eclipse.core.runtime.adapters" href="reference/extension-points/org_eclipse_core_runtime_adapters.html"/>
        <topic label="org.eclipse.core.runtime.applications" href="reference/extension-points/org_eclipse_core_runtime_applications.html"/>
-       <topic label="org.eclipse.core.runtime.contentTypes" href="reference/extension-points/org_eclipse_core_runtime_contentTypes.html"/>
        <topic label="org.eclipse.core.runtime.preferences" href="reference/extension-points/org_eclipse_core_runtime_preferences.html"/>
        <topic label="org.eclipse.core.runtime.products" href="reference/extension-points/org_eclipse_core_runtime_products.html"/>
        <topic label="org.eclipse.core.variables.dynamicVariables" href="reference/extension-points/org_eclipse_core_variables_dynamicVariables.html"/>


### PR DESCRIPTION
The long-deprecated `org.eclipse.core.runtime.contentTypes` extension point and its `contentTypes.exsd` schema are being removed from `org.eclipse.core.runtime` in eclipse.platform PR #1644. Since `org.eclipse.platform.doc.isv` lives here, the stale doc references have to go too, otherwise `org.eclipse.ua.tests.doc` `ApiDocTest#testTopicsReference` fails because the ISV doc TOC lists an extension point that is no longer registered at runtime.

This removes the `topics_Reference.xml` TOC entry and the matching link in the extension-points index, and repoints the content-types guide to the still-valid replacement extension point `org.eclipse.core.contenttype.contentTypes`.