### PR TITLE
Define a version for the exec-maven-plugin plug-in in parent pom.xml

### DIFF
--- a/eclipse-platform-parent/pom.xml
+++ b/eclipse-platform-parent/pom.xml
@@ -356,6 +356,11 @@
           <version>3.1.4</version>
         </plugin>
         <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>3.6.3</version>
+        </plugin>
+        <plugin>
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>target-platform-configuration</artifactId>
           <version>${tycho.version}</version>


### PR DESCRIPTION
The `exec-maven-plugin` is required by SWT and will soon be required by JDT UI. So define its version in the `eclipse-platform-parent/pom.xml` file.