### PR TITLE
Enforces qualifier update on doc bundles due to build with Java-25

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/forceQualifierUpdate.txt
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/forceQualifierUpdate.txt
@@ -1,0 +1,1 @@
+Consider changes due to build with Java-25

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/forceQualifierUpdate.txt
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/forceQualifierUpdate.txt
@@ -1,0 +1,1 @@
+Consider changes due to build with Java-25


### PR DESCRIPTION
This also enforces a new qualifier update on the doc bundles to clear them from comparator errors in the context of
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3891