### PR TITLE
Restore right directory for TestResultsGenerator execution

### DIFF
--- a/jobs/automated-tests/integration-tests.jenkinsfile
+++ b/jobs/automated-tests/integration-tests.jenkinsfile
@@ -109,6 +109,7 @@ pipeline {
 									ssh genie.releng@projects-storage.eclipse.org mkdir -p ${remoteResultsDirectory}
 									if [ -d "${localResultsDirectory}/xml" ] && [ -z "$(find ${localResultsDirectory}/xml -maxdepth 0 -empty)" ]; then
 										
+										pushd scripts/releng
 										# Generate new summary file
 										java \
 											-DxmlDirectory="${WORKSPACE}/${localResultsDirectory}/xml" \


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/4021