### PR TITLE
Update list of source code repositories of eclipse-platform organization

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -26,16 +26,7 @@ SPDX-License-Identifier: EPL-2.0
 
 The project maintains the following source code repositories:
 
-* https:/github.com/eclipse-platform/eclipse.platform.common
-* https:/github.com/eclipse-platform/eclipse.platform.debug
 * https:/github.com/eclipse-platform/eclipse.platform
 * https:/github.com/eclipse-platform/eclipse.platform.releng.aggregator
-* https:/github.com/eclipse-platform/eclipse.platform.releng.buildtools
-* https:/github.com/eclipse-platform/eclipse.platform.releng
-* https:/github.com/eclipse-platform/eclipse.platform.resources
 * https:/github.com/eclipse-platform/eclipse.platform.swt
-* https:/github.com/eclipse-platform/eclipse.platform.team
-* https:/github.com/eclipse-platform/eclipse.platform.text
-* https:/github.com/eclipse-platform/eclipse.platform.ua
 * https:/github.com/eclipse-platform/eclipse.platform.ui
-* https:/github.com/eclipse-platform/eclipse.platform.ui.tools


### PR DESCRIPTION
Similar to
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/3465

and initially requested in
- https://gitlab.eclipse.org/eclipsefdn/emo-team/emo/-/work_items/1035#note_8080983