### PR TITLE
Move I/Y-Build and RelEng jobs to build with Java-25

### DIFF
--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
 		}
 	}
 	tools {
-		jdk 'temurin-jdk21-latest'
+		jdk 'temurin-jdk25-latest'
 		maven 'apache-maven-latest'
 	}
 	environment {
@@ -209,9 +209,6 @@ pipeline {
 			}
 		}
 		stage('Check for comparator errors') {
-			tools {
-				jdk 'temurin-jdk25-latest'
-			}
 			steps {
 				sh '''#!/bin/bash -xe
 					# Gather maven properties
@@ -255,9 +252,6 @@ pipeline {
 				stage('Eclipse') {
 					stages {
 						stage('Gather Eclipse parts') {
-							tools {
-								jdk 'temurin-jdk25-latest'
-							}
 							steps {
 								dir("${DROP_DIR}/${BUILD_ID}") {
 									script {
@@ -412,9 +406,6 @@ pipeline {
 					}
 					stages {
 						stage('Gather Equinox parts') {
-							tools {
-								jdk 'temurin-jdk25-latest'
-							}
 							steps {
 								dir("${EQUINOX_DROP_DIR}/${BUILD_ID}") {
 									script {
@@ -522,9 +513,6 @@ pipeline {
 			}
 		}
 		stage('Archive build logs') {
-			tools {
-				jdk 'temurin-jdk25-latest'
-			}
 			environment {
 				JENKINS_API_TOKEN = credentials('jenkins-api') // username:password
 			}

--- a/JenkinsJobs/Releng/deployToMaven.jenkinsfile
+++ b/JenkinsJobs/Releng/deployToMaven.jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
 		label 'basic'
 	}
 	tools {
-		jdk 'temurin-jdk21-latest'
+		jdk 'temurin-jdk25-latest'
 		maven 'apache-maven-latest'
 		maven 'maven-daemon'
 	}

--- a/JenkinsJobs/Releng/modifyP2CompositeRepository.jenkinsfile
+++ b/JenkinsJobs/Releng/modifyP2CompositeRepository.jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
 		label 'basic'
 	}
 	tools {
-		jdk 'temurin-jdk21-latest'
+		jdk 'temurin-jdk25-latest'
 		maven 'apache-maven-latest'
 	}
 	stages {

--- a/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
+++ b/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
 		label 'ubuntu-2404'
 	}
 	tools {
-		jdk 'temurin-jdk21-latest'
+		jdk 'temurin-jdk25-latest'
 		maven 'apache-maven-latest'
 	}
 	environment {

--- a/JenkinsJobs/Releng/promoteBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/promoteBuild.jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
 		DRY_RUN_PREFIX = "${params.DRY_RUN ? 'eclipse/try-outs/' : ''}"
 	}
 	tools {
-		jdk 'temurin-jdk21-latest'
+		jdk 'temurin-jdk25-latest'
 		maven 'apache-maven-latest'
 	}
 	stages {

--- a/JenkinsJobs/Releng/publishPromotedBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/publishPromotedBuild.jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
 		label 'basic'
 	}
 	tools {
-		jdk 'temurin-jdk21-latest'
+		jdk 'temurin-jdk25-latest'
 		maven 'apache-maven-latest'
 	}
 	environment {

--- a/JenkinsJobs/Releng/sendAnnouncement.jenkinsfile
+++ b/JenkinsJobs/Releng/sendAnnouncement.jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
 		label 'basic'
 	}
 	tools {
-		jdk 'temurin-jdk21-latest'
+		jdk 'temurin-jdk25-latest'
 		maven 'apache-maven-latest'
 	}
 	stages {


### PR DESCRIPTION
SimRel starts to accept Java-25 bundles, and although the bundles of the Eclipse top level project still must still require only on Java-21, the build and RelEng infrastructure can already be moved to use Java-25 as a first step in that direction.
It also simplifies the build pipeline a bit.

Since the I/Y-build runs with the `bree-libs` profile activated, a JDK matching each bundle's BREE is selected from the toolchain for compilation anyway.

I/Y-build tests remain on their current JDK to test the Java-21 baseline.

@akurtakov this is what we discussed today at the PMC meeting.