### PR TITLE
[RelEng] Automate creation of Migration guide in release preparation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,8 @@
   - Run the [`Send announcement`](https://ci.eclipse.org/releng/job/releng/job/send-announcement) job
     - `type`: `REMINDER_RC`
     - `rcNumber`: number of current RC, `1` or `2`
+  The job sending the reminder for the RC2 week, also creates the issue to track the final release steps in this repository.
+
 ### Milestone/RC Week
    - **M 1/2/3 Release**
      * All milestone releases are 'lightweight', meaning there is no announcement or signoff.
@@ -52,21 +54,6 @@
 
 ## GA Releases 
 Tasks to be completed after RC2
-
-### Release Preparation
-Tasks that need to be completed before Friday
-
-The job sending the request to sign-off of RC2, also creates the issue to track the final release steps in this repository.
-
-  * #### Readme
-    - Create a tracking issue in [www.eclipse.org-eclipse](https://github.com/eclipse-platform/www.eclipse.org-eclipse) (see [Readme file for 4.26](https://github.com/eclipse-platform/www.eclipse.org-eclipse/issues/24) as an example).
-    - Add Readme files and update generatation scripts.
-  * #### Migration Guide
-    - Create a tracking issue in [eclipse.platform.releng.aggregator](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues) and link it to the main release issue.
-    - Every release a new porting guide and folder need to be added to [eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/tree/master/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/porting), named with the version being migrated *to*.
-      - i.e `eclipse_4_27_porting_guide.html` is for migrating from 4.26 tp 4.27.
-    - Update `topics_Porting.xml` in [eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/tree/master/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv) and [eclipse.platform.common/bundles/org.eclipse.platform.doc.isv](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/tree/master/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv)
-    - Update the name of the proting html document in [eclipse.platform/platform/org.eclipse.platform/intro/migrateExtensionContent.xml](https://github.com/eclipse-platform/eclipse.platform/blob/master/platform/org.eclipse.platform/intro/migrateExtensionContent.xml) 
 
 ### RC2 Respin
 Sometimes there is a critical issue that requires a fix, if it's decided that one is needed then an `RC2a` (followed by `RC2b`, `RC2c`, etc. if necessary) is built from the maintenance branch and promoted using the RC2 process.

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/templates/porting/eclipse_porting_guide.html
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/templates/porting/eclipse_porting_guide.html
@@ -1,0 +1,38 @@
+<!DOCTYPE HTML>
+<html lang="en">
+
+<head>
+
+<meta name="copyright" content="Copyright (c) IBM ${NEXT_RELEASE_YEAR} Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css">
+<title>Eclipse JDT ${NEXT_RELEASE_VERSION} Plug-in Migration Guide</title>
+</head>
+
+<body>
+
+<h1>Eclipse JDT ${NEXT_RELEASE_VERSION} Plug-in Migration Guide</h1>
+<p>This guide covers migrating Eclipse JDT ${PREVIOUS_RELEASE_VERSION} plug-ins to Eclipse JDT ${NEXT_RELEASE_VERSION}.</p>
+<p>One of the goals of Eclipse ${NEXT_RELEASE_VERSION} was to move Eclipse forward while remaining compatible
+  with previous versions to the greatest extent possible. That is, plug-ins written
+  against the Eclipse ${PREVIOUS_RELEASE_VERSION} APIs should continue to work in ${NEXT_RELEASE_VERSION} in spite of the
+  API changes.</p>
+<p>The key kinds of compatibility are API contract compatibility and binary compatibility.
+  API contract compatibility means that valid use of ${PREVIOUS_RELEASE_VERSION} APIs remains valid for
+  ${NEXT_RELEASE_VERSION}, so there is no need to revisit working code. Binary compatibility means
+  that the API method signatures, etc. did not change in ways that would cause
+  existing compiled (&quot;binary&quot;) code to no longer link and run with the
+  new ${NEXT_RELEASE_VERSION} libraries.</p>
+<p>While every effort was made to avoid breakage, there are a few areas of incompatibility or new
+  APIs that should be adopted by clients.
+  This document describes those areas and provides instructions for migrating ${PREVIOUS_RELEASE_VERSION} plug-ins to
+  ${NEXT_RELEASE_VERSION}.</p>
+<ul>
+  <li><a href="${NEXT_RELEASE_VERSION}/faq.html">Eclipse JDT ${NEXT_RELEASE_VERSION} Plug-in Migration FAQ</a></li>
+  <li><a href="${NEXT_RELEASE_VERSION}/incompatibilities.html">Incompatibilities between Eclipse JDT ${PREVIOUS_RELEASE_VERSION} and ${NEXT_RELEASE_VERSION}</a></li>
+  <li><a href="${NEXT_RELEASE_VERSION}/recommended.html">Adopting ${NEXT_RELEASE_VERSION} mechanisms and API</a></li>
+</ul>
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/templates/porting/faq.html
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/templates/porting/faq.html
@@ -1,0 +1,19 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) ${NEXT_RELEASE_YEAR} IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../../book.css">
+<title>Eclipse JDT ${NEXT_RELEASE_VERSION} Plug-in Migration FAQ</title>
+</head>
+
+<body>
+
+<h1>Eclipse JDT ${NEXT_RELEASE_VERSION} Plug-in Migration FAQ</h1>
+
+<ol>
+	<li>None</li>
+</ol>
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/templates/porting/incompatibilities.html
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/templates/porting/incompatibilities.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) ${NEXT_RELEASE_YEAR} IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta charset="UTF-8">
+<link rel="STYLESHEET" href="../../book.css">
+<title>Incompatibilities between Eclipse ${PREVIOUS_RELEASE_VERSION} and ${NEXT_RELEASE_VERSION}</title>
+</head>
+<body>
+<h1>Incompatibilities Between Eclipse ${PREVIOUS_RELEASE_VERSION} and ${NEXT_RELEASE_VERSION}</h1>
+
+<p>
+  So far Eclipse did not change incompatibly between ${PREVIOUS_RELEASE_VERSION} and ${NEXT_RELEASE_VERSION} in ways that affect
+  plug-ins. Plug-ins that ran on ${PREVIOUS_RELEASE_VERSION} should run on ${NEXT_RELEASE_VERSION} without any problems.
+</p>
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/templates/porting/recommended.html
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/templates/porting/recommended.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) ${NEXT_RELEASE_YEAR} IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../../book.css">
+<title>Adopting JDT ${NEXT_RELEASE_VERSION} mechanisms and APIs</title>
+</head>
+
+<body>
+
+<h1>Adopting JDT ${NEXT_RELEASE_VERSION} Mechanisms and APIs</h1>
+<p>
+  This section describes changes that are required if you are trying to change
+  your ${PREVIOUS_RELEASE_VERSION} plug-in to adopt the ${NEXT_RELEASE_VERSION} mechanisms and APIs.
+</p>
+
+<ol>
+	<li>None</li>
+</ol>
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/templates/topics_Porting.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.jdt.doc.isv/templates/topics_Porting.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?NLS TYPE="org.eclipse.help.toc"?>
+<!-- ============================================================================= -->
+<!-- Define topics for the porting guide index                                     -->
+<!-- ============================================================================= -->
+<toc label="Migration">
+<topics/>
+	<topic label="Older Migration Guides">
+<olderTopics/>
+	</topic>
+</toc>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/templates/porting/eclipse_porting_guide.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/templates/porting/eclipse_porting_guide.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) ${NEXT_RELEASE_YEAR} IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../book.css" type="text/css">
+<title>Eclipse ${NEXT_RELEASE_VERSION} Plug-in Migration Guide</title>
+</head>
+
+<body>
+
+<h1>Eclipse ${NEXT_RELEASE_VERSION} Plug-in Migration Guide</h1>
+<p>This guide covers migrating Eclipse ${PREVIOUS_RELEASE_VERSION} plug-ins to Eclipse ${NEXT_RELEASE_VERSION}.</p>
+<p>One of the goals of Eclipse ${NEXT_RELEASE_VERSION} was to move Eclipse forward while remaining compatible
+  with previous versions to the greatest extent possible. That is, plug-ins written
+  against the Eclipse ${PREVIOUS_RELEASE_VERSION} APIs should continue to work in ${NEXT_RELEASE_VERSION} in spite of any API changes.</p>
+<p>The key kinds of compatibility are API contract compatibility and binary compatibility.
+  API contract compatibility means that valid use of ${PREVIOUS_RELEASE_VERSION} APIs remains valid for
+  ${NEXT_RELEASE_VERSION}, so there is no need to revisit working code. Binary compatibility means
+  that the API method signatures, etc. did not change in ways that would cause
+  existing compiled (&quot;binary&quot;) code to no longer link and run with the
+  new ${NEXT_RELEASE_VERSION} libraries.</p>
+<p>While every effort was made to avoid breakage, there are a few areas of incompatibility or new
+  APIs that should be adopted by clients.
+  This document describes those areas and provides instructions for migrating ${PREVIOUS_RELEASE_VERSION} plug-ins to
+  ${NEXT_RELEASE_VERSION}.</p>
+<ul>
+  <li><a href="${NEXT_RELEASE_VERSION}/faq.html">Eclipse ${NEXT_RELEASE_VERSION} Plug-in Migration FAQ</a></li>
+  <li><a href="${NEXT_RELEASE_VERSION}/incompatibilities.html">Incompatibilities between Eclipse ${PREVIOUS_RELEASE_VERSION} and ${NEXT_RELEASE_VERSION}</a></li>
+  <li><a href="${NEXT_RELEASE_VERSION}/recommended.html">Adopting ${NEXT_RELEASE_VERSION} mechanisms and API</a></li>
+</ul>
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/templates/porting/faq.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/templates/porting/faq.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) ${NEXT_RELEASE_YEAR} IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../../book.css" type="text/css">
+<title>Eclipse ${NEXT_RELEASE_VERSION} Plug-in Migration FAQ</title>
+</head>
+<body>
+<h1>Eclipse ${NEXT_RELEASE_VERSION} Plug-in Migration FAQ</h1>
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/templates/porting/incompatibilities.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/templates/porting/incompatibilities.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) ${NEXT_RELEASE_YEAR} IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta charset="utf-8">
+<link rel="STYLESHEET" href="../../book.css" type="text/css">
+<title>Incompatibilities between Eclipse ${PREVIOUS_RELEASE_VERSION} and ${NEXT_RELEASE_VERSION}</title>
+</head>
+<body>
+<h1>Incompatibilities Between Eclipse ${PREVIOUS_RELEASE_VERSION} and ${NEXT_RELEASE_VERSION}</h1>
+
+<p>
+  Eclipse changed in incompatible ways between ${PREVIOUS_RELEASE_VERSION} and ${NEXT_RELEASE_VERSION} in ways that affect
+  plug-ins. The following entries describe the areas that changed and provide
+  instructions for migrating ${PREVIOUS_RELEASE_VERSION} plug-ins to ${NEXT_RELEASE_VERSION}. Note that you only need to look
+  here if you are experiencing problems running your ${PREVIOUS_RELEASE_VERSION} plug-in on ${NEXT_RELEASE_VERSION}.
+</p>
+<p>
+See also the list of <a href="../removals.html">deprecated API removals</a> for this release.
+</p>
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/templates/porting/recommended.html
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/templates/porting/recommended.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML>
+<html lang="en">
+
+<head>
+	<meta name="copyright"
+		content="Copyright (c) ${NEXT_RELEASE_YEAR} IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+	<meta charset="utf-8">
+	<link rel="STYLESHEET" href="../../book.css" type="text/css">
+	<title>Adopting ${NEXT_RELEASE_VERSION} mechanisms and APIs</title>
+</head>
+
+<body>
+	<h1>Adopting ${NEXT_RELEASE_VERSION} Mechanisms and APIs</h1>
+
+	<p>This section describes changes that are required if you are
+		trying to change your ${PREVIOUS_RELEASE_VERSION} plug-in to adopt the ${NEXT_RELEASE_VERSION} mechanisms and
+		APIs.</p>
+
+	<!-- ##############################################
+	 ############################################## -->
+
+</body>
+</html>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/templates/topics_Porting.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/templates/topics_Porting.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?NLS TYPE="org.eclipse.help.toc"?>
+<!-- ============================================================================= -->
+<!-- Define topics for the porting guide index                                     -->
+<!-- ============================================================================= -->
+<toc label="Migration">
+	<topic label="Deprecated API removals" href="porting/removals.html"/>
+<topics/>
+	<topic label="Older Migration Guides">
+<olderTopics/>
+	</topic>
+</toc>

