### PR TITLE
Revert "Silence warnings for unused lambda params"

### DIFF
--- a/scripts/releng/TestResultsGenerator.java
+++ b/scripts/releng/TestResultsGenerator.java
@@ -1,5 +1,6 @@
+
 /*******************************************************************************
- *  Copyright (c) 2000, 2026 IBM Corporation and others.
+ *  Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -162,7 +163,7 @@ public class TestResultsGenerator {
 			collectErrors(junitResultsFile, test);
 			String testPluginName = computeCoreName(filename);
 			String configuration = computeConfig(filename);
-			JSON.Object summary = summaries.computeIfAbsent(configuration, _ -> JSON.Object.create());
+			JSON.Object summary = summaries.computeIfAbsent(configuration, c -> JSON.Object.create());
 			summary.add(testPluginName, test);
 		}
 

--- a/scripts/releng/utilities/XmlProcessorFactoryRelEng.java
+++ b/scripts/releng/utilities/XmlProcessorFactoryRelEng.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2023, 2026 Joerg Kubitz and others.
+ *  Copyright (c) 2023, 2025 Joerg Kubitz and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -77,7 +77,7 @@ public class XmlProcessorFactoryRelEng {
 	public static synchronized Document parseDocumentIgnoringDOCTYPE(Path file)
 			throws ParserConfigurationException, IOException, SAXException {
 		DocumentBuilder builder = DOCUMENT_BUILDER_FACTORY_IGNORING_DOCTYPE.newDocumentBuilder();
-		builder.setEntityResolver((_, _) -> new InputSource(new ByteArrayInputStream(new byte[0])));
+		builder.setEntityResolver((__, ___) -> new InputSource(new ByteArrayInputStream(new byte[0])));
 		return builder.parse((file.toFile()));
 	}
 


### PR DESCRIPTION
Reverts eclipse-platform/eclipse.platform.releng.aggregator#3937 as it broke reporting on Java 21 as can be seen at https://ci.eclipse.org/releng/job/AutomatedTests/job/ep441I-unit-linux-x86_64-java21/57/console