### PR TITLE
Fix findMilestoneNumber returning milestone object instead of number

### DIFF
--- a/JenkinsJobs/shared/githubAPI.groovy
+++ b/JenkinsJobs/shared/githubAPI.groovy
@@ -80,7 +80,7 @@ def findMilestoneNumber(String orgaRepo, String title) {
 	if (milestone == null) {
 		error "Milestone '${title}' not found among the most recent ~1000 milestones"
 	}
-	return milestone
+	return milestone.number
 }
 
 private Object findElement(String query, Closure predicate) {


### PR DESCRIPTION
findMilestoneNumber was returning the whole milestone Map returned by findElement() instead of extracting its `number` field. When interpolated into the PATCH URL in updateMilestone, Groovy's default Map.toString() rendered it as `[url:, id, number:79,]`, which curl then misinterpreted as glob syntax, failing with: curl: (3) bad range in URL position N.