### PR TITLE
[RelEng] Fix stale build result paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ git submodule update
 mvn clean verify  -DskipTests=true
 
 # find the results in
-# eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/target/products
+# products/eclipse-sdk/target/products      (SDK archives per platform)
+# products/eclipse-platform/target/products (Platform archives per platform)
+# sites/eclipse-platform-repository/target/repository (p2 update site)
 ```
 
 Build with custom compiler


### PR DESCRIPTION
The README still points to `eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/target/products` for the output of a local SDK build. That project no longer exists, its last remaining script was moved to `scripts` in e519ac96ec, and the README was the only place still referencing the name.

Replaced it with the directories the Tycho build actually writes to: the per-platform product archives under `products/eclipse-sdk` and `products/eclipse-platform`, and the p2 update site under `sites/eclipse-platform-repository`. These match the paths already used in the Jenkinsfile archive step.