### PR TITLE
Enable JVM native access

### DIFF
--- a/products/eclipse-platform/platform.product
+++ b/products/eclipse-platform/platform.product
@@ -15,6 +15,7 @@
 -Dorg.slf4j.simpleLogger.defaultLogLevel=off
 -Declipse.platform.mergeTrust=true
 --add-modules=ALL-SYSTEM
+--enable-native-access=ALL-UNNAMED
       </vmArgs>
       <vmArgsMac>-Xdock:icon=../Resources/Eclipse.icns -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>

--- a/products/eclipse-sdk/sdk.product
+++ b/products/eclipse-sdk/sdk.product
@@ -15,6 +15,7 @@
 -Dorg.slf4j.simpleLogger.defaultLogLevel=off
 -Declipse.platform.mergeTrust=true
 --add-modules=ALL-SYSTEM
+--enable-native-access=ALL-UNNAMED
       </vmArgs>
       <vmArgsMac>-Xdock:icon=../Resources/Eclipse.icns -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>


### PR DESCRIPTION
Silences warnings on startup like
```
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for
callers in this module
WARNING: Restricted methods will be blocked in a future release unless
native access is enabled
```
caused by https://openjdk.org/jeps/472