### PR TITLE
Remove unused SAC (xml-apis-ext) from the target platform

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
@@ -220,11 +220,6 @@
                   </requirement>
                   <requirement>
                     <type>eclipse-plugin</type>
-                    <id>org.eclipse.orbit.xml-apis-ext</id>
-                    <versionRange>0.0.0</versionRange>
-                  </requirement>
-                  <requirement>
-                    <type>eclipse-plugin</type>
                     <id>org.eclipse.update.configurator</id>
                     <versionRange>0.0.0</versionRange>
                   </requirement>

--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -18,9 +18,6 @@
       <!-- This version contains with notarized *.jnilib -->
       <unit id="com.sun.jna" version="5.19.1.v20260612-1000"/>
 
-      <!-- Provides the SAC API (org.w3c.css.sac), used by org.eclipse.pde.spy.css -->
-      <unit id="org.eclipse.orbit.xml-apis-ext" version="1.0.0.v20240917-0534"/>
-
       <!-- ECF -->
       <unit id="org.apache.httpcomponents.client5.httpclient5" version="5.6.2.v20260630-1000"/>
       <unit id="org.apache.httpcomponents.client5.httpclient5-win" version="5.2.3.v20231203-1619"/>

--- a/eclipse.platform.releng/deploy-to-maven/SDK4Mvn.aggr
+++ b/eclipse.platform.releng/deploy-to-maven/SDK4Mvn.aggr
@@ -39,7 +39,6 @@
   <mavenMappings namePattern="org\.apache\.ant$" groupId="org.apache.ant" artifactId="ant"/>
   <mavenMappings namePattern="org.apache.batik.([^.]+)" groupId="org.apache.xmlgraphics" artifactId="batik-$1" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
   <mavenMappings namePattern="org.junit" groupId="junit" artifactId="junit" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
-  <mavenMappings namePattern="org.eclipse.orbit.xml-apis-ext" groupId="xml-apis" artifactId="xml-apis-ext" versionPattern=".*" versionTemplate="1.3.04"/>
   <mavenMappings namePattern="(com\.sun\.el|org.apache.jasper.glassfish)" groupId="org.eclipse.jetty.orbit" artifactId="$1"/>
   <mavenMappings namePattern="com\.sun\.jna" groupId="net.java.dev.jna" artifactId="jna"/>
   <mavenMappings namePattern=".*" groupId="\$maven-groupId\$" artifactId="\$maven-artifactId\$" versionPattern=".*" versionTemplate="\$maven-version\$"/>


### PR DESCRIPTION
The e4 CSS engine dropped SAC long ago, and its last consumer, org.eclipse.pde.spy.css, no longer references org.w3c.css.sac in code (the dead CSSParseException catch was removed in eclipse-pde#2385). The org.eclipse.orbit.xml-apis-ext bundle was pulled into the target solely to provide that API, so this drops it from the SDK prereqs target, from the doc.isv extraRequirements that forced it into the Javadoc build, and from the deploy-to-maven mappings. Removing a dependency that nothing uses keeps the target platform smaller and the build a little faster. The pde.spy.css Import-Package is cleaned up separately.