### PR TITLE
Remove unused com.ibm.icu icu4j dependency from SDK prereqs target

### DIFF
--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -113,12 +113,6 @@
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>
-				  <groupId>com.ibm.icu</groupId>
-				  <artifactId>icu4j</artifactId>
-				  <version>78.3</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
 				  <groupId>commons-fileupload</groupId>
 				  <artifactId>commons-fileupload</artifactId>
 				  <version>1.6.0</version>


### PR DESCRIPTION
Nothing in the Eclipse SDK source consumes `com.ibm.icu` anymore. No production bundle declares a `Require-Bundle` or `Import-Package` on it, and no Java source imports it; the only remaining references in the tree are test fixtures and old test data. Following the recent removal of the icu4j `extraRequirement` from the ISV doc builds, the icu4j entry in the `eclipse-sdk-prereqs` target is now dead weight, so this drops it.

This shrinks the target platform and removes a long-standing third-party dependency that the SDK no longer needs.