### PR TITLE
[Build] Further refinements of releng Docker image build

### DIFF
--- a/.github/workflows/dockerImageBuild.yml
+++ b/.github/workflows/dockerImageBuild.yml
@@ -25,8 +25,9 @@ jobs:
       contents: read
       packages: write
       attestations: write
+      artifact-metadata: write
       id-token: write
-    if: github.event_name != 'schedule' || github.repository_owner == 'eclipse-platform' # Skip execution on schedule in forks
+    if: github.event_name == 'workflow_dispatch' || github.repository_owner == 'eclipse-platform' # Skip execution on schedule or push in forks
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Add missing permission to fix warnings in the workflow execution. Run the build in forks only when the workflow is triggered manually, in order to prevent package builds and push in forks when they are synced after a change in any Docker image.

Follow-up on
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3955