### PR TITLE
[RelEng] Adapt checkout in update-index job to new website file paths

### DIFF
--- a/JenkinsJobs/Releng/updateIndex.jenkinsfile
+++ b/JenkinsJobs/Releng/updateIndex.jenkinsfile
@@ -26,8 +26,7 @@ pipeline {
 					checkout scmGit(userRemoteConfigs: [[url: "${scm.userRemoteConfigs[0].url}"]], branches: [[name: "${scm.branches[0].name}"]],
 						extensions: [cloneOption(depth: 1, shallow: true, noTags: true), sparseCheckout([
 						[path: 'JenkinsJobs/shared/utilities.groovy'],
-						[path: 'sites/eclipse'],
-						[path: 'sites/equinox'],
+						[path: 'sites/websites'],
 					])])
 				}
 				script {


### PR DESCRIPTION
This was missing in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3813