### PR TITLE
[RelEng] Ensure storage target directory is empty in promotion pipeline

### DIFF
--- a/JenkinsJobs/Releng/promoteBuild.jenkinsfile
+++ b/JenkinsJobs/Releng/promoteBuild.jenkinsfile
@@ -373,6 +373,7 @@ def renameBuildDrop(String baseDropPath, String oldDropID, String oldBuildLabel,
 	sh """#!/bin/bash -xe
 		
 		# Copy drop-directory to new location
+		ssh genie.releng@projects-storage.eclipse.org rm -rf '${targetPath}'
 		ssh genie.releng@projects-storage.eclipse.org mkdir -p '${targetPath}'
 		# Create this marker first to ensure the page is never visible without it (until it's published)
 		ssh genie.releng@projects-storage.eclipse.org touch '${targetPath}/buildHidden'


### PR DESCRIPTION
To prevent problems in promotions, after a previous attempt failed partially, like in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3929#issuecomment-4886418267