### PR TITLE
Replace abandoned Wandalen/wretry.action in version increment workflow

### DIFF
--- a/.github/workflows/checkVersions.yml
+++ b/.github/workflows/checkVersions.yml
@@ -74,15 +74,22 @@ jobs:
         ${{ inputs.extra-setup-command }}
 
     - name: Check and increment versions
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # master
-      with:
-        attempt_delay: 200
-        attempt_limit: 10
-        current_path: ${{ inputs.working-directory }}
-        command: >
-          mvn verify ${{ inputs.extra-maven-args }} -DskipTests -Dcompare-version-with-baselines.skip=false
-          org.eclipse.tycho:tycho-versions-plugin:bump-versions -Dtycho.bump-versions.increment=100
-          --update-snapshots --threads 1C --fail-at-end --show-version
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set +e -x
+        attemptLimit=10
+        attempt=0
+        while ((attempt++ < ${attemptLimit})); do
+          mvn verify ${{ inputs.extra-maven-args }} -DskipTests -Dcompare-version-with-baselines.skip=false \
+            org.eclipse.tycho:tycho-versions-plugin:bump-versions -Dtycho.bump-versions.increment=100 \
+            --update-snapshots --threads 1C --fail-at-end --show-version
+          if [[ $? -eq 0 ]]; then
+            echo "Attempt ${attempt} successful. Exit."
+            exit 0
+          fi
+        done
+        echo "Attempt limit of ${attemptLimit} reached. Abort!"
+        exit 1
 
     - name: Commit version increments, if any
       run: |


### PR DESCRIPTION
The `com/Wandalen/wretry.action` seems not to be updated anymore and is using the deprecated Node.js 20:
- https://github.com/Wandalen/wretry.action/issues/193

This replaces it by a simple loop in bash.