### PR TITLE
Provision the PDE schema converter from the stream being built

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -578,6 +578,18 @@
           </executions>
         </plugin>
         <plugin>
+          <groupId>org.eclipse.tycho.extras</groupId>
+          <artifactId>tycho-document-bundle-plugin</artifactId>
+          <version>${tycho.version}</version>
+          <configuration>
+            <!-- Without this the schema converter is provisioned from a release hardcoded in Tycho, not from the stream being built. -->
+            <pdeToolsRepository>
+              <id>eclipse</id>
+              <url>${eclipse-sdk-repo}</url>
+            </pdeToolsRepository>
+          </configuration>
+        </plugin>
+        <plugin>
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-versions-plugin</artifactId>
           <version>${tycho.version}</version>


### PR DESCRIPTION
The schema-to-html goal of tycho-document-bundle-plugin provisions a headless Eclipse containing org.eclipse.pde.core in order to run ConvertSchemaToHTML. With no pdeToolsRepository configured, Tycho falls back to a repository URL hardcoded in TychoConstants, currently the 2025-12 simultaneous release. The converter was therefore taken from an unrelated release rather than from the stream being built, and drifts further out of date with every release until someone bumps that constant.

Configure pdeToolsRepository in eclipse-platform-parent to ${eclipse-sdk-repo}, next to tycho-eclipse-plugin, which already pins the same repository for the same purpose. All three consumers of schema-to-html inherit this parent.