### PR TITLE
[RelEng] Update Build instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,89 @@
 Aggregator repo for Eclipse SDK builds
 ======================================
 
-This repo is used to build the Eclipse SDK which provides the framework for Eclipse based applications, the Java development tooling and the Plug-in development tooling.
-To clone it, it is recommended to use one of the URLs found on the following website: 
-https://github.com/eclipse-platform/eclipse.platform.releng.aggregator
+This repo is used to build the Eclipse SDK which contains the framework for Eclipse based applications, the Java® development tools (JDT™) and the Plug-in Development Environment (PDE™).
+To clone it, it is recommended to use one of the URLs found on this website: 
+- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator
 
-An anonymous clone can be done via the following commands:
-
+An anonymous clone can be done via the following command:
 ```
-git clone https://github.com/eclipse-platform/eclipse.platform.releng.aggregator.git
-cd eclipse.platform.releng.aggregator
-git submodule update --init --recursive
+git clone --recurse-submodules https://github.com/eclipse-platform/eclipse.platform.releng.aggregator.git
 ```
-
-The latter command will clone all submodules.
+It will also clone all submodules.
 
 How to build the Eclipse SDK
 ----------------------------
-
-To run a complete build, on your local machine, run the following commands.
-The `-DskipTests=true` will skip the tests which take a significant time to run, e.g., up to 10 hours.
-
+For a complete build run the following command from the root of this repository:
 ```
-# clean up "dirt" from previous build see Bug 420078
+mvn clean verify
+```
+But this will result in a significant runtime of up to 10 hours, mainly due to test executions.
+Skiping the execution of tests and building in parallel reduces the runtime to about 10-20min (depending on your computer):
+```
+mvn clean verify -DskipTests --threads 1C
+```
+
+After a successful build, the `Eclipse-SDK` and `Eclipse-Platform` products are located at
+```
+products/eclipse-sdk/target/products
+products/eclipse-platform/target/products
+```
+and the assembled P2 update-site is at
+```
+sites/eclipse-platform-repository/target/repository
+```
+
+To update your local clone and all it's submodules to the latest state run:
+```
+git checkout master
+git pull --recurse-submodules
+git submodule update
+```
+Furthermore it's recommended to make sure your work-tree is clean before a build, which can be ensured by executing
+```
 git submodule foreach git clean -f -d -x
 git submodule foreach git reset --hard HEAD
 git clean -f -d -x
 git reset --hard HEAD
-
-# update master and submodules
-git checkout master
-git pull --recurse-submodules
-git submodule update
-
-# run the build
-mvn clean verify  -DskipTests=true
-
-# find the results in
-# products/eclipse-sdk/target/products      (SDK archives per platform)
-# products/eclipse-platform/target/products (Platform archives per platform)
-# sites/eclipse-platform-repository/target/repository (p2 update site)
 ```
 
 Build with custom compiler
 --------------------------
 
-To compile the build itself with a custom compiler perform the follwoing step after cloning the submodules:
+To compile the build itself with a custom compiler perform the following step after cloning the submodules:
 
 ```
 # compile local version
 mvn clean install -f eclipse.jdt.core/org.eclipse.jdt.core.compiler.batch -DlocalEcjVersion=99.99
 
 # run build with local compiler
-mvn clean verify  -DskipTests=true -Dcbi-ecj-version=99.99
+mvn clean verify -DskipTests=true -Dcbi-ecj-version=99.99
 ```
 
 Build requirements
 ------------------
 
-The build commands require the installation and setup of Java 17 or higher and Maven version 3.5.4 or higher.
-See also the complete instructions on the [Platform Build wiki](https://wiki.eclipse.org/Platform-releng/Platform_Build "Platform Build"). 
-Note, it is highly recommended to use toolchains.xml and -Pbree-libs as decribed in [Using BREE Libs](https://wiki.eclipse.org/Platform-releng/Platform_Build#Using_BREE_Libs "Using BREE Libs").
+The build commands require the installation and setup of Java 21 or higher and Maven version 3.9.12 or higher.
+See also the complete instructions on the [Platform Build wiki](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/wiki/Platform-Build). 
+Note, it is highly recommended to use toolchains.xml and `-Pbree-libs` as described in [Using BREE Libs](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/wiki/Platform-Build#using-bree-libs).
 
 Integration builds
 ------------------
 
 The integrations (nightly) build jobs are hosted on Jenkins instance https://ci.eclipse.org/releng/job/Builds/.
 
-The job with the highest release number is the one that builds nightly SDK build, like https://ci.eclipse.org/releng/job/Builds/job/I-build-4.39/ job for 4.39 SDK.
+The job with the highest release number is the one that builds nightly SDK build, like `I-build-4.41` job for 4.41 SDK.
 
 - The build artifacts and test results are accessible at https://download.eclipse.org/eclipse/downloads/
 - If the tests fail to start, test jobs for each platform can be found at https://ci.eclipse.org/releng/job/AutomatedTests/
-- If the build is successful but relevant functionality is severely broken and the build shouldn't be used, the build can be marked as unstable via the [Mark Build](https://ci.eclipse.org/releng/job/Builds/job/markBuild/) job.
+- If the build is successful but relevant functionality is severely broken and the build shouldn't be used,
+  the build can be marked as *unstable* using the [Mark Build](https://ci.eclipse.org/releng/job/Builds/job/markBuild) job.
 - Daily Maven snapshots are provided by the [Deploy To Maven](https://ci.eclipse.org/releng/job/Releng/job/deployToMaven) job
-and are available from https://repo.eclipse.org/content/repositories/eclipse-maven2-snapshots/
+and are available at https://repo.eclipse.org/content/repositories/eclipse-snapshots/
 
 Milestone and release tasks
 -----------------
-See [Releng-Tasks 2.0](RELEASE.md) (includes links to schedule, calendar etc)
+See [Releng-Tasks 2.1](RELEASE.md) (includes links to schedule, calendar etc)
 
 How to contribute
 -----------------
@@ -88,9 +94,9 @@ For a complete guide, see https://github.com/eclipse-platform/.github/blob/main/
 Additional informations
 -----------------------
 
-Eclipse Platform Project committers should also read [Automated Platform Builds](https://wiki.eclipse.org/Platform-releng/Automated_Platform_Build "Automated Platform Builds").
+Eclipse Platform Project committers should also read [Automated Platform Builds](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/wiki/Platform-Build-Automated).
 
-Release Engineers should also be familiar with other documents on the [Releng Wiki](https://wiki.eclipse.org/Category:Eclipse_Platform_Releng "Releng Wiki").
+Release Engineers should also be familiar with other documents on the [Releng Wiki](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/wiki).
 
 License
 -------


### PR DESCRIPTION
Update Build instructions in README and replace links to the obsolete wiki.eclipse.org.