### PR TITLE
Remove com.ibm.icu extraRequirement from ISV doc builds

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/pom.xml
@@ -86,11 +86,6 @@
                   </requirement>
                   <requirement>
                     <type>eclipse-plugin</type>
-                    <id>com.ibm.icu</id>
-                    <versionRange>0.0.0</versionRange>
-                  </requirement>
-                  <requirement>
-                    <type>eclipse-plugin</type>
                     <id>org.apache.ant</id>
                     <versionRange>0.0.0</versionRange>
                   </requirement>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
@@ -80,11 +80,6 @@
                 <extraRequirements>
                   <requirement>
                     <type>eclipse-plugin</type>
-                    <id>com.ibm.icu</id>
-                    <versionRange>0.0.0</versionRange>
-                  </requirement>
-                  <requirement>
-                    <type>eclipse-plugin</type>
                     <id>org.osgi.service.event</id>
                     <versionRange>0.0.0</versionRange>
                   </requirement>


### PR DESCRIPTION
The platform and JDT ISV documentation bundles no longer reference any com.ibm.icu API, so the bundle is no longer required to resolve javadoc references during documentation generation. This drops the now-obsolete `com.ibm.icu` extraRequirement from both `org.eclipse.platform.doc.isv` and `org.eclipse.jdt.doc.isv` poms, removing one more lingering tie to ICU from the doc build.