### PR TITLE
[RelEng] Update Release procedure to promote to GA artifacts earlier

### DIFF
--- a/JenkinsJobs/Releng/promoteBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/promoteBuild.jenkinsfile
@@ -274,20 +274,28 @@ pipeline {
 						utilities.gitPushBranch('master', "update-build-to-R${BUILD_MAJOR}.${BUILD_MINOR}", /*force*/ true)
 						utilities.gitPushBranch('updateMaintenance', "update-${MAINTENANCE_BRANCH}", /*force*/ true)
 						
+						def releaseIssue = githubAPI.findIssue('eclipse-platform/eclipse.platform.releng.aggregator', "Release ${BUILD_MAJOR}.${BUILD_MINOR}")
+						
 						def masterPR = githubAPI.createPullRequest('eclipse-platform/eclipse.platform.releng.aggregator',
 							"Update previous release version to ${BUILD_MAJOR}.${BUILD_MINOR} GA across build scripts", """\
-							Update the the `${MAINTENANCE_BRANCH}` branch with final ${BUILD_MAJOR}.${BUILD_MINOR} release version.
+							Update the `master` branch with final ${BUILD_MAJOR}.${BUILD_MINOR} release versions.
 							
-							**This should not be submitted before ${BUILD_MAJOR}.${BUILD_MINOR} is finally released.**
+							**This should be submitted immediately before the ${BUILD_MAJOR}.${BUILD_MINOR} release is finally published.**
+							
+							Part of
+							- ${releaseIssue}
 							""".stripIndent(),"update-build-to-R${BUILD_MAJOR}.${BUILD_MINOR}", 'master', /*skipExistingPR*/ true)
 						
 						githubAPI.createPullRequest('eclipse-platform/eclipse.platform.releng.aggregator',
 							"Update ${MAINTENANCE_BRANCH} branch with release version for ${BUILD_MAJOR}_${BUILD_MINOR}+ changes", """\
-							Update the the `${MAINTENANCE_BRANCH}` branch with final ${BUILD_MAJOR}.${BUILD_MINOR} release version.
+							Update the `${MAINTENANCE_BRANCH}` branch with final ${BUILD_MAJOR}.${BUILD_MINOR} release versions.
 							This complements:
 							- ${masterPR}
 							
-							**This should not be submitted before ${BUILD_MAJOR}.${BUILD_MINOR} is finally released.**
+							**This should be submitted immediately before the ${BUILD_MAJOR}.${BUILD_MINOR} release is finally published.**
+							
+							Part of
+							- ${releaseIssue}
 							""".stripIndent(),"update-${MAINTENANCE_BRANCH}", "${MAINTENANCE_BRANCH}", /*skipExistingPR*/ true)
 					}
 				}

