### PR TITLE
[Build] Simplify skipping the baseline check for test projects

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -919,26 +919,9 @@
           <value>eclipse-test-plugin</value>
         </property>
       </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-p2-extras-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <executions>
-              <execution>
-                <id>compare-attached-artifacts-with-release</id>
-                <goals>
-                  <goal>compare-version-with-baselines</goal>
-                </goals>
-                <configuration>
-                  <skip>true</skip>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
+      <properties>
+        <version.baseline.check.skip>true</version.baseline.check.skip>
+      </properties>
     </profile>
     <profile>
       <id>eclipse-sign</id>
@@ -1185,6 +1168,9 @@
     </profile>
     <profile>
         <id>javac</id>
+        <properties>
+          <version.baseline.check.skip>true</version.baseline.check.skip>
+        </properties>
         <build>
             <pluginManagement>
                 <plugins>
@@ -1205,22 +1191,6 @@
                             <baselineReplace>none</baselineReplace>
                             <baselineMode>disable</baselineMode>
                         </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.eclipse.tycho.extras</groupId>
-                        <artifactId>tycho-p2-extras-plugin</artifactId>
-                        <version>${tycho.version}</version>
-                        <executions>
-                            <execution>
-                                <id>compare-attached-artifacts-with-release</id>
-                                <goals>
-                                    <goal>compare-version-with-baselines</goal>
-                                </goals>
-                                <configuration>
-                                    <skip>true</skip>
-                                </configuration>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </pluginManagement>


### PR DESCRIPTION
Re-use the 'version.baseline.check.skip' Maven property that already exists for this purpose.

This simplifies the solution introduced in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3785

and leverages the property introduced via
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2381