### PR TITLE
Version-check: allow checkout of PR head SHA

### DIFF
--- a/.github/workflows/publishVersionCheckResults.yml
+++ b/.github/workflows/publishVersionCheckResults.yml
@@ -41,6 +41,7 @@ jobs:
       with:
         ref: '${{ github.event.workflow_run.head_sha }}'
         persist-credentials: false #Opt out from persisting the default Github-token authentication in order to enable use of the bot's PAT when pushing below
+        allow-unsafe-pr-checkout: true
 
     - name: Download version increment git patch
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
Safe here: only a pre generated, trusted patch (built in the checkVersions job) is applied via `git am` .
fix : #3935 