### PR TITLE
Replace abandoned com.jcraft.jsch with the maintained mwiede fork

### DIFF
--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/network.htm
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/guide/network.htm
@@ -18,7 +18,7 @@ Network support
 <li>Proxy support provided by the 
 <a href="../reference/api/org/eclipse/core/net/proxy/package-summary.html">org.eclipse.core.net.proxy</a> 
 package of the <em>org.eclipse.core.net</em> plug-in.</li>
-<li>SSH2 support provided by the <em>com.jcraft.jsch</em> plug-in. Clients should make use
+<li>SSH2 support provided by the <em>com.github.mwiede.jsch</em> plug-in. Clients should make use
 of the API in the <a href="../reference/api/org/eclipse/jsch/core/package-summary.html">org.eclipse.jsch.core</a>
 package to ensure that the settings specified in the preference page are respected.</li>
 </ul>

--- a/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
+++ b/eclipse.platform.common/bundles/org.eclipse.platform.doc.isv/pom.xml
@@ -90,7 +90,7 @@
                   </requirement>
                   <requirement>
                     <type>eclipse-plugin</type>
-                    <id>com.jcraft.jsch</id>
+                    <id>com.github.mwiede.jsch</id>
                     <versionRange>0.0.0</versionRange>
                   </requirement>
                   <requirement>

--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -4,7 +4,8 @@
   <locations>
     <location includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
 
-      <unit id="com.jcraft.jsch" version="0.1.55.v20230916-1400"/>
+      <!-- Maintained fork of the abandoned JCraft JSch; exports com.jcraft.jsch -->
+      <unit id="com.github.mwiede.jsch" version="2.28.7"/>
 
       <unit id="org.apache.ant" version="1.10.18.v20260906-1000"/>
 

--- a/eclipse.platform.releng/deploy-to-maven/SDK4Mvn.aggr
+++ b/eclipse.platform.releng/deploy-to-maven/SDK4Mvn.aggr
@@ -31,7 +31,7 @@
   <mavenMappings namePattern="(org\.eclipse\.jdt)(.*)" groupId="$1" artifactId="$1$2" snapshot="false"/>
   <mavenMappings namePattern="(org\.eclipse\.pde)(.*)" groupId="$1" artifactId="$1$2" snapshot="false"/>
   <mavenMappings namePattern="(org\.eclipse)((?!(\.emf|\.jetty|\.ecf|\.orbit)).*)$" groupId="$1.platform" artifactId="$1$2" snapshot="false"/>
-  <mavenMappings namePattern="(com\.jcraft)\.(.*)" groupId="$1" artifactId="$2"/>
+  <mavenMappings namePattern="(com\.github\.mwiede)\.(.*)" groupId="$1" artifactId="$2"/>
   <mavenMappings namePattern="(org\.(commonmark))-(gfm-tables)" groupId="$1" artifactId="$2-ext-$3"/>
   <mavenMappings namePattern="javax\.annotation" groupId="jakarta.annotation" artifactId="jakarta.annotation-api"/>
   <mavenMappings namePattern="(javax.inject)" groupId="$1" artifactId="$1" versionPattern="([^.]+)\.0(?:\..*)?" versionTemplate="$1"/>


### PR DESCRIPTION
com.github.mwiede.jsch exports the same com.jcraft.jsch package, so no changes are needed in the consumers, when they use Import-Package.

https://github.com/eclipse-platform/eclipse.platform/issues/958

Assisted-by: Anthropic Claude Code (claude-opus-5[1m])