### PR TITLE
[RelEng] Extend wait period between status check in Maven deployment

### DIFF
--- a/jobs/releng/deploy-maven.jenkinsfile
+++ b/jobs/releng/deploy-maven.jenkinsfile
@@ -216,7 +216,7 @@ pipeline {
 												"https://central.sonatype.com/api/v1/publisher/upload?name=${PROJECT^^}_${REPO_TAG}&publishingType=USER_MANAGED"
 										''')
 										writeFile(file: "${WORKSPACE}/deploymentId-${PROJECT}.txt", text: "${deploymentId}")
-										waitUntil(initialRecurrencePeriod: 5_000) {
+										waitUntil(initialRecurrencePeriod: 30_000, maxRecurrencePeriod: 90_000) {
 											// See https://central.sonatype.org/publish/publish-portal-api/#verify-status-of-the-deployment
 											def deploymentStatusResponse = sh(returnStdout: true, script: """
 												curl --request POST \


### PR DESCRIPTION
Extend wait period between status check in Maven deployment to make it more resilient and avoid issues like the ones mentioned in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3951#issuecomment-5533044488
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3987#issuecomment-5533144960

Requires
- https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/553