--- a/eclipse.platform.common/bundles/prepareNextDevCycle.sh
+++ b/eclipse.platform.common/bundles/prepareNextDevCycle.sh
@@ -1,0 +1,129 @@
+#!/bin/bash -eu
+set -o pipefail
+
+#******************************************************************************
+# Copyright (c) 2025, 2026 Hannes Wellmann and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Hannes Wellmann - initial API and implementation
+#******************************************************************************
+
+# This script is called by the pipeline for preparing the next development cycle (this file's name is crucial!)
+# and applies the changes required individually for the common documentation bundles.
+# The calling pipeline also defines environment variables usable in this script.
+
+declare -A MIGRATION_GUIDE_DOC_BUNDLES
+MIGRATION_GUIDE_DOC_BUNDLES['org.eclipse.platform.doc.isv']=renderPlatformDocTopicEntry
+MIGRATION_GUIDE_DOC_BUNDLES['org.eclipse.jdt.doc.isv']=renderJDTDocTopicEntry
+
+TOPIC_LIMIT=8
+OLD_TOPIC_LIMIT=4
+
+cd $(dirname "$0")
+
+# Update links to N&N entries
+for whatsNewFile in */whatsNew/*_whatsnew.html; do
+	sed --in-place "${whatsNewFile}" \
+		--expression "s|Eclipse ${PREVIOUS_RELEASE_VERSION}|Eclipse ${NEXT_RELEASE_VERSION}|g" \
+		--expression "s|news/${PREVIOUS_RELEASE_VERSION}/|news/${NEXT_RELEASE_VERSION}/|g"
+done
+
+# Clear content of all forceQualifierUpdate files in this directory
+for file in */forceQualifierUpdate.txt; do
+	> "$file"
+done
+
+# Create new migration guide file structure
+for bundle in ${!MIGRATION_GUIDE_DOC_BUNDLES[@]}; do
+	portingDir="${bundle}/porting/${NEXT_RELEASE_VERSION}"
+	mkdir -p "${portingDir}"
+	for file in ${bundle}/templates/porting/*; do
+		filePath="${portingDir}/$(basename ${file})"
+		cp -v "${file}" "${filePath}"
+		sed --in-place "${filePath}" \
+			--expression "s/\${NEXT_RELEASE_VERSION}/${NEXT_RELEASE_VERSION}/g" \
+			--expression "s/\${PREVIOUS_RELEASE_VERSION}/${PREVIOUS_RELEASE_VERSION}/g" \
+			--expression "s/\${NEXT_RELEASE_YEAR}/${NEXT_RELEASE_YEAR}/g"
+	done
+	mv -v "${portingDir}/eclipse_porting_guide.html" "${bundle}/porting/eclipse_${NEXT_RELEASE_VERSION//./_}_porting_guide.html"
+done
+
+
+# Update topics TOC
+
+function renderPlatformDocTopicEntry() {
+	local nextReleaseVersion="$1"
+	local previousReleaseVersion="$2"
+	cat <<EOF
+${INDENT}<topic label="Migrating to Eclipse ${nextReleaseVersion} from ${previousReleaseVersion}">
+${INDENT}	<topic label="Introduction" href="porting/eclipse_${nextReleaseVersion//./_}_porting_guide.html"/>
+${INDENT}	<topic label="FAQ" href="porting/${nextReleaseVersion}/faq.html" />
+${INDENT}	<topic label="Incompatibilities" href="porting/${nextReleaseVersion}/incompatibilities.html" />
+${INDENT}	<topic label="Adopting ${nextReleaseVersion} mechanisms and API" href="porting/${nextReleaseVersion}/recommended.html" />
+${INDENT}</topic>
+EOF
+}
+
+function renderJDTDocTopicEntry() {
+	local nextReleaseVersion="$1"
+	local previousReleaseVersion="$2"
+	cat <<EOF
+${INDENT}<topic label="Migrating to Eclipse JDT ${nextReleaseVersion} from ${previousReleaseVersion}">
+${INDENT}	<topic label="Introduction" href="porting/eclipse_${nextReleaseVersion//./_}_porting_guide.html"/>
+${INDENT}	<topic label="FAQ"                             href="porting/${nextReleaseVersion}/faq.html" />
+${INDENT}	<topic label="Incompatibilities"               href="porting/${nextReleaseVersion}/incompatibilities.html" />
+${INDENT}	<topic label="Adopting ${nextReleaseVersion} Mechanisms and API" href="porting/${nextReleaseVersion}/recommended.html" />
+${INDENT}</topic>
+EOF
+}
+
+for bundle in ${!MIGRATION_GUIDE_DOC_BUNDLES[@]}; do
+	pushd $bundle
+		# List entries in descending order
+		mapfile -t allVersions < <(find porting -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -Vr)
+		
+		echo "Generate ${bundle}/topics_Porting.xml for versions ${allVersions[@]}"
+		
+		function buildTopicsList() {
+			local start=$1
+			local len=$2
+			for (( i=start; i < (start + len); i++ )); do
+				renderTopicEntry=${MIGRATION_GUIDE_DOC_BUNDLES[$bundle]}
+				$renderTopicEntry "${allVersions[i]}" "${allVersions[i+1]}"
+			done	
+		}
+		
+		INDENT=$'\t'
+		topics="$(buildTopicsList 0 $TOPIC_LIMIT)"
+		INDENT=$'\t\t'
+		olderTopics="$(buildTopicsList $TOPIC_LIMIT $OLD_TOPIC_LIMIT)"
+		
+		# Replace placeholders with generated lists and create final file
+		awk -v tops="$topics" -v oTops="$olderTopics" \
+			'{ sub(/<topics\/>/, tops); sub(/<olderTopics\/>/, oTops); print }' \
+			'templates/topics_Porting.xml' > 'topics_Porting.xml'
+	popd
+done
+
+# Delete old entries and files that exceed the specified limit
+migrationGuidesLimit="$(( TOPIC_LIMIT + OLD_TOPIC_LIMIT))"
+for bundle in ${!MIGRATION_GUIDE_DOC_BUNDLES[@]}; do
+	dirsToDelete=$(find ${bundle}/porting/ -mindepth 1 -maxdepth 1 -type d | sort -V | head -n -${migrationGuidesLimit})
+	rm -rf -v ${dirsToDelete}
+	filesToDelete=$(find ${bundle}/porting/eclipse_*_porting_guide.html -type f | sort -V | head -n -${migrationGuidesLimit})
+	rm -rf -v ${filesToDelete}
+done
+
+
+git add .
+git commit --message="Prepare doc bundles for ${NEXT_RELEASE_VERSION}
+
+Adds the initial Migration guide for Eclipse ${NEXT_RELEASE_VERSION} from ${PREVIOUS_RELEASE_VERSION}, among others.
+"

--- a/jobs/releng/prepare-next-dev-cycle.jenkinsfile
+++ b/jobs/releng/prepare-next-dev-cycle.jenkinsfile
@@ -189,22 +189,20 @@ pipeline {
 				gitCommitAllExcludingSubmodules("Move previous version to ${PREVIOUS_RELEASE_CANDIDATE_TAG} in build scripts")
 			}
 		}
-		stage('Update doc bundles') {
+		stage('Individual preparation') {
+			environment {
+				PREPARATION_SCRIPT = 'prepareNextDevCycle.sh'
+			}
 			steps {
-				dir('eclipse.platform.common/bundles') {
-					sh '''
-						# Update links to N&N entries
-						for whatsNewFile in */whatsNew/*_whatsnew.html; do
-							sed --expression "s|Eclipse ${PREVIOUS_RELEASE_VERSION}|Eclipse ${NEXT_RELEASE_VERSION}|" -i "${whatsNewFile}"
-							sed --expression "s|news/${PREVIOUS_RELEASE_VERSION}/|news/${NEXT_RELEASE_VERSION}/|" -i "${whatsNewFile}"
-						done
-						# Clear content of all forceQualifierUpdate files in this directory
-						for file in */forceQualifierUpdate.txt; do
-							> "$file"
-						done
-						git commit --message "Update doc bundles for ${NEXT_RELEASE_VERSION} development" .
-					'''
-				}
+				sh '''#!/bin/bash -xe
+					scripts=$(find $(pwd) -maxdepth 3 -name "${PREPARATION_SCRIPT}")
+					for script in ${scripts}; do
+						# Preparation scripts expect the working directory to be their container
+						cd $(dirname ${script})
+						chmod +x ${PREPARATION_SCRIPT}
+						"./${PREPARATION_SCRIPT}"
+					done
+				'''
 			}
 		}
 		stage('Early setup redirection') {
@@ -229,16 +227,6 @@ pipeline {
 						sh "git commit --message 'Enable and update early redirection for ${NEXT_RELEASE_VERSION} in platform setup' ."
 					}
 				}
-			}
-		}
-		stage('Apply individual updates') {
-			environment {
-				UPDATE_SCRIPT = 'prepareNextDevCycle.sh'
-			}
-			steps {
-				sh '''
-					git submodule foreach 'if [ -f ${UPDATE_SCRIPT} ]; then chmod +x ./${UPDATE_SCRIPT} && ./${UPDATE_SCRIPT}; fi'
-				'''
 			}
 		}
 		stage('Prepare maintenance branch') {

--- a/jobs/releng/send-announcement.jenkinsfile
+++ b/jobs/releng/send-announcement.jenkinsfile
@@ -74,8 +74,7 @@ pipeline {
 								
 								### RC2 week
 								before the RC2 build at end of ${eclipseReleaseDates.RC2.minusDays(2).format(dateFormat)}:
-								- [ ] [Create Readme files](${releaseDocURL}#Readme)
-								- [ ] [Create Migration Guide](${releaseDocURL}#migration-guide)
+								- [ ] Check that Readme, migration guide (porting) and project plan are up to date at the website and in documentation bundles
 								- [ ] Ensure the build is cleared of comparator errors in doc bundles
 								  - Check this before the final RC2 build and again before promoting the final GA release
 								


### PR DESCRIPTION
Automate the creation of Migration guide in release preparation pipeline.

This automates changes like the following during release preparation
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3991

Furthermore this updates the Release documentation to consider the automation added here and in
- https://github.com/eclipse-platform/www.eclipse.org-eclipse/pull/601

The automation of the corresponding JDT change is added in
- https://github.com/eclipse-jdt/eclipse.jdt/pull/163

