### PR TITLE
Exclude junit-jupiter-engine from deprecations report

### DIFF
--- a/scripts/releng/apiReport/exclusions.txt
+++ b/scripts/releng/apiReport/exclusions.txt
@@ -16,6 +16,7 @@ org.apache.httpcomponents.client5.httpclient5
 org.apache.httpcomponents.core5.httpcore5
 org.apache.httpcomponents.core5.httpcore5-h2
 junit-jupiter-api
+junit-jupiter-engine
 junit-jupiter-params
 junit-platform-commons
 junit-platform-engine


### PR DESCRIPTION
No API guarantees for 3rd party dependencies. 
Actual project deprecations are easily lost in the noise of junit-jupiter-engine deprecations.