--- a/JenkinsJobs/Releng/publishPromotedBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/publishPromotedBuild.jenkinsfile
@@ -129,19 +129,19 @@ pipeline {
 					We are pleased to announce that Eclipse and Equinox ${RELEASE_VERSION_MAJOR}.${RELEASE_VERSION_MINOR} ${CHECKPOINT} (for ${TRAIN_NAME}) is available for download and updates.
 					
 						Eclipse downloads:
-						https://download.eclipse.org/eclipse/downloads/drops4/${RELEASE_BUILD_ID}/
+						https://download.eclipse.org/eclipse/downloads/drops4/${RELEASE_BUILD_ID}
 						
 						New and Noteworthy:
-						https://www.eclipse.org/eclipse/news/${RELEASE_VERSION_MAJOR}.${RELEASE_VERSION_MINOR}/
+						https://www.eclipse.org/eclipse/news/${RELEASE_VERSION_MAJOR}.${RELEASE_VERSION_MINOR}
 						
 						Update existing ${ RELEASE_TYPE != 'R' ? '(non-production) ' : ''}installations:
-						https://download.eclipse.org/eclipse/updates/${REPOSITORY_PATH.substring(0, REPOSITORY_PATH.lastIndexOf('/'))}/
+						https://download.eclipse.org/eclipse/updates/${REPOSITORY_PATH.substring(0, REPOSITORY_PATH.lastIndexOf('/'))}
 						
 						Specific repository good for building against:
-						https://download.eclipse.org/eclipse/updates/${REPOSITORY_PATH}/
+						https://download.eclipse.org/eclipse/updates/${REPOSITORY_PATH}
 						
 						Equinox specific downloads:
-						https://download.eclipse.org/equinox/drops/${RELEASE_BUILD_ID}/
+						https://download.eclipse.org/equinox/drops/${RELEASE_BUILD_ID}
 					
 					Thank you to everyone who made this checkpoint possible.
 					""")

--- a/JenkinsJobs/Releng/sendAnnouncement.jenkinsfile
+++ b/JenkinsJobs/Releng/sendAnnouncement.jenkinsfile
@@ -74,32 +74,32 @@ pipeline {
 								
 								### RC2 week
 								before the RC2 build at end of ${eclipseReleaseDates.RC2.minusDays(2).format(dateFormat)}:
-								  - [ ] [Create Readme files](${releaseDocURL}#Readme)
-								  - [ ] [Create Migration Guide](${releaseDocURL}#migration-guide)
-								  - [ ] Ensure the build is cleared of comparator errors in doc bundles
-								    - Check this before the final RC2 build and again before promoting the final GA release
+								- [ ] [Create Readme files](${releaseDocURL}#Readme)
+								- [ ] [Create Migration Guide](${releaseDocURL}#migration-guide)
+								- [ ] Ensure the build is cleared of comparator errors in doc bundles
+								  - Check this before the final RC2 build and again before promoting the final GA release
 								
 								After RC2 promotion:
-								  - [ ] [Prepare subsequent development cycle](${releaseDocURL}#preparation-for-the-next-release)
-								    - [ ] Perform a _Dry-Run_ with the final parameters (ideally shortly) before and verify correctness
+								- [ ] [Prepare subsequent development cycle](${releaseDocURL}#preparation-for-the-next-release)
+								  - [ ] Perform a _Dry-Run_ with the final parameters (ideally shortly) before and verify correctness
 								
-								### Five days before release
-								at ${eclipseReleaseDates.GA.minusDays(5).format(dateFormat)}
-								  - [ ] [Promote latest RC2(a,b,...) to GA release](${releaseDocURL}#promote-to-ga)
-								  (it is only staged and will be hidden until it's published at release)
+								### One week before release
+								at ${eclipseReleaseDates.GA.minusDays(7).format(dateFormat)} end of business day
+								- [ ] [Promote latest RC2(a,b,...) to GA release](${releaseDocURL}#promote-to-ga)
+								(it is only staged and will be hidden until it's published at release)
+								- [ ] [Contribute ${releaseVersion} to SimRel](${releaseDocURL}#contribute-to-simrel)
 								
 								### One day before release
 								at ${eclipseReleaseDates.GA.minusDays(1).format(dateFormat)}
-								  - [ ] [Publish ${releaseVersion} to Maven central](${releaseDocURL}#complete-publication-to-maven-central)
-								  - [ ] [Contribute ${releaseVersion} to SimRel](${releaseDocURL}#contribute-to-simrel)
-								  - [ ] Submit the pending PRs in this repository to update build scripts to ${releaseVersion} GA on master and the ${releaseVersion}-maintenance branch
+								- [ ] [Publish ${releaseVersion} to Maven central](${releaseDocURL}#complete-publication-to-maven-central)
 								
 								### Release day
 								at ${eclipseReleaseDates.GA.format(dateFormat)} 10:00 UTC
-								  - [ ] [Publish the staged ${releaseVersion} release build](${releaseDocURL}#make-the-release-visible)
+								- [ ] Submit the pending PRs updating build scripts to ${releaseVersion} GA on `master` and the `${releaseVersion}-maintenance` branch
+								- [ ] [Publish the staged ${releaseVersion} release build](${releaseDocURL}#make-the-release-visible)
 								
-								### Clean-up after release
-								  - [ ] Delete the old [`I-build-${releaseVersion}`](https://ci.eclipse.org/releng/job/Builds/) job and its associated [Test jobs](https://ci.eclipse.org/releng/job/AutomatedTests/).
+								### After the release
+								- [ ] Delete the old [`I-build-${releaseVersion}`](https://ci.eclipse.org/releng/job/Builds/) job and its associated [test jobs](https://ci.eclipse.org/releng/job/AutomatedTests/).
 								""".stripIndent())
 						}
 						utilities.sendEmail("Eclipse and Equinox ${releaseVersion} (${simRel}) RC${rcNumber} Reminder", """\

--- a/JenkinsJobs/shared/githubAPI.groovy
+++ b/JenkinsJobs/shared/githubAPI.groovy
@@ -76,23 +76,32 @@ def findMilestoneNumber(String orgaRepo, String title) {
 	// Iterate over all (open and closed) milestones, sorted by decending due-date.
 	// See https://docs.github.com/en/rest/issues/milestones?apiVersion=2026-03-10#list-milestones
 	// Consider even closed milestones to make the pipelines more robust in case some milestones are closed manually
-	def perPage = 10 // Should usually be sufficient
-	def maxPage = 100
+	def milestone = findElement("repos/${orgaRepo}/milestones?state=all&sort=due_on&direction=desc", {ms -> ms.title == title})
+	if (milestone == null) {
+		error "Milestone '${title}' not found among the most recent ~1000 milestones"
+	}
+	return milestone
+}
+
+private Object findElement(String query, Closure predicate) {
+	// See https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2026-03-10
+	def perPage = 30 // Should usually be sufficient
+	def maxPage = 33
 	for (int page in 1..maxPage) {
-		def response = queryGithubAPI('', "repos/${orgaRepo}/milestones?state=all&sort=due_on&direction=desc&per_page=${perPage}&page=${page}")
+		def response = queryGithubAPI('', "${query}&per_page=${perPage}&page=${page}")
 		if (!(response instanceof List) && isFailed(response, 200)) {
 			error "Response contains errors:\n${response}"
 		}
-		for (milestone in response) {
-			if(milestone.title == title) {
-				return milestone.number
+		for (element in response) {
+			if (predicate.call(element)) {
+				return element
 			}
 		}
 		if (response.size() < perPage) {
 			break; // last page reached
 		}
 	}
-	error "Milestone '${title}' not found among the most recent ${perPage * maxPage} milestones"
+	return null
 }
 
 /**
@@ -123,6 +132,13 @@ def createIssue(String orgaRepo, String title, String body) {
 		error "Response contains errors:\n${response}"
 	}
 	return response?.html_url
+}
+
+def findIssue(String orgaRepo, String title) {
+	// Iterate over all issues, sorted by decending date of last update.
+	// See https://docs.github.com/en/rest/issues/issues?apiVersion=2026-03-10#list-repository-issues
+	def issue = findElement("repos/${orgaRepo}/issues?state=all&sort=updated&direction=desc", {i -> i.title == title})
+	return issue?.html_url // Do not fail if issue was not found
 }
 
 def triggerWorkflow(String orgaSlashRepo, String workflowId, Map<String, String> inputs, String referenceBranch = 'master') {

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -74,23 +74,27 @@ Sometimes there is a critical issue that requires a fix, if it's decided that on
   2. Start a new I-build for that release.
     The still existing I-build jobs are now running on the maintenance branch and will include the backported fix.
   3. Promote the newly built I-build as `RC2a` or `RC2b`, ... and use it for the final release promotion
-  - In case the a fix is necessary after the final release promotion, but before its publication, additionally run the final release promotion with the new RC2x.
-    Also make sure to discard the previously promoted artifacts, by deleting the previous release download and update sites and to **DROP** the artifacts previously staged for Maven Central.
+  - In case the a fix is necessary after the final release promotion happened (but of course before its publication), additionally run the final release promotion with the new RC2x.
+    Also make sure to discard the previously promoted artifacts, by deleting the previously promoted release Eclipse and Equinox download sites and the release update site, in both, the `download` and `archive` area.
+    Additionally **DROP** the artifacts previously staged for Maven Central and replace the final contribution to SimRel.
 
 ### Release
 The actual steps to release
 
-**Friday**
-  * #### Promote to GA
-    - After **SimRel** declares RC2 (usually on Friday before the final release) run the [Promote Build](https://ci.eclipse.org/releng/job/Releng/job/promoteBuild/) job to promote RC2 (or RC2a, ...) to be the final release.
+**Wednesday, one week before release**
+  - #### Promote to GA
+    - At the very end of the **SimRel RC2 contribution period** (usually at Wednesday end of business day),
+      Run the [Promote Build](https://ci.eclipse.org/releng/job/Releng/job/promoteBuild/) job to promote RC2 (or RC2a, ...) to be the final release.
       - `DROP_ID`: Final release candidate's ID, e.g.: `S-4.36RC2-202505281830`
       - `CHECKPOINT`: blank for final releases
     - It creates the download and update sites of the final release at their final location, but does not publish them and keeps them hidden from the public.
     - It also creates pull requests to update the build configuration on the master and corresponding maintenance branch to the promoted release.
-      - Only submit them **AFTER** the release was finally published.
+      - Submit them **IMMEDIATLY BEFORE** the release is finally published.
     - It will again update the Acknowledgements and creates a PR if there are any last changes.
       Review and submit it at https://github.com/eclipse-platform/www.eclipse.org-eclipse/pulls
     - You can subscribe to [cross-project-issues](https://accounts.eclipse.org/mailing-list/cross-project-issues-dev) to get the notifications on Simrel releases.
+  - #### Contribute to SimRel
+    - The final release repo has to be contributed to SimRel before the currently active I-build repo is deleted (is done automatically after the release is published)
 
 **Tuesday/Monday**
   - #### Complete Publication to Maven Central
@@ -100,15 +104,14 @@ The actual steps to release
       - Make sure the name of the deployment you are about to release matches the tag and timestamp of the final release repository.
         E.g for a P2 repo with id `R-4.36-202505281830` the deployments should be named `PLATFORM_R-4.36-202505281830`, `PDE_R-4.36-202505281830` or `JDT_R-4.36-202505281830` respectivly.
       - If you do not have an account on `central.sonatype.com` for performing the rest of the release request one by creating an [EF Help Desk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues) issue to get permissions for platform, JDT and PDE projects and tag an existing release engineer to give approval.
-  - #### Contribute to SimRel
-    - The final release repo has to be contributed to SimRel before the currently active I-build repo is deleted (is done automatically after the release is published)
+
+**Wednesday**
+
+The release is scheduled for 10:00 UTC.
+
   - #### Update build versions to GA
     - Upon promotion of the final GA build, PRs for the the master and corresponding maintenance branch were created to update the build to the GA versions.
     - Submit these PRs now.
-
-**Wednesday**
-The release is scheduled for 10:00 UTC.
-
   - #### Make the Release Visible
     - Run the [Publish Promoted Build](https://ci.eclipse.org/releng/job/Releng/job/publishPromotedBuild/) job in Releng jenkins to make the promoted build visible on the download page.
       - `releaseBuildID`: the full id of the release build to publish, e.g. `R-4.36-202505281830`


### PR DESCRIPTION
This updates the release documentation to promote to GA artifacts earlier than before and additionally moves the submission of build-script updates to the final release repositories to happen only immediately before the publication.
These where changes were found helpful in the past release cycle and where already applied to
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3848


Plus clean-up formatting for created release issue and link the release issue in the PRs for the final build script updates on master and maintenance branch.

For your information @merks and @MohananRahul.
Please let me know if you want/need further adjustments.