### PR TITLE
[Build] Define build schedule and the build time in UTC timezone

### DIFF
--- a/JenkinsJobs/Builds/build.jenkinsfile
+++ b/JenkinsJobs/Builds/build.jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
 					}
 					
 					def int jobStart = currentBuild.startTimeInMillis.intdiv(1000)
-					BUILD_PROPERTIES.TIMESTAMP = sh(script: "TZ='America/Toronto' date +%Y%m%d-%H%M --date='@${jobStart}'", returnStdout: true).trim()
+					BUILD_PROPERTIES.TIMESTAMP = sh(script: "TZ=UTC date +%Y%m%d-%H%M --date='@${jobStart}'", returnStdout: true).trim()
 					BUILD_PROPERTIES.BUILD_TYPE = job.type
 					BUILD_PROPERTIES.BUILD_TYPE_NAME = BUILD.typeName
 					BUILD_PROPERTIES.BUILD_ID = "${BUILD_PROPERTIES.BUILD_TYPE}${BUILD_PROPERTIES.TIMESTAMP}"

--- a/JenkinsJobs/Cleanup/cleanupBuilds.jenkinsfile
+++ b/JenkinsJobs/Cleanup/cleanupBuilds.jenkinsfile
@@ -15,9 +15,9 @@ pipeline {
 		buildDiscarder(logRotator(numToKeepStr:'5'))
 	}
 	triggers {
-		cron '''TZ=America/Toronto
-			0 4 * * *
-			0 16 * * *
+		cron '''TZ=UTC
+			0 9 * * *
+			0 21 * * *
 		'''
 	}
 	agent {

--- a/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
+++ b/JenkinsJobs/Releng/prepareNextDevCycle.jenkinsfile
@@ -75,12 +75,12 @@ pipeline {
 					// Compute new build schedule
 					def now = java.time.LocalDate.now()
 					def rcEnd = eclipseReleaseDates.RC2.minusDays(2) // Wednesday before RC2 is the last planned I-build and the cron-triggers should stop after
-					assignEnvVariable('I_BUILD_SCHEDULE', createCronPattern(now, rcEnd, 18, '*').trim())
+					assignEnvVariable('I_BUILD_SCHEDULE', createCronPattern(now, rcEnd, 23, '*').trim())
 					
 					echo "NEXT_JAVA_RELEASE_DATE: ${NEXT_JAVA_RELEASE_DATE}"
 					def yBuildSchedule = null
 					if ("${NEXT_JAVA_RELEASE_DATE}".isEmpty()) {
-						yBuildSchedule = createCronPattern(now, rcEnd, 10, '2,4,6')
+						yBuildSchedule = createCronPattern(now, rcEnd, 15, '2,4,6')
 					} else {
 						// Java releases soon after the Eclipse release, therefore schedule Y-builds daily within the 'Java RC phase'
 						def javaReleaseDate = utilities.parseDate("${NEXT_JAVA_RELEASE_DATE}")
@@ -90,7 +90,7 @@ pipeline {
 							// If this is encountered, enhance the logic to handle 'java RC' phases ranging more than one month
 							error "Java release is not in the middle of a month"
 						}
-						yBuildSchedule = createCronPattern(now, javaRCStart, 10, '2,4,6') + """\
+						yBuildSchedule = createCronPattern(now, javaRCStart, 15, '2,4,6') + """\
 						0 10 ${javaRCStart.dayOfMonth}-${javaRCEnd.dayOfMonth} ${javaRCStart.monthValue} *
 						""".stripIndent()
 					}
@@ -452,7 +452,7 @@ private String createCronPattern(java.time.LocalDate start, java.time.LocalDate 
 	// Consider end-of-year overflows
 	def completeMonths = (start.monthValue < lastCompleteMonth) ? "${start.monthValue}-${lastCompleteMonth}" : "${start.monthValue}-12,1-${lastCompleteMonth}"
 	return """\
-		TZ=America/Toronto
+		TZ=UTC
 		# Format: Minute Hour Day Month Day-of-week (1-7)
 		0 ${hour} * ${completeMonths} ${daysOfWeek}
 		0 ${hour} 1-${end.dayOfMonth} ${end.monthValue} ${daysOfWeek}

--- a/JenkinsJobs/Releng/updateIndex.jenkinsfile
+++ b/JenkinsJobs/Releng/updateIndex.jenkinsfile
@@ -184,7 +184,6 @@ def toUTCdateTime(String dateTime) {
 	def int hour = Integer.parseInt(dateTime.substring(8, 10))
 	def int minute = Integer.parseInt(dateTime.substring(10, 12))
 	return java.time.LocalDateTime.of(year, month, day, hour, minute)
-		.atZone(java.time.ZoneId.of("America/New_York"))
-		.withZoneSameInstant(java.time.ZoneOffset.UTC)
-		.toLocalDateTime().toString() + 'Z';
+		.atZone(java.time.ZoneOffset.UTC)
+		.format(java.time.format.DateTimeFormatter.ISO_INSTANT); // formats in UTC, such as '2011-12-03T10:15:30Z'
 }

--- a/JenkinsJobs/buildConfigurations.json
+++ b/JenkinsJobs/buildConfigurations.json
@@ -5,7 +5,7 @@
 		"streams": {
 			"4.41": {
 				"branch": "master",
-				"schedule": "TZ=America/Toronto\n# Format: Minute Hour Day Month Day-of-week (1-7)\n0 18 * 5-7 *\n0 18 1-26 8 *"
+				"schedule": "TZ=UTC\n# Format: Minute Hour Day Month Day-of-week (1-7)\n0 23 * 5-7 *\n0 23 1-26 8 *"
 			}
 		},
 		"mailingList": "platform-releng-dev@eclipse.org",
@@ -84,7 +84,7 @@
 			"4.41": {
 				"branch": "master",
 				"disabled": "false",
-				"schedule": "TZ=America/Toronto\n# Format: Minute Hour Day Month Day-of-week (1-7)\n0 10 * 5-8 2,4,6\n0 10 1-7 9 2,4,6\n0 10 7-16 9 *"
+				"schedule": "TZ=UTC\n# Format: Minute Hour Day Month Day-of-week (1-7)\n0 15 * 5-8 2,4,6\n0 15 1-7 9 2,4,6\n0 15 7-16 9 *"
 			}
 		},
 		"branches": {

--- a/scripts/releng/BuildDropDataGenerator.java
+++ b/scripts/releng/BuildDropDataGenerator.java
@@ -62,7 +62,7 @@ void mainEclipsePageData() throws IOException {
 	Map<Path, FileInfo> files = OS.listFileTree(DIRECTORY, 1);
 	Map<String, String> properties = OS.loadProperties(DIRECTORY.resolve("buildproperties.properties"));
 	String buildId = properties.get("BUILD_ID");
-	ZonedDateTime buildDate = buildTimestamp(buildId);
+	ZonedDateTime buildDateUTC = buildTimestampUTC(buildId);
 
 	JSON.Object buildProperties = JSON.Object.create();
 	// basic data
@@ -75,7 +75,7 @@ void mainEclipsePageData() throws IOException {
 	buildProperties.add("release", JSON.String.create(major + "." + minor + "." + service));
 	buildProperties.add("releaseShort", JSON.String.create(properties.get("RELEASE_VER")));
 	buildProperties.add("previousReleaseAPILabel", JSON.String.create(previousReleaseAPILabel(major, minor)));
-	buildProperties.add("timestamp", JSON.String.create(buildDate.toString()));
+	buildProperties.add("timestamp", JSON.String.create(buildDateUTC.toString()));
 
 	// git log
 	buildProperties.add("gitTag", JSON.String.create(buildId));
@@ -127,7 +127,7 @@ void mainEquinoxPageData() throws IOException {
 	Map<Path, FileInfo> files = OS.listFileTree(DIRECTORY, 1);
 	Map<String, String> properties = OS.loadProperties(DIRECTORY.resolve("buildproperties.properties"));
 	String buildId = properties.get("BUILD_ID");
-	ZonedDateTime buildDate = buildTimestamp(buildId);
+	ZonedDateTime buildDateUTC = buildTimestampUTC(buildId);
 
 	JSON.Object buildProperties = JSON.Object.create();
 	// basic data
@@ -135,7 +135,7 @@ void mainEquinoxPageData() throws IOException {
 	buildProperties.add("label", JSON.String.create(buildId));
 	buildProperties.add("kind", JSON.String.create(properties.get("BUILD_TYPE_NAME")));
 	buildProperties.add("releaseShort", JSON.String.create(properties.get("RELEASE_VER")));
-	buildProperties.add("timestamp", JSON.String.create(buildDate.toString()));
+	buildProperties.add("timestamp", JSON.String.create(buildDateUTC.toString()));
 
 	// files
 	buildProperties.add("equinoxRepository",
@@ -256,10 +256,10 @@ JSON.Object createFileDescription(Path file, FileInfo fileInfo) {
 }
 
 final Pattern INTEGRATION_BUILD_ID = Pattern.compile("[A-Z](?<date>\\d{8})-(?<time>\\d{4})");
-final ZoneId BUILD_TIMEZONE = ZoneId.of("America/New_York");
+final ZoneId BUILD_TIMEZONE = ZoneOffset.UTC;
 final DateTimeFormatter BASIC_LOCAL_TIME = DateTimeFormatter.ofPattern("HHmm");
 
-ZonedDateTime buildTimestamp(String buildId) {
+ZonedDateTime buildTimestampUTC(String buildId) {
 	Matcher buildIDMatcher = INTEGRATION_BUILD_ID.matcher(buildId);
 	if (!buildIDMatcher.matches()) {
 		throw new IllegalArgumentException("Unexpected BUILD_ID: " + buildId);


### PR DESCRIPTION
Using UTC as reference timezone makes the schedule more international and makes it simpler for those not located at the American east-coast to understand the build schedule.

Furthermore it aligns the time-zone of build timestamps with the time-zone used for git timestamps.

This should also fix a rarely occurring failures, when running two integration builds shortly after each other and a change was committed only shortly before the first build.
Since commit timestamps are in UTC, with the previous build timezone the qualifier of the changed artifact had a later timestamp (higher value) than the build timestamp was in that case (between 4 and 5 hours depending on the difference).
If that changed bundle is in included in a feature, together with a bundle that uses the build time as qualifier, the features timestamp was dominated by the bundle that's using the git-timestamp in that case.
In the second build the qualifier of the 'runtime-qualified' bundle of course reflects the second build's time, but the feature was still dominated by the 'git-qualified' bundle, consequently didn't change it's qualifier and was therefore baseline replaced.
But in the baseline version the feature requires the exact timestamp of the previous build for the other, 'runtime-qualified' bundle.
Eventually this lead to a build failure because the version of the 'runtime-qualified' bundle from the previous build isn't found in the current build.

Using UTC, which doesn't have rules for daylight saving, means that the build time will change by on hour for regions that do have such mechanisms, when entering or leaving a daylight saving time period.
But I don't think this is a problem.