### PR TITLE
[Build|RelEng] Require Java-25 for the Eclipse SDK

### DIFF
--- a/.github/workflows/checkDependencies.yml
+++ b/.github/workflows/checkDependencies.yml
@@ -96,7 +96,7 @@ jobs:
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         if: ${{ fromJson(steps.list-prs.outputs.prs)[9] == null }}
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
       - name: Check ${{ matrix.bundles }} 

--- a/.github/workflows/checkVersions.yml
+++ b/.github/workflows/checkVersions.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
       with:
-        java-version: 25
+        java-version: '25'
         distribution: 'temurin'
 
       # Use a dedicated cache to prevent conflicts with the verification build cache

--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -21,6 +21,7 @@ jobs:
     uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
     with:
       projectId: eclipse.platform
+      javaVersion: '25'
       submodules: recursive
     secrets:
       gitlabAPIToken: ${{ secrets.ECLIPSE_GITLAB_API_TOKEN }}

--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -63,13 +63,11 @@ jobs:
         java-version: |
           11
           17
-          25
           21
           25
         mvn-toolchain-id: |
           JavaSE-11
           JavaSE-17
-          JavaSE-25
           JavaSE-21
           JavaSE-25
         distribution: 'temurin'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
 	}
 	tools {
 		maven 'apache-maven-latest'
-		jdk 'temurin-jdk21-latest'
+		jdk 'temurin-jdk25-latest'
 	}
 	environment {
 		MAVEN_OPTS = '-Xmx4000m'

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ mvn clean verify -DskipTests=true -Dcbi-ecj-version=99.99
 Build requirements
 ------------------
 
-The build commands require the installation and setup of Java 21 or higher and Maven version 3.9.12 or higher.
+The build commands require the installation and setup of Java 25 or higher and Maven version 3.9.12 or higher.
 See also the complete instructions on the [Platform Build wiki](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/wiki/Platform-Build). 
 Note, it is highly recommended to use toolchains.xml and `-Pbree-libs` as described in [Using BREE Libs](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/wiki/Platform-Build#using-bree-libs).
 

--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -947,5 +947,5 @@
 		  </dependencies>
 	  </location>
   </locations>
-  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-25"/>
 </target>

--- a/jobs/automated-tests/integration-tests.jenkinsfile
+++ b/jobs/automated-tests/integration-tests.jenkinsfile
@@ -109,18 +109,12 @@ pipeline {
 									ssh genie.releng@projects-storage.eclipse.org mkdir -p ${remoteResultsDirectory}
 									if [ -d "${localResultsDirectory}/xml" ] && [ -z "$(find ${localResultsDirectory}/xml -maxdepth 0 -empty)" ]; then
 										
-										# As long as not all tests run with Java-25 (or later) we cannot use multi-file Source Programs and have to compile manually
-										pushd scripts/releng
-										javac TestResultsGenerator.java
-										javac utilities/JSON.java
-										javac utilities/OS.java
-										javac utilities/XmlProcessorFactoryRelEng.java
 										# Generate new summary file
 										java \
 											-DxmlDirectory="${WORKSPACE}/${localResultsDirectory}/xml" \
 											-DtestsConfigExpected=${JOB_BASE_NAME} \
 											-DtestManifestFile="${WORKSPACE}/scripts/testing/publishingFiles/testManifest.xml" \
-											TestResultsGenerator
+											TestResultsGenerator.java
 										popd
 										
 										# First delete result files from a previous run of the same configuration (in case that test configuration was run again), then transfer the new results.

--- a/jobs/automated-tests/smoke-tests.jenkinsfile
+++ b/jobs/automated-tests/smoke-tests.jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
 					}
 					axis {
 						name 'JAVA_VERSION'
-						values '21', '25'
+						values '25', '26'
 					}
 				}
 				stages {

--- a/jobs/buildConfigurations.json
+++ b/jobs/buildConfigurations.json
@@ -19,17 +19,6 @@
 				"os": "linux",
 				"ws": "gtk",
 				"arch": "x86_64",
-				"javaVersion": 21,
-				"agent": "ubuntu-2404",
-				"jdk": {
-					"type": "tool",
-					"name": "temurin-jdk21-latest"
-				}
-			},
-			{
-				"os": "linux",
-				"ws": "gtk",
-				"arch": "x86_64",
 				"javaVersion": 25,
 				"agent": "ubuntu-2404",
 				"jdk": {
@@ -52,7 +41,7 @@
 				"os": "macosx",
 				"ws": "cocoa",
 				"arch": "aarch64",
-				"javaVersion": 25,
+				"javaVersion": 26,
 				"agent": "nc1ht-macos26-arm64",
 				"jdk": {
 					"type": "temurin"
@@ -62,7 +51,7 @@
 				"os": "macosx",
 				"ws": "cocoa",
 				"arch": "x86_64",
-				"javaVersion": 21,
+				"javaVersion": 25,
 				"agent": "b9h15-macos15-x86_64",
 				"jdk": {
 					"type": "temurin"
@@ -72,11 +61,10 @@
 				"os": "win32",
 				"ws": "win32",
 				"arch": "x86_64",
-				"javaVersion": 21,
+				"javaVersion": 25,
 				"agent": "qa6xd-win11",
 				"jdk": {
-					"type": "local",
-					"path": "C:\\Program Files\\Eclipse Adoptium\\jdk-21.0.5.11-hotspot"
+					"type": "temurin"
 				}
 			}
 		]
@@ -108,11 +96,11 @@
 				"os": "linux",
 				"ws": "gtk",
 				"arch": "x86_64",
-				"javaVersion": 21,
+				"javaVersion": 25,
 				"agent": "ubuntu-2404",
 				"jdk": {
 					"type": "tool",
-					"name": "temurin-jdk21-latest"
+					"name": "temurin-jdk25-latest"
 				}
 			},
 			{

--- a/oomph/PlatformSDKConfiguration.setup
+++ b/oomph/PlatformSDKConfiguration.setup
@@ -92,7 +92,7 @@
             &lt;booleanAttribute key=&quot;org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE&quot; value=&quot;false&quot;/>
             &lt;booleanAttribute key=&quot;org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES&quot; value=&quot;true&quot;/>
             &lt;booleanAttribute key=&quot;org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD&quot; value=&quot;true&quot;/>
-            &lt;stringAttribute key=&quot;org.eclipse.jdt.launching.JRE_CONTAINER&quot; value=&quot;org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21&quot;/>
+            &lt;stringAttribute key=&quot;org.eclipse.jdt.launching.JRE_CONTAINER&quot; value=&quot;org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-25&quot;/>
             &lt;stringAttribute key=&quot;org.eclipse.jdt.launching.PROGRAM_ARGUMENTS&quot; value=&quot;-os $${target.os} -ws $${target.ws} -arch $${target.arch} -nl $${target.nl} -consoleLog&quot;/>
             &lt;stringAttribute key=&quot;org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER&quot; value=&quot;org.eclipse.pde.ui.workbenchClasspathProvider&quot;/>
             &lt;stringAttribute key=&quot;org.eclipse.jdt.launching.VM_ARGUMENTS&quot; value=&quot;-Xms256m&amp;#13;&amp;#10;-Xmx4g&quot;/>

--- a/products/eclipse-platform/platform.product
+++ b/products/eclipse-platform/platform.product
@@ -9,7 +9,7 @@
    <launcherArgs>
       <programArgs>--launcher.defaultAction openFile --launcher.appendVmargs
       </programArgs>
-      <vmArgs>-Dosgi.requiredJavaVersion=21
+      <vmArgs>-Dosgi.requiredJavaVersion=25
 -Dosgi.dataAreaRequiresExplicitInit=true
 -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true
 -Dorg.slf4j.simpleLogger.defaultLogLevel=off

--- a/products/eclipse-sdk/sdk.product
+++ b/products/eclipse-sdk/sdk.product
@@ -9,7 +9,7 @@
    <launcherArgs>
       <programArgs>--launcher.defaultAction openFile --launcher.appendVmargs
       </programArgs>
-      <vmArgs>-Dosgi.requiredJavaVersion=21
+      <vmArgs>-Dosgi.requiredJavaVersion=25
 -Dosgi.dataAreaRequiresExplicitInit=true
 -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true
 -Dorg.slf4j.simpleLogger.defaultLogLevel=off

--- a/scripts/releng/TestResultsGenerator.java
+++ b/scripts/releng/TestResultsGenerator.java
@@ -47,10 +47,6 @@ import utilities.XmlProcessorFactoryRelEng;
  */
 public class TestResultsGenerator {
 
-	//
-	// NOTE: KEEP THIS AT Java-21 until all tests are executed with Java-25!
-	//
-
 	private static final String XML_EXTENSION = ".xml";
 	private static final String elementName = "testsuite";
 	private List<String> expectedTestConfigs;
@@ -104,11 +100,11 @@ public class TestResultsGenerator {
 						test.add("suites", suites);
 					}
 				} catch (final IOException e) {
-					println("ERROR: IOException: " + fileName);
+					IO.println("ERROR: IOException: " + fileName);
 					e.printStackTrace();
 					errorCount = -4;
 				} catch (final SAXException e) {
-					println("ERROR: SAXException: " + fileName);
+					IO.println("ERROR: SAXException: " + fileName);
 					e.printStackTrace();
 					errorCount = -5;
 				} catch (final ParserConfigurationException e) {
@@ -126,16 +122,16 @@ public class TestResultsGenerator {
 		generator.xmlDirectory = Path.of(OS.readProperty("xmlDirectory")).toRealPath();
 		generator.expectedTestConfigs = List.of(OS.readProperty("testsConfigExpected").split(","));
 
-		println("INFO: Processing test results in");
-		println("\t" + generator.xmlDirectory);
-		println("INFO: For configurations");
-		generator.expectedTestConfigs.forEach(c -> println("\t- " + c));
+		IO.println("INFO: Processing test results in");
+		IO.println("\t" + generator.xmlDirectory);
+		IO.println("INFO: For configurations");
+		generator.expectedTestConfigs.forEach(c -> IO.println("\t- " + c));
 
 		generator.parseJUnitTestsXml();
 	}
 
 	private void parseJUnitTestsXml() throws Exception {
-		println("DEBUG: Begin: Parsing XML JUnit results files");
+		IO.println("DEBUG: Begin: Parsing XML JUnit results files");
 		List<String> foundConfigs = new ArrayList<>();
 		List<Path> allFiles = new ArrayList<>();
 		for (String expectedConfig : expectedTestConfigs) {
@@ -149,7 +145,7 @@ public class TestResultsGenerator {
 			if (sizeBefore < allFiles.size()) {
 				foundConfigs.add(expectedConfig);
 			} else {
-				println("WARNING: No tests found for configuration: " + expectedConfig);
+				IO.println("WARNING: No tests found for configuration: " + expectedConfig);
 			}
 		}
 		expectedTestLogs = loadExpectedTests(foundConfigs);
@@ -167,23 +163,23 @@ public class TestResultsGenerator {
 			summary.add(testPluginName, test);
 		}
 
-		println("DEBUG: End: Parsing XML JUnit results files");
+		IO.println("DEBUG: End: Parsing XML JUnit results files");
 		// above is all "compute data". Now it is time to "display" it.
 		if (foundConfigs.size() > 0) {
-			println("DEBUG: Begin: Generating test results index");
+			IO.println("DEBUG: Begin: Generating test results index");
 			for (Entry<String, JSON.Object> entry : summaries.entrySet()) {
 				String configName = entry.getKey();
 				JSON.Object summary = entry.getValue();
 				String shortConfig = computeShortConfigurationName(configName);
 				Path file = xmlDirectory.resolveSibling(shortConfig + "-summary.json");
-				println("DEBUG: Write Eclipse drop main data to: " + file);
+				IO.println("DEBUG: Write Eclipse drop main data to: " + file);
 				JSON.write(summary, file);
 			}
 			verifyAllTestsRan(xmlDirectory);
 			listMissingManifestFiles();
-			println("DEBUG: End: Generating test results index tables");
+			IO.println("DEBUG: End: Generating test results index tables");
 		} else {
-			println("WARNING: Test results not found in " + xmlDirectory);
+			IO.println("WARNING: Test results not found in " + xmlDirectory);
 		}
 		// TODO: It seems that the DNF/-1 was (just) set if a test result was not
 		// available for one config, but not for another one (i.e. a missing cell).
@@ -277,9 +273,9 @@ public class TestResultsGenerator {
 			}
 		}
 		if (missingFiles.size() > 0) {
-			println("WARNING: Results of test(s) listed in testManifest.xml are missing: " + missingFiles.size());
+			IO.println("WARNING: Results of test(s) listed in testManifest.xml are missing: " + missingFiles.size());
 			for (String testLogName : missingFiles) {
-				println("WARNING:\t- " + testLogName);
+				IO.println("WARNING:\t- " + testLogName);
 			}
 		}
 	}
@@ -288,14 +284,14 @@ public class TestResultsGenerator {
 		if (missingManifestFiles.size() > 0) {
 			// TODO: Make this visible on the download page somehow?
 			Path filename = xmlDirectory.resolve("addToTestManifest.xml");
-			println("WARNING: Found test(s) missing in testManifest.xml: " + missingManifestFiles.size());
-			println("WARNING:\tFor details see: " + filename);
+			IO.println("WARNING: Found test(s) missing in testManifest.xml: " + missingManifestFiles.size());
+			IO.println("WARNING:\tFor details see: " + filename);
 			StringBuilder xmlFragment = new StringBuilder("""
 					<?xml version=\"1.0\" encoding=\"UTF-8\"?>
 					<topLevel>
 					""");
 			for (String testLogName : missingManifestFiles) {
-				println("WARNING:\t- " + testLogName);
+				IO.println("WARNING:\t- " + testLogName);
 				xmlFragment.append("<logFile\n");
 				xmlFragment.append("  name=\"").append(testLogName).append("\"\n");
 				xmlFragment.append("  type=\"test\" />\n");
@@ -303,10 +299,6 @@ public class TestResultsGenerator {
 			xmlFragment.append("</topLevel>");
 			Files.writeString(filename, xmlFragment);
 		}
-	}
-
-	private static void println(String msg) {
-		System.out.println(msg);
 	}
 
 }

--- a/scripts/releng/utilities/XmlProcessorFactoryRelEng.java
+++ b/scripts/releng/utilities/XmlProcessorFactoryRelEng.java
@@ -77,7 +77,7 @@ public class XmlProcessorFactoryRelEng {
 	public static synchronized Document parseDocumentIgnoringDOCTYPE(Path file)
 			throws ParserConfigurationException, IOException, SAXException {
 		DocumentBuilder builder = DOCUMENT_BUILDER_FACTORY_IGNORING_DOCTYPE.newDocumentBuilder();
-		builder.setEntityResolver((__, ___) -> new InputSource(new ByteArrayInputStream(new byte[0])));
+		builder.setEntityResolver((_, _) -> new InputSource(new ByteArrayInputStream(new byte[0])));
 		return builder.parse((file.toFile()));
 	}
 

--- a/sites/websites/eclipse/build/index.html
+++ b/sites/websites/eclipse/build/index.html
@@ -150,7 +150,7 @@ gpg: Can't check signature: public key not found
 			The Eclipse SDK includes the Eclipse Platform, Java development tools, and Plug-in Development Environment,
 			including source and both user and programmer documentation.
 			If you aren't sure which download you want... then you probably want this one.
-			You will need a <em>Java</em> installation, ideally a JDK, to run Eclipse (Java-21 or greater is required).
+			You will need a <em>Java</em> installation, ideally a JDK, to run Eclipse.
 		</dialog>
 		<table class="files-table" data-path="sdkProducts"></table>
 


### PR DESCRIPTION
Set the required execution environment for the Eclipse SDK as a whole to JavaSE-25. Update product, build pipelines and workflows to require Java-25.
Update test configurations to require at least Java-25 and set it as low-end version, remove configurations for Java-21. Leverage Java-25 as baseline in test scripts.