### PR TITLE
Silence deprecations reporting from lucene

### DIFF
--- a/scripts/releng/apiReport/exclusions.txt
+++ b/scripts/releng/apiReport/exclusions.txt
@@ -7,6 +7,7 @@ org.apache.commons.commons-io
 biz.aQute.bndlib
 biz.aQute.repository
 org.apache.lucene.core
+org.apache.lucene.analysis-common
 org.apache.commons.commons-beanutils
 bcpg
 bcprov


### PR DESCRIPTION
Seen in https://download.eclipse.org/eclipse/downloads/drops4/I20260629-2300/apitools/deprecation/apideprecation.html . As it's third party library, deprecation is beyond our control thus shouldn't be reported.