### PR TITLE
Update Y-build tests to run on latest OpenJDK JDK 27 Release-Candidate

### DIFF
--- a/jobs/buildConfigurations.json
+++ b/jobs/buildConfigurations.json
@@ -114,7 +114,7 @@
 				"agent": "ubuntu-2404",
 				"jdk": {
 					"type": "install",
-					"url": "https://download.java.net/java/early_access/jdk27/17/GPL/openjdk-27-ea+17_linux-x64_bin.tar.gz"
+					"url": "https://download.java.net/java/GA/jdk27/55ce5470a6294008af0057ff4626d0e5/35/GPL/openjdk-27_linux-x64_bin.tar.gz"
 				}
 			},
 			{
@@ -125,7 +125,7 @@
 				"agent": "nc1ht-macos26-arm64",
 				"jdk": {
 					"type": "install",
-					"url": "https://download.java.net/java/early_access/jdk27/17/GPL/openjdk-27-ea+17_macos-aarch64_bin.tar.gz"
+					"url": "https://download.java.net/java/GA/jdk27/55ce5470a6294008af0057ff4626d0e5/35/GPL/openjdk-27_macos-aarch64_bin.tar.gz"
 				}
 			},
 			{
@@ -136,7 +136,7 @@
 				"agent": "qa6xd-win11",
 				"jdk": {
 					"type": "install",
-					"url": "https://download.java.net/java/early_access/jdk27/17/GPL/openjdk-27-ea+17_windows-x64_bin.zip"
+					"url": "https://download.java.net/java/GA/jdk27/55ce5470a6294008af0057ff4626d0e5/35/GPL/openjdk-27_windows-x64_bin.zip"
 				}
 			}
 		]


### PR DESCRIPTION
The current RC is Build 35 (2026/8/20).

@jarthana, @mpalat are you interested in that update now, so the final builds can run on the latest RC?