### PR TITLE
[Build] Skip javadoc generation for eclipse-test-plugin modules

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -936,6 +936,19 @@
       </properties>
     </profile>
     <profile>
+      <id>skip-javadoc-of-tests</id>
+      <activation>
+        <property>
+          <name>packaging</name>
+          <value>eclipse-test-plugin</value>
+        </property>
+      </activation>
+      <properties>
+        <!-- The API docs of test bundles are never published, so generating and jarring them only costs build time. -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+      </properties>
+    </profile>
+    <profile>
       <id>eclipse-sign</id>
       <build>
         <plugins>


### PR DESCRIPTION
Instead of adding `pom.model.property.maven.javadoc.skip` to each test bundle in every SDK repository (as https://github.com/eclipse-platform/eclipse.platform.ui/pull/4358 did), set it once in the parent through a profile activated on `eclipse-test-plugin` packaging, like `skip-baseline-comparision-of-tests` a few lines above.

Nobody publishes the API docs of test bundles, so building and jarring them is wasted CI time: roughly 2 of the 7 minutes the `eclipse.platform.ui` reactor spent on javadoc locally. Doing it in the parent covers jdt, pde, platform, swt and equinox at once and keeps working for test bundles added later.

Verified with `help:evaluate`: `maven.javadoc.skip` is `true` for `org.eclipse.jface.tests` and unset for `org.eclipse.jface`. Once this is in, the per-bundle properties from the PR above can be reverted.