### PR TITLE
Remove unused Batik from SDK target platform

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
@@ -125,11 +125,6 @@
                   </requirement>
                   <requirement>
                     <type>eclipse-plugin</type>
-                    <id>org.apache.batik.css</id>
-                    <versionRange>0.0.0</versionRange>
-                  </requirement>
-                  <requirement>
-                    <type>eclipse-plugin</type>
                     <id>org.apache.lucene.analysis-common</id>
                     <versionRange>0.0.0</versionRange>
                   </requirement>

--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -8,14 +8,7 @@
 
       <unit id="org.apache.ant" version="1.10.17.v20260410-1000"/>
 
-      <unit id="org.apache.batik.css" version="1.19.0.v20250506-1400"/>
-      <unit id="org.apache.batik.util" version="1.19.0.v20250506-1400"/>
-      <unit id="org.apache.batik.i18n" version="1.19.0.v20250506-1400"/>
-      <unit id="org.apache.batik.constants" version="1.19.0.v20250506-1400"/>
-
-      <unit id="org.apache.xmlgraphics" version="2.11.0.v20250506-1400"/>
-
-      <!-- needed because org.eclipse.jdt.feature.group  includes it, but it should include org.hamcrest (direct-from-maven) instead --> 
+      <!-- needed because org.eclipse.jdt.feature.group  includes it, but it should include org.hamcrest (direct-from-maven) instead -->
       <unit id="org.junit" version="4.13.2.v20240929-1000"/>
 
       <unit id="org.apache.lucene.core" version="10.4.0.v20260226-1000"/>
@@ -25,7 +18,7 @@
       <!-- This version contains with notarized *.jnilib -->
       <unit id="com.sun.jna" version="5.19.1.v20260612-1000"/>
 
-      <!-- Batik dependencies -->
+      <!-- Provides the SAC API (org.w3c.css.sac), used by org.eclipse.pde.spy.css -->
       <unit id="org.eclipse.orbit.xml-apis-ext" version="1.0.0.v20240917-0534"/>
 
       <!-- ECF -->


### PR DESCRIPTION
Nothing in the platform imports `org.apache.batik.*` anymore: the e4 CSS engine moved to its own internal parser and SVG rendering now uses JSVG, and `org.apache.batik.css` is not shipped in the SDK product. This drops the four Batik bundles from the prereqs target along with `org.apache.xmlgraphics`, which was only consumed by `batik.css`, plus the matching stale requirement in the doc.isv build.

`org.eclipse.orbit.xml-apis-ext` is intentionally kept: it provides the SAC API (`org.w3c.css.sac`) that `org.eclipse.pde.spy.css` still imports and that ships in the product. Its target comment is updated to reflect that, since it was previously labelled a Batik dependency.