### PR TITLE
R4_35_maintenance pin cbi-ecj-version to 3.39.0

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -90,7 +90,7 @@
     <tycho-snapshot-repo.url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</tycho-snapshot-repo.url>
 
     <eclipse-snapshots-repo.url>https://repo.eclipse.org/content/repositories/eclipse-snapshots/</eclipse-snapshots-repo.url>
-    <cbi-ecj-version>[3.39,)</cbi-ecj-version>
+    <cbi-ecj-version>3.39.0</cbi-ecj-version>
 
     <!--
       repo for released versions of CBI. Note, we intentionally use as specific a repo as possible.


### PR DESCRIPTION
Pin the version to the ecj 3.39.0 to ensure reproducible builds.