### PR TITLE
Run API tools check and version baseline comparison only on Linux

### DIFF
--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -81,9 +81,9 @@ jobs:
       run: >-
         ${{ runner.os == 'Linux' && 'xvfb-run' || '' }}
         mvn --show-version --update-snapshots --errors
-        -Dcompare-version-with-baselines.skip=false
+        ${{ runner.os == 'Linux' && '-Dcompare-version-with-baselines.skip=false' || '' }}
         -Pbree-libs
-        -Papi-check
+        ${{ runner.os == 'Linux' && '-Papi-check' || '' }}
         --fail-at-end
         ${{ inputs.maven-goals }}
     - name: Upload Test Results for ${{ matrix.config.name }}


### PR DESCRIPTION
The validation build runs on a Linux/Windows/macOS matrix, but `-Papi-check` and `-Dcompare-version-with-baselines.skip=false` were passed unconditionally, so both checks ran three times per pull request.

Both are platform-independent: API tools compares compiled class files against a p2 baseline, and the version baseline comparison compares built artifacts against the previous release repository. The Windows and macOS runs therefore produce the same result as the Linux run and add no signal. Gating both on the Linux matrix entry removes that duplicated work and shortens the two slowest matrix legs, which is where it helps most.

Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3959