### PR TITLE
[RelEng] Fix build warnings in releng Docker images

### DIFF
--- a/cje-production/dockerfiles/centos-gtk4-mutter/9-gtk4/Dockerfile
+++ b/cje-production/dockerfiles/centos-gtk4-mutter/9-gtk4/Dockerfile
@@ -36,7 +36,7 @@ RUN dnf -y update && dnf -y install \
     && dnf clean all
 
 ENV HOME=/home/vnc
-ENV DISPLAY :0
+ENV DISPLAY=:0
 
 RUN useradd -u 10001 -d ${HOME} testuser
 

--- a/cje-production/dockerfiles/debian/swtgtk3nativebuild/Dockerfile
+++ b/cje-production/dockerfiles/debian/swtgtk3nativebuild/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update -qq && apt-get install -qq -y \
       gcc-aarch64-linux-gnu
 
 ENV HOME=/home/swtbuild
-ENV DISPLAY :0
+ENV DISPLAY=:0
 RUN useradd -u 10001 -d ${HOME} testuser
 
 RUN mkdir -p /var/lib/dbus && dbus-uuidgen > /var/lib/dbus/machine-id \

--- a/cje-production/dockerfiles/debian/swtnativebuild/Dockerfile
+++ b/cje-production/dockerfiles/debian/swtnativebuild/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update -qq && apt-get install -qq -y \
       webkit2gtk-driver
 
 ENV HOME=/home/swtbuild
-ENV DISPLAY :0
+ENV DISPLAY=:0
 RUN useradd -u 10001 -d ${HOME} testuser
 
 RUN mkdir -p /var/lib/dbus && dbus-uuidgen > /var/lib/dbus/machine-id \


### PR DESCRIPTION
Fix warnings like `- LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format`.