### PR TITLE
[Build] pull referenced images in releng Docker image build

### DIFF
--- a/.github/workflows/dockerImageBuild.yml
+++ b/.github/workflows/dockerImageBuild.yml
@@ -6,7 +6,7 @@ name: Docker Image Build
 on:
   workflow_dispatch:
   schedule:
-    - cron: '45 23 * * 6'
+    - cron: '45 23 * * 0'
   push:
     branches: [ master ]
     paths:
@@ -62,6 +62,7 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: '${{ matrix.image.path }}'
+          pull: true
           push: ${{ ! github.event.pull_request }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Always attempt to pull all referenced images when building the releng Docker images.
This was also done in the previously used Jenkins pipeline and was missed in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3955

Additionally fix the schedule cron, to run on Sunday night, not on Saturday.