### PR TITLE
[I-Build] Run tests on macOS ARM with Java-25

### DIFF
--- a/JenkinsJobs/buildConfigurations.json
+++ b/JenkinsJobs/buildConfigurations.json
@@ -48,7 +48,7 @@
 				"os": "macosx",
 				"ws": "cocoa",
 				"arch": "aarch64",
-				"javaVersion": 21,
+				"javaVersion": 25,
 				"agent": "nc1ht-macos26-arm64",
 				"jdk": {
 					"type": "temurin"


### PR DESCRIPTION
Run tests on macOS ARM with Java-25 to increase the Java version coverage on macOS.