### PR TITLE
ci: scope htmlvalidator workflow token to contents: read

### DIFF
--- a/.github/workflows/htmlvalidator.yml
+++ b/.github/workflows/htmlvalidator.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - '**.htm*'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Small hardening change: set `permissions: contents: read` at the top of `.github/workflows/htmlvalidator.yml` so the workflow token is read-only instead of inheriting the repository default. The job only does checkout and build/test, so nothing else is required.