### PR TITLE
Fix documentation after

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/removals.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/porting/removals.html
@@ -110,32 +110,6 @@ The following dialogs are planned to be removed from this package:
 For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=448275" target="_blank">bug 448275</a>.
 </p>
 
-
-<!-- ############################################## -->
-
-<h2>API Removals After March 2021</h2>
-
-<h3 id="commandsutil">1. org.eclipse.core.commands.util Package</h3>
-
-The <code>org.eclipse.core.commands.util</code> package is planned to be removed. It contains one utility class for tracing code.
-
-<p>
-For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=143992" target="_blank">bug 143992</a>.
-</p>
-
-<h3 id="equinoxlauncher">3. org.eclipse.core.launcher#Main and WebStartMain and Related Interfaces</h3>
-
-The classes <code>org.eclipse.core.launcher.Main</code>, <code>org.eclipse.equinox.launcher.WebStartMain</code> its related interfaces will be deleted.
-
-<p>
-For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=544262" target="_blank">bug 544262</a>.
-</p>
-
-
-<!-- ############################################## -->
-
-<h2>API Removals After June 2021</h2>
-
 <!-- ############################################## -->
 
 <h2>API Removals After May 2022</h2>
@@ -627,6 +601,25 @@ The following deprecated contents of org.eclipse.ui.commands are not used anymor
 
 <p>
 For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=431177" target="_blank">bug 431177</a>.
+</p>
+
+<h2>API Removals in the Eclipse 4.32 Release</h2>
+<h3 id="equinoxlauncher">3. org.eclipse.core.launcher#Main and WebStartMain and Related Interfaces</h3>
+
+The classes <code>org.eclipse.core.launcher.Main</code>, <code>org.eclipse.equinox.launcher.WebStartMain</code> its related interfaces will be deleted.
+
+<p>
+For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=544262" target="_blank">bug 544262</a>.
+</p>
+
+
+<h2>API Removals in the Eclipse 4.41 Release</h2>
+<h3 id="commandsutil">1. org.eclipse.core.commands.util Package</h3>
+
+The <code>org.eclipse.core.commands.util</code> package is planned to be removed. It contains one utility class for tracing code.
+
+<p>
+For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=143992" target="_blank">bug 143992</a>.
 </p>
 
 

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/topics_Reference.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/topics_Reference.xml
@@ -16,7 +16,6 @@
       <topic label="org.eclipse.core.commands.common" href="reference/api/org/eclipse/core/commands/common/package-summary.html"/>
       <topic label="org.eclipse.core.commands.contexts" href="reference/api/org/eclipse/core/commands/contexts/package-summary.html"/>
       <topic label="org.eclipse.core.commands.operations" href="reference/api/org/eclipse/core/commands/operations/package-summary.html"/>
-      <topic label="org.eclipse.core.commands.util" href="reference/api/org/eclipse/core/commands/util/package-summary.html"/>
       <topic label="org.eclipse.core.databinding" href="reference/api/org/eclipse/core/databinding/package-summary.html"/>
       <topic label="org.eclipse.core.databinding.beans" href="reference/api/org/eclipse/core/databinding/beans/package-summary.html"/>
       <topic label="org.eclipse.core.databinding.conversion" href="reference/api/org/eclipse/core/databinding/conversion/package-summary.html"/>


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.ui/pull/4065

Fixes a test failure in I-build:
```
org.eclipse.ua.tests.doc.internal.linkchecker.ApiDocTest	testTopicsReference()	Failure	Expecting
empty but was: " * Unexpected exported API packages in
topics_Reference.xml: org.eclipse.core.commands.util "

java.lang.AssertionError:
Expecting empty but was: "
* Unexpected exported API packages in topics_Reference.xml:
org.eclipse.core.commands.util
"
at org.eclipse.ua.tests.doc.internal.linkchecker.ApiDocTest.testTopicsReference(ApiDocTest.java:181)
at java.base/java.lang.reflect.Method.invoke(Method.java:580)
at